### PR TITLE
ci: extend Android build timeout from 70m to 120m to prevent prematur…

### DIFF
--- a/.github/workflows/rebuild-android.yml
+++ b/.github/workflows/rebuild-android.yml
@@ -231,13 +231,13 @@ jobs:
           GRADLE_OPTS: -Dorg.gradle.daemon=false
         run: |
           set +e
-          echo "Starting Android build with 70 minute timeout"
-          timeout --signal=TERM --kill-after=60s 70m npx tauri android build --target aarch64
+          echo "Starting Android build with 120 minute timeout"
+          timeout --signal=TERM --kill-after=60s 120m npx tauri android build --target aarch64
           status=$?
           set -e
 
           if [ "$status" -eq 124 ]; then
-            echo "::error::Android build timed out after 70 minutes"
+            echo "::error::Android build timed out after 120 minutes"
           elif [ "$status" -ne 0 ]; then
             echo "::error::Android build failed with exit code ${status}"
           fi

--- a/.github/workflows/rebuild-release.yml
+++ b/.github/workflows/rebuild-release.yml
@@ -535,13 +535,13 @@ jobs:
           GRADLE_OPTS: -Dorg.gradle.daemon=false
         run: |
           set +e
-          echo "Starting Android build with 70 minute timeout"
-          timeout --signal=TERM --kill-after=60s 70m npx tauri android build --target aarch64
+          echo "Starting Android build with 120 minute timeout"
+          timeout --signal=TERM --kill-after=60s 120m npx tauri android build --target aarch64
           status=$?
           set -e
 
           if [ "$status" -eq 124 ]; then
-            echo "::error::Android build timed out after 70 minutes"
+            echo "::error::Android build timed out after 120 minutes"
           elif [ "$status" -ne 0 ]; then
             echo "::error::Android build failed with exit code ${status}"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -734,13 +734,13 @@ jobs:
           GRADLE_OPTS: -Dorg.gradle.daemon=false
         run: |
           set +e
-          echo "Starting Android build with 70 minute timeout"
-          timeout --signal=TERM --kill-after=60s 70m npx tauri android build --target aarch64
+          echo "Starting Android build with 120 minute timeout"
+          timeout --signal=TERM --kill-after=60s 120m npx tauri android build --target aarch64
           status=$?
           set -e
 
           if [ "$status" -eq 124 ]; then
-            echo "::error::Android build timed out after 70 minutes"
+            echo "::error::Android build timed out after 120 minutes"
           elif [ "$status" -ne 0 ]; then
             echo "::error::Android build failed with exit code ${status}"
           fi


### PR DESCRIPTION

## 变更内容

将 Android 构建超时时长从 70 分钟延长至 120 分钟，涉及 3 个 workflow 文件：

- `.github/workflows/release.yml`
- `.github/workflows/rebuild-release.yml`
- `.github/workflows/rebuild-android.yml`

每处同步更新了 `timeout` 命令的实际值以及前后两行日志文本。

## 背景

v0.9.40 的 Android APK 构建在 GitHub Actions runner 上连续 70 分钟超时，120 分钟可提供充足余量。

## 影响范围

仅修改构建脚本的超时参数，不影响任何业务代码或构建逻辑。
