### PR TITLE
fix: pin @lobehub/icons to 5.6.0 (white screen hotfix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deep-student",
-  "version": "0.9.36",
+  "version": "0.9.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deep-student",
-      "version": "0.9.36",
+      "version": "0.9.35",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
@@ -18,7 +18,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "3.2.2",
         "@hello-pangea/dnd": "^18.0.1",
-        "@lobehub/icons": "^5.6.0",
+        "@lobehub/icons": "5.6.0",
         "@milkdown/crepe": "7.17.1",
         "@milkdown/kit": "7.17.1",
         "@milkdown/plugin-automd": "7.17.1",
@@ -2997,9 +2997,9 @@
       }
     },
     "node_modules/@lobehub/icons": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@lobehub/icons/-/icons-5.8.0.tgz",
-      "integrity": "sha512-pt06WqZdIQzagevf+aX4MlEOrBtAPHAvo2pq3sIoRikzzUCND/zhnXG8pFPjoxhnkkvUCWXWm/8wjnFasufW7A==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@lobehub/icons/-/icons-5.6.0.tgz",
+      "integrity": "sha512-wxDk6kqOJ5ctoyHbi0zNDZkpgCW3uxtWM8iA4ZZVqcKvL8xQxeWBO+0IzOtDcSij68xhKJkjcBEVTg+IFk4VHg==",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "@hello-pangea/dnd": "^18.0.1",
-    "@lobehub/icons": "^5.6.0",
+    "@lobehub/icons": "5.6.0",
     "@milkdown/crepe": "7.17.1",
     "@milkdown/kit": "7.17.1",
     "@milkdown/plugin-automd": "7.17.1",


### PR DESCRIPTION
v0.9.36 built with @lobehub/icons@5.8.0 which uses React 19 runtime APIs causing white screen. This pins to 5.6.0 (the version originally tested on nightly).