### PR TITLE
fix: add RECORD_AUDIO permission for Android manifest

### DIFF
--- a/.github/workflows/rebuild-android.yml
+++ b/.github/workflows/rebuild-android.yml
@@ -170,6 +170,18 @@ jobs:
       - name: Initialize Android project
         run: npx tauri android init
 
+      - name: Inject Android permissions
+        run: |
+          MANIFEST="src-tauri/gen/android/app/src/main/AndroidManifest.xml"
+          PERM='<uses-permission android:name="android.permission.RECORD_AUDIO" />'
+          if grep -qF "$PERM" "$MANIFEST"; then
+            echo "RECORD_AUDIO permission already present"
+          else
+            echo "Injecting RECORD_AUDIO permission..."
+            sed -i "/<manifest/a\\    $PERM" "$MANIFEST"
+            echo "RECORD_AUDIO permission injected"
+          fi
+
       - name: Copy custom Android icons
         run: |
           ICONS_SRC="src-tauri/icons/android"

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -129,6 +129,7 @@ setup_dev_package() {
         fi
         npx @tauri-apps/cli android init || die "Android 项目初始化失败"
         info "✓ Android 项目已重新初始化"
+        inject_android_permissions
     fi
 }
 
@@ -163,6 +164,26 @@ ensure_android_project() {
         npx @tauri-apps/cli android init || die "Android 项目初始化失败"
         info "✓ Android 项目初始化完成"
     fi
+}
+
+inject_android_permissions() {
+    local MANIFEST="$REPO_ROOT/src-tauri/gen/android/app/src/main/AndroidManifest.xml"
+    if [[ ! -f "$MANIFEST" ]]; then
+        warn "未找到 AndroidManifest.xml，跳过权限注入"
+        return
+    fi
+    local PERM="<uses-permission android:name=\"android.permission.RECORD_AUDIO\" />"
+    if grep -qF "$PERM" "$MANIFEST" 2>/dev/null; then
+        return
+    fi
+    say "向 AndroidManifest.xml 注入 RECORD_AUDIO 权限..."
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "/<manifest/a\\
+    $PERM" "$MANIFEST"
+    else
+        sed -i "/<manifest/a\\    $PERM" "$MANIFEST"
+    fi
+    info "✓ 已注入 RECORD_AUDIO 权限"
 }
 
 apply_android_version_code() {
@@ -486,6 +507,7 @@ if [[ -z "${SKIP_ANDROID_BUILD:-}" ]]; then
     # 打包 pdfium 动态库到 Android APK
     say "打包 pdfium 动态库..."
     ensure_android_project
+    inject_android_permissions
     JNILIBS_DIR="$REPO_ROOT/src-tauri/gen/android/app/src/main/jniLibs/arm64-v8a"
     mkdir -p "$JNILIBS_DIR"
     PDFIUM_ANDROID_SO="$REPO_ROOT/src-tauri/resources/pdfium/libpdfium_android_arm64.so"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -88,10 +88,7 @@
       }
     },
     "android": {
-      "versionCode": 13896,
-      "permissions": [
-        "android.permission.RECORD_AUDIO"
-      ]
+      "versionCode": 13896
     }
   },
   "plugins": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -88,7 +88,10 @@
       }
     },
     "android": {
-      "versionCode": 13896
+      "versionCode": 13896,
+      "permissions": [
+        "android.permission.RECORD_AUDIO"
+      ]
     }
   },
   "plugins": {


### PR DESCRIPTION
Add android.permission.RECORD_AUDIO to bundle.android.permissions in tauri.conf.json. Fixes voice input being rejected on Android due to missing manifest permission declaration.