### PR TITLE
fix(release): add --legacy-peer-deps to npm ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,7 +338,7 @@ jobs:
           workspaces: './src-tauri -> target'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Generate version info
         run: node scripts/generate-version.mjs
@@ -465,7 +465,7 @@ jobs:
           workspaces: './src-tauri -> target'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Generate version info
         run: node scripts/generate-version.mjs
@@ -532,7 +532,7 @@ jobs:
           workspaces: './src-tauri -> target'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Generate version info
         run: node scripts/generate-version.mjs
@@ -663,7 +663,7 @@ jobs:
           workspaces: './src-tauri -> target'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Generate version info
         run: node scripts/generate-version.mjs


### PR DESCRIPTION
Fix release builds blocked by @lobehub/icons React 19 peer dep conflict.