### PR TITLE
Feat/cloud storage ftp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ devsec/
 
 # Editor directories and files
 .vscode/*
+.trae/*
 !.vscode/extensions.json
 .idea
 .DS_Store

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,11 +1,6 @@
 [build]
 # rustc-wrapper = "sccache"  # Windows 开发环境临时禁用
 
-jobs = 10
-
-# 2. 增量编译：确保开启，让 Rust 只重新编译改动过的部分
-incremental = true
-
 # Windows 本地编译链接器配置 - 解决内存不足问题
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "link-arg=/INCREMENTAL:NO", "-C", "link-arg=/STACK:16777216"]

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,6 +1,11 @@
 [build]
 # rustc-wrapper = "sccache"  # Windows 开发环境临时禁用
 
+jobs = 10
+
+# 2. 增量编译：确保开启，让 Rust 只重新编译改动过的部分
+incremental = true
+
 # Windows 本地编译链接器配置 - 解决内存不足问题
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "link-arg=/INCREMENTAL:NO", "-C", "link-arg=/STACK:16777216"]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3089,6 +3089,7 @@ dependencies = [
  "arrow-array",
  "arrow-schema",
  "assert_matches",
+ "async-std",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -182,7 +182,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -193,7 +193,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -520,6 +520,17 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
@@ -542,6 +553,21 @@ dependencies = [
  "futures-lite",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
 ]
 
 [[package]]
@@ -574,6 +600,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-native-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9343dc5acf07e79ff82d0c37899f079db3534d99f189a1837c8e549c99405bec"
+dependencies = [
+ "futures-util",
+ "native-tls",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "async-priority-channel"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,7 +626,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-io",
  "async-lock",
  "async-signal",
@@ -627,6 +665,32 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1315,7 +1379,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1827,7 +1891,7 @@ dependencies = [
  "cocoa-foundation",
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -2079,7 +2143,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -2092,7 +2156,7 @@ dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.1",
  "core-graphics-types 0.2.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -3017,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "deep-student"
-version = "0.9.39"
+version = "0.9.40"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3085,6 +3149,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
+ "suppaftp",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
@@ -3509,6 +3574,12 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
@@ -3784,12 +3855,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -3802,6 +3882,12 @@ dependencies = [
  "quote",
  "syn 2.0.115",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -4310,6 +4396,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -5325,6 +5423,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lance"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5591,7 +5698,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
- "async-channel",
+ "async-channel 2.5.0",
  "async-recursion",
  "async-trait",
  "bitpacking",
@@ -5800,6 +5907,29 @@ dependencies = [
  "snafu",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -6349,6 +6479,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand 0.8.5",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -7125,10 +7272,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -8984,7 +9168,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9938,6 +10122,23 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "suppaftp"
+version = "6.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821742c6eeb5a90b95566abae78cc4bab5b96d9c230d29ea9e1a2e3181e57885"
+dependencies = [
+ "async-native-tls",
+ "async-std",
+ "async-trait",
+ "chrono",
+ "futures-lite",
+ "lazy-regex",
+ "log",
+ "pin-project",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "swift-rs"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -128,6 +128,8 @@ argon2 = "0.5"
 zeroize = { version = "1", features = ["derive"] }
 # FTP/FTPS 支持
 suppaftp = { version = "6", default-features = false, features = ["async", "async-native-tls"] }
+# suppaftp v6 的 async Read/Write traits 依赖 async-std
+async-std = { version = "1", default-features = false, features = ["std"] }
 
 # 云存储 S3 兼容（可选，feature-gated 避免默认增加编译时间）
 aws-sdk-s3 = { version = "1.65", optional = true, default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -126,6 +126,8 @@ urlencoding = "2.1.3"
 roxmltree = "0.20"
 argon2 = "0.5"
 zeroize = { version = "1", features = ["derive"] }
+# FTP/FTPS 支持
+suppaftp = { version = "6", default-features = false, features = ["async", "async-native-tls"] }
 
 # 云存储 S3 兼容（可选，feature-gated 避免默认增加编译时间）
 aws-sdk-s3 = { version = "1.65", optional = true, default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"] }

--- a/src-tauri/src/cloud_storage/config.rs
+++ b/src-tauri/src/cloud_storage/config.rs
@@ -13,6 +13,8 @@ pub enum StorageProvider {
     WebDav,
     /// S3 兼容存储（AWS S3、Cloudflare R2、阿里云 OSS、MinIO 等）
     S3,
+    /// FTP/FTPS 存储（支持显式 FTPS）
+    Ftp,
 }
 
 impl Default for StorageProvider {
@@ -26,6 +28,7 @@ impl std::fmt::Display for StorageProvider {
         match self {
             StorageProvider::WebDav => write!(f, "WebDAV"),
             StorageProvider::S3 => write!(f, "S3"),
+            StorageProvider::Ftp => write!(f, "FTP"),
         }
     }
 }
@@ -93,6 +96,40 @@ impl std::fmt::Debug for S3Config {
     }
 }
 
+/// FTP/FTPS 配置
+#[derive(Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct FtpConfig {
+    /// FTP 服务器主机名或 IP 地址
+    pub host: String,
+    /// FTP 端口（默认 21）
+    #[serde(default = "default_ftp_port")]
+    pub port: u16,
+    /// 用户名
+    pub username: String,
+    /// 密码
+    pub password: String,
+    /// 是否使用 TLS（FTPS 显式加密）
+    #[serde(default)]
+    pub use_tls: bool,
+}
+
+fn default_ftp_port() -> u16 {
+    21
+}
+
+impl std::fmt::Debug for FtpConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FtpConfig")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("username", &self.username)
+            .field("password", &"[REDACTED]")
+            .field("use_tls", &self.use_tls)
+            .finish()
+    }
+}
+
 /// 统一的云存储配置
 #[derive(Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -106,6 +143,9 @@ pub struct CloudStorageConfig {
     /// S3 配置（当 provider 为 S3 时使用）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub s3: Option<S3Config>,
+    /// FTP 配置（当 provider 为 Ftp 时使用）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ftp: Option<FtpConfig>,
     /// 根目录路径（所有操作都在此目录下）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub root: Option<String>,
@@ -126,6 +166,7 @@ impl std::fmt::Debug for CloudStorageConfig {
             .field("provider", &self.provider)
             .field("webdav", &self.webdav)
             .field("s3", &self.s3)
+            .field("ftp", &self.ftp)
             .field("root", &self.root)
             .field(
                 "encryption_password",
@@ -160,6 +201,12 @@ impl CloudStorageConfig {
             .and_then(|u| u.host_str().map(|h| h.to_lowercase()))
             .map(|host| matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1"))
             .unwrap_or(false)
+    }
+
+    /// 判断 FTP host 是否为本地地址
+    fn is_local_ftp_host(host: &str) -> bool {
+        let host = host.trim().to_lowercase();
+        matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1")
     }
 
     /// 验证配置是否完整
@@ -208,6 +255,24 @@ impl CloudStorageConfig {
                         .starts_with("https://")
                 {
                     return Err("S3 endpoint 必须使用 HTTPS（仅 localhost 允许 HTTP）".into());
+                }
+                Ok(())
+            }
+            StorageProvider::Ftp => {
+                let config = self.ftp.as_ref().ok_or("缺少 FTP 配置")?;
+                if config.host.trim().is_empty() {
+                    return Err("FTP host 不能为空".into());
+                }
+                if config.username.trim().is_empty() {
+                    return Err("FTP 用户名不能为空".into());
+                }
+                if config.password.trim().is_empty() {
+                    return Err("FTP 密码不能为空".into());
+                }
+                // 非 localhost 且 use_tls=true 时强制使用 TLS
+                let is_local = Self::is_local_ftp_host(&config.host);
+                if !is_local && !config.use_tls {
+                    return Err("FTP 连接必须使用 TLS（仅 localhost 允许明文）".into());
                 }
                 Ok(())
             }
@@ -414,6 +479,91 @@ mod tests {
         assert!(
             config.validate().is_err(),
             "S3 http://localhost.evil.com should be rejected as non-local HTTP"
+        );
+    }
+
+    #[test]
+    fn test_ftp_config_validation() {
+        // FTP 配置验证
+        let config = CloudStorageConfig {
+            provider: StorageProvider::Ftp,
+            ftp: Some(FtpConfig {
+                host: "ftp.example.com".into(),
+                port: 21,
+                username: "user".into(),
+                password: "pass".into(),
+                use_tls: true,
+            }),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+
+        // 缺少 host
+        let mut config = CloudStorageConfig {
+            provider: StorageProvider::Ftp,
+            ftp: Some(FtpConfig {
+                host: "".into(),
+                port: 21,
+                username: "user".into(),
+                password: "pass".into(),
+                use_tls: true,
+            }),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+
+        // 缺少用户名
+        config.ftp.as_mut().unwrap().username = "".into();
+        config.ftp.as_mut().unwrap().host = "ftp.example.com".into();
+        assert!(config.validate().is_err());
+
+        // 缺少密码
+        config.ftp.as_mut().unwrap().username = "user".into();
+        config.ftp.as_mut().unwrap().password = "".into();
+        assert!(config.validate().is_err());
+
+        // 非 localhost 不使用 TLS 应该被拒绝
+        config.ftp.as_mut().unwrap().password = "pass".into();
+        config.ftp.as_mut().unwrap().use_tls = false;
+        assert!(config.validate().is_err());
+
+        // localhost 不使用 TLS 应该被允许
+        config.ftp.as_mut().unwrap().host = "localhost".into();
+        config.ftp.as_mut().unwrap().use_tls = false;
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_ftp_debug_redaction() {
+        let ftp = FtpConfig {
+            host: "ftp.example.com".into(),
+            port: 21,
+            username: "user".into(),
+            password: "super-secret".into(),
+            use_tls: true,
+        };
+        let debug = format!("{:?}", ftp);
+        assert!(
+            !debug.contains("super-secret"),
+            "password should be redacted in Debug"
+        );
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn test_is_local_ftp_host() {
+        assert!(CloudStorageConfig::is_local_ftp_host("localhost"));
+        assert!(CloudStorageConfig::is_local_ftp_host("127.0.0.1"));
+        assert!(CloudStorageConfig::is_local_ftp_host("::1"));
+        assert!(CloudStorageConfig::is_local_ftp_host("  localhost  "));
+
+        assert!(
+            !CloudStorageConfig::is_local_ftp_host("ftp.example.com"),
+            "remote host should not be treated as local"
+        );
+        assert!(
+            !CloudStorageConfig::is_local_ftp_host("localhost.evil.com"),
+            "localhost.evil.com should not be treated as local"
         );
     }
 }

--- a/src-tauri/src/cloud_storage/config.rs
+++ b/src-tauri/src/cloud_storage/config.rs
@@ -269,11 +269,7 @@ impl CloudStorageConfig {
                 if config.password.trim().is_empty() {
                     return Err("FTP 密码不能为空".into());
                 }
-                // 非 localhost 且 use_tls=true 时强制使用 TLS
-                let is_local = Self::is_local_ftp_host(&config.host);
-                if !is_local && !config.use_tls {
-                    return Err("FTP 连接必须使用 TLS（仅 localhost 允许明文）".into());
-                }
+                // 允许不安全的 FTP 使用（不强制 TLS）
                 Ok(())
             }
         }

--- a/src-tauri/src/cloud_storage/ftp.rs
+++ b/src-tauri/src/cloud_storage/ftp.rs
@@ -1,6 +1,6 @@
 //! FTP/FTPS 存储实现
 //!
-//! 基于 suppaftp 的异步 FTP 客户端，支持显式 FTPS（AUTH TLS）
+//! 基于 suppaftp 的异步 FTP 客户端，支持显式 FTPS（AUTH TLS）和明文 FTP
 
 use async_std::io::ReadExt;
 use async_trait::async_trait;
@@ -34,12 +34,8 @@ impl FtpStorage {
             return Err(AppError::validation("FTP host 不能为空"));
         }
 
-        let is_local = Self::is_local_ftp_host(&config.host);
-        if !is_local && !config.use_tls {
-            return Err(AppError::configuration(
-                "FTP 连接必须使用 TLS 以保护凭据（仅 localhost 允许明文）".to_string(),
-            ));
-        }
+        // 允许不安全的 FTP 使用，不强制要求使用 TLS
+        // 注意：明文 FTP 会暴露凭据和数据，建议在生产环境使用 FTPS
 
         Ok(Self {
             host: config.host.trim().to_string(),
@@ -93,7 +89,7 @@ impl FtpStorage {
 
             Ok(FtpClient::Secure(secure_stream))
         } else {
-            // 明文 FTP（仅 localhost 允许）
+            // 明文 FTP（不推荐用于生产环境）
             let mut stream = AsyncFtpStream::connect(&address)
                 .await
                 .map_err(|e| AppError::network(format!("FTP 连接失败 {}: {}", address, e)))?;

--- a/src-tauri/src/cloud_storage/ftp.rs
+++ b/src-tauri/src/cloud_storage/ftp.rs
@@ -2,13 +2,14 @@
 //!
 //! 基于 suppaftp 的异步 FTP 客户端，支持显式 FTPS（AUTH TLS）
 
+use async_std::io::ReadExt;
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use sha2::{Digest, Sha256};
 use std::path::Path;
-use std::sync::Arc;
 use std::time::Duration;
-use suppaftp::{AsyncFtpStream, AsyncNativeTlsFtpStream, AsyncNativeTlsConnector};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use suppaftp::async_native_tls::TlsConnector;
+use suppaftp::{AsyncFtpStream, AsyncNativeTlsConnector, AsyncNativeTlsFtpStream};
 
 use super::config::FtpConfig;
 use super::traits::{
@@ -62,37 +63,51 @@ impl FtpStorage {
 
         tracing::debug!("[FtpStorage] 正在连接到 {}", address);
 
-        let mut stream = AsyncFtpStream::connect(&address)
-            .await
-            .map_err(|e| AppError::network(format!("FTP 连接失败 {}: {}", address, e)))?;
-
-        // 设置被动模式（PASV）
-        stream
-            .transfer_type(suppaftp::types::FileType::Binary)
-            .await
-            .map_err(|e| AppError::internal(format!("设置 FTP 传输类型失败：{}", e)))?;
-
-        // 如果配置了 TLS，升级为安全连接
         if self.use_tls {
+            // FTPS: 使用 AsyncNativeTlsFtpStream 作为基础类型，
+            // 使得 into_secure 的 Stream 类型参数匹配
+            let mut stream = AsyncNativeTlsFtpStream::connect(&address)
+                .await
+                .map_err(|e| AppError::network(format!("FTP 连接失败 {}: {}", address, e)))?;
+
             tracing::debug!("[FtpStorage] 正在升级到 TLS...");
             let mut secure_stream = stream
-                .into_secure(AsyncNativeTlsConnector::new(), &self.host)
+                .into_secure(
+                    AsyncNativeTlsConnector::from(TlsConnector::new()),
+                    &self.host,
+                )
                 .await
                 .map_err(|e| AppError::network(format!("FTP TLS 升级失败：{}", e)))?;
 
-            // 登录
+            // 登录（在 TLS 升级之后进行，确保凭据加密传输）
             secure_stream
                 .login(&self.username, &self.password)
                 .await
                 .map_err(|e| AppError::authentication(format!("FTP 登录失败：{}", e)))?;
 
+            // 登录后再设置传输类型
+            secure_stream
+                .transfer_type(suppaftp::types::FileType::Binary)
+                .await
+                .map_err(|e| AppError::internal(format!("设置 FTP 传输类型失败：{}", e)))?;
+
             Ok(FtpClient::Secure(secure_stream))
         } else {
-            // 明文登录（仅 localhost 允许）
+            // 明文 FTP（仅 localhost 允许）
+            let mut stream = AsyncFtpStream::connect(&address)
+                .await
+                .map_err(|e| AppError::network(format!("FTP 连接失败 {}: {}", address, e)))?;
+
+            // 先登录，再设置传输类型（有些服务器要求先认证）
             stream
                 .login(&self.username, &self.password)
                 .await
                 .map_err(|e| AppError::authentication(format!("FTP 登录失败：{}", e)))?;
+
+            stream
+                .transfer_type(suppaftp::types::FileType::Binary)
+                .await
+                .map_err(|e| AppError::internal(format!("设置 FTP 传输类型失败：{}", e)))?;
 
             Ok(FtpClient::Plain(stream))
         }
@@ -227,90 +242,133 @@ impl FtpClient {
         Ok(())
     }
 
-    async fn put_file<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+    /// suppaftp 6.0.7: put_file(filename, reader) 接收远程文件名和一个 async_std::io::Read + Unpin 的 reader
+    async fn put_file(
+        &mut self,
+        filename: &str,
+        reader: &mut (impl async_std::io::Read + std::marker::Unpin),
+    ) -> Result<u64> {
         match self {
             FtpClient::Plain(stream) => stream
-                .put_file(path)
+                .put_file(filename, reader)
                 .await
-                .map_err(|e| AppError::file_system(format!("FTP 上传失败：{}", e)))?,
+                .map_err(|e| AppError::file_system(format!("FTP 上传失败：{}", e))),
             FtpClient::Secure(stream) => stream
-                .put_file(path)
+                .put_file(filename, reader)
                 .await
-                .map_err(|e| AppError::file_system(format!("FTP 上传失败：{}", e)))?,
+                .map_err(|e| AppError::file_system(format!("FTP 上传失败：{}", e))),
         }
-        Ok(())
     }
 
-    async fn get_file<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+    /// suppaftp 6.0.7: 使用 retr_as_stream 获取数据流后用 ReadExt 逐块读取
+    async fn retr_to_vec(&mut self, filename: &str) -> Result<Vec<u8>> {
         match self {
-            FtpClient::Plain(stream) => stream
-                .get_file(path)
-                .await
-                .map_err(|e| AppError::file_system(format!("FTP 下载失败：{}", e)))?,
-            FtpClient::Secure(stream) => stream
-                .get_file(path)
-                .await
-                .map_err(|e| AppError::file_system(format!("FTP 下载失败：{}", e)))?,
+            FtpClient::Plain(stream) => {
+                let mut data_stream = stream
+                    .retr_as_stream(filename)
+                    .await
+                    .map_err(|e| AppError::file_system(format!("FTP 下载失败：{}", e)))?;
+                let mut buf = Vec::new();
+                let mut tmp = [0u8; 8192];
+                loop {
+                    let n = data_stream
+                        .read(&mut tmp)
+                        .await
+                        .map_err(|e| AppError::file_system(format!("FTP 读取数据失败：{}", e)))?;
+                    if n == 0 {
+                        break;
+                    }
+                    buf.extend_from_slice(&tmp[..n]);
+                }
+                stream
+                    .finalize_retr_stream(data_stream)
+                    .await
+                    .map_err(|e| AppError::file_system(format!("FTP 下载结束失败：{}", e)))?;
+                Ok(buf)
+            }
+            FtpClient::Secure(stream) => {
+                let mut data_stream = stream
+                    .retr_as_stream(filename)
+                    .await
+                    .map_err(|e| AppError::file_system(format!("FTP 下载失败：{}", e)))?;
+                let mut buf = Vec::new();
+                let mut tmp = [0u8; 8192];
+                loop {
+                    let n = data_stream
+                        .read(&mut tmp)
+                        .await
+                        .map_err(|e| AppError::file_system(format!("FTP 读取数据失败：{}", e)))?;
+                    if n == 0 {
+                        break;
+                    }
+                    buf.extend_from_slice(&tmp[..n]);
+                }
+                stream
+                    .finalize_retr_stream(data_stream)
+                    .await
+                    .map_err(|e| AppError::file_system(format!("FTP 下载结束失败：{}", e)))?;
+                Ok(buf)
+            }
         }
-        Ok(())
     }
 
+    /// suppaftp 6.0.7: list 返回 Result<Vec<String>>
     async fn list(&mut self, path: Option<&str>) -> Result<Vec<String>> {
         match self {
-            FtpClient::Plain(stream) => Ok(stream
+            FtpClient::Plain(stream) => stream
                 .list(path)
                 .await
-                .map_err(|e| AppError::file_system(format!("FTP LIST 失败：{}", e)))?
-                .unwrap_or_default()),
-            FtpClient::Secure(stream) => Ok(stream
+                .map_err(|e| AppError::file_system(format!("FTP LIST 失败：{}", e))),
+            FtpClient::Secure(stream) => stream
                 .list(path)
                 .await
-                .map_err(|e| AppError::file_system(format!("FTP LIST 失败：{}", e)))?
-                .unwrap_or_default()),
+                .map_err(|e| AppError::file_system(format!("FTP LIST 失败：{}", e))),
         }
     }
 
-    async fn delete(&mut self, path: &str) -> Result<()> {
+    /// suppaftp 6.0.7: 删除文件的方法名是 rm
+    async fn rm(&mut self, path: &str) -> Result<()> {
         match self {
             FtpClient::Plain(stream) => stream
-                .delete(path)
+                .rm(path)
                 .await
-                .map_err(|e| AppError::file_system(format!("FTP DELETE 失败：{}", e)))?,
+                .map_err(|e| AppError::file_system(format!("FTP DELETE 失败：{}", e))),
             FtpClient::Secure(stream) => stream
-                .delete(path)
+                .rm(path)
                 .await
-                .map_err(|e| AppError::file_system(format!("FTP DELETE 失败：{}", e)))?,
+                .map_err(|e| AppError::file_system(format!("FTP DELETE 失败：{}", e))),
         }
-        Ok(())
     }
 
+    /// suppaftp 6.0.7: size 返回 FtpResult<usize>，转为 u64
     async fn size(&mut self, path: &str) -> Result<u64> {
         match self {
-            FtpClient::Plain(stream) => Ok(stream
+            FtpClient::Plain(stream) => stream
                 .size(path)
                 .await
-                .map_err(|e| AppError::file_system(format!("FTP SIZE 失败：{}", e)))?
-                .unwrap_or(0)),
-            FtpClient::Secure(stream) => Ok(stream
+                .map(|s| s as u64)
+                .map_err(|e| AppError::file_system(format!("FTP SIZE 失败：{}", e))),
+            FtpClient::Secure(stream) => stream
                 .size(path)
                 .await
-                .map_err(|e| AppError::file_system(format!("FTP SIZE 失败：{}", e)))?
-                .unwrap_or(0)),
+                .map(|s| s as u64)
+                .map_err(|e| AppError::file_system(format!("FTP SIZE 失败：{}", e))),
         }
     }
 
-    async fn mdtm(&mut self, path: &str) -> Result<chrono::DateTime<chrono::Utc>> {
+    /// suppaftp 6.0.7: mdtm 返回 FtpResult<NaiveDateTime>，转为 DateTime<Utc>
+    async fn mdtm(&mut self, path: &str) -> Result<DateTime<Utc>> {
         match self {
-            FtpClient::Plain(stream) => Ok(stream
+            FtpClient::Plain(stream) => stream
                 .mdtm(path)
                 .await
-                .map_err(|e| AppError::file_system(format!("FTP MDTM 失败：{}", e)))?
-                .unwrap_or_else(|| chrono::Utc::now())),
-            FtpClient::Secure(stream) => Ok(stream
+                .map(|dt| DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc))
+                .map_err(|e| AppError::file_system(format!("FTP MDTM 失败：{}", e))),
+            FtpClient::Secure(stream) => stream
                 .mdtm(path)
                 .await
-                .map_err(|e| AppError::file_system(format!("FTP MDTM 失败：{}", e)))?
-                .unwrap_or_else(|| chrono::Utc::now())),
+                .map(|dt| DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc))
+                .map_err(|e| AppError::file_system(format!("FTP MDTM 失败：{}", e))),
         }
     }
 
@@ -338,7 +396,10 @@ impl CloudStorage for FtpStorage {
     async fn check_connection(&self) -> Result<()> {
         self.with_retry(|| async {
             let mut client = self.create_client().await?;
-            // 尝试切换到根目录
+            // 先确保根目录存在（与 put / put_file 保持一致）
+            client.cwd("/").await?;
+            self.ensure_directory(&mut client, &self.root).await?;
+            // 再确认可以切换进去
             client.cwd(&format!("/{}", self.root)).await?;
             client.quit().await?;
             Ok(())
@@ -361,37 +422,18 @@ impl CloudStorage for FtpStorage {
             if let Some(parent) = key.rfind('/') {
                 let parent_path = &key[..parent];
                 if !parent_path.is_empty() {
-                    self.ensure_directory(&mut client, parent_path).await?;
-                    client.cwd(&format!("/{}/{}", self.root, parent_path))
+                    let full_parent = format!("{}/{}", self.root, parent_path);
+                    self.ensure_directory(&mut client, &full_parent).await?;
+                    client
+                        .cwd(&format!("/{}", full_parent))
                         .await?;
                 }
             }
 
-            // 创建临时文件
-            let temp_file = tempfile::Builder::new()
-                .prefix("ftp-upload-")
-                .tempfile()
-                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
-            let temp_path = temp_file.path().to_path_buf();
-
-            // 写入数据
-            let mut file = tokio::fs::File::create(&temp_path)
-                .await
-                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
-            file.write_all(data)
-                .await
-                .map_err(|e| AppError::file_system(format!("写入临时文件失败：{}", e)))?;
-            file.flush()
-                .await
-                .map_err(|e| AppError::file_system(format!("刷新临时文件失败：{}", e)))?;
-            drop(file);
-
-            // 上传文件
+            // 使用 async_std::io::Cursor 包装内存数据为 reader
             let filename = key.rfind('/').map(|i| &key[i + 1..]).unwrap_or(key);
-            client.put_file(&temp_path).await?;
-
-            // 清理临时文件
-            let _ = std::fs::remove_file(&temp_path);
+            let mut cursor = async_std::io::Cursor::new(data);
+            client.put_file(filename, &mut cursor).await?;
 
             client.quit().await?;
             Ok(())
@@ -403,22 +445,33 @@ impl CloudStorage for FtpStorage {
         self.with_retry(|| async {
             let mut client = self.create_client().await?;
 
-            // 切换到根目录
+            // 确保根目录存在并切换
+            client.cwd("/").await?;
+            self.ensure_directory(&mut client, &self.root).await?;
             client.cwd(&format!("/{}", self.root)).await?;
 
-            // 检查文件是否存在
+            // 切换到文件所在目录
             let filename = key.rfind('/').map(|i| &key[i + 1..]).unwrap_or(key);
             if let Some(parent) = key.rfind('/') {
                 let parent_path = &key[..parent];
                 if !parent_path.is_empty() {
-                    client.cwd(parent_path).await?;
+                    let full_parent = format!("{}/{}", self.root, parent_path);
+                    self.ensure_directory(&mut client, &full_parent).await?;
+                    client.cwd(&format!("/{}", full_parent)).await?;
                 }
             }
 
-            // 获取文件大小
-            let size = client.size(filename).await?;
+            // 检查文件是否存在
+            let size = match client.size(filename).await {
+                Ok(s) => s,
+                Err(_) => {
+                    client.quit().await?;
+                    return Ok(None);
+                }
+            };
+
             if size == 0 {
-                // 尝试获取修改时间来判断文件是否存在
+                // 再通过 mdtm 确认
                 match client.mdtm(filename).await {
                     Ok(_) => {}
                     Err(_) => {
@@ -428,25 +481,9 @@ impl CloudStorage for FtpStorage {
                 }
             }
 
-            // 创建临时文件
-            let temp_file = tempfile::Builder::new()
-                .prefix("ftp-download-")
-                .tempfile()
-                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
-            let temp_path = temp_file.path().to_path_buf();
+            let data = client.retr_to_vec(filename).await?;
 
-            // 下载文件
-            client.get_file(&temp_path).await?;
             client.quit().await?;
-
-            // 读取文件内容
-            let data = tokio::fs::read(&temp_path)
-                .await
-                .map_err(|e| AppError::file_system(format!("读取临时文件失败：{}", e)))?;
-
-            // 清理临时文件
-            let _ = std::fs::remove_file(&temp_path);
-
             Ok(Some(data))
         })
         .await
@@ -456,13 +493,17 @@ impl CloudStorage for FtpStorage {
         self.with_retry(|| async {
             let mut client = self.create_client().await?;
 
-            // 切换到根目录
+            // 确保根目录存在并切换
+            client.cwd("/").await?;
+            self.ensure_directory(&mut client, &self.root).await?;
             client.cwd(&format!("/{}", self.root)).await?;
 
-            // 如果有 prefix，切换到对应目录
+            // 如果有 prefix，确保目录存在并切换
             if !prefix.is_empty() {
                 let prefix_path = prefix.trim_matches('/');
-                client.cwd(prefix_path).await?;
+                let full_prefix = format!("{}/{}", self.root, prefix_path);
+                self.ensure_directory(&mut client, &full_prefix).await?;
+                client.cwd(&format!("/{}", full_prefix)).await?;
             }
 
             // 列出文件
@@ -505,7 +546,10 @@ impl CloudStorage for FtpStorage {
                     format!("{}/{}", prefix.trim_matches('/'), filename)
                 };
 
-                let modified = client.mdtm(&file_path).await.unwrap_or_else(|_| chrono::Utc::now());
+                let modified = client
+                    .mdtm(&file_path)
+                    .await
+                    .unwrap_or_else(|_| Utc::now());
 
                 files.push(FileInfo {
                     key: full_key,
@@ -528,7 +572,9 @@ impl CloudStorage for FtpStorage {
         self.with_retry(|| async {
             let mut client = self.create_client().await?;
 
-            // 切换到根目录
+            // 确保根目录存在并切换
+            client.cwd("/").await?;
+            self.ensure_directory(&mut client, &self.root).await?;
             client.cwd(&format!("/{}", self.root)).await?;
 
             // 切换到文件所在目录
@@ -536,12 +582,13 @@ impl CloudStorage for FtpStorage {
             if let Some(parent) = key.rfind('/') {
                 let parent_path = &key[..parent];
                 if !parent_path.is_empty() {
-                    client.cwd(parent_path).await?;
+                    let full_parent = format!("{}/{}", self.root, parent_path);
+                    client.cwd(&format!("/{}", full_parent)).await?;
                 }
             }
 
-            // 删除文件
-            match client.delete(filename).await {
+            // suppaftp 6.0.7: 删除文件使用 rm
+            match client.rm(filename).await {
                 Ok(_) => {}
                 Err(e) => {
                     // 文件不存在也算成功
@@ -562,7 +609,9 @@ impl CloudStorage for FtpStorage {
         self.with_retry(|| async {
             let mut client = self.create_client().await?;
 
-            // 切换到根目录
+            // 确保根目录存在并切换
+            client.cwd("/").await?;
+            self.ensure_directory(&mut client, &self.root).await?;
             client.cwd(&format!("/{}", self.root)).await?;
 
             // 切换到文件所在目录
@@ -570,11 +619,12 @@ impl CloudStorage for FtpStorage {
             if let Some(parent) = key.rfind('/') {
                 let parent_path = &key[..parent];
                 if !parent_path.is_empty() {
-                    client.cwd(parent_path).await?;
+                    let full_parent = format!("{}/{}", self.root, parent_path);
+                    client.cwd(&format!("/{}", full_parent)).await?;
                 }
             }
 
-            // 获取文件大小
+            // 获取文件大小（suppaftp 6.0.7 返回 usize，已转为 u64）
             let size = match client.size(filename).await {
                 Ok(size) => size,
                 Err(_) => {
@@ -638,50 +688,28 @@ impl CloudStorage for FtpStorage {
             if let Some(parent) = key.rfind('/') {
                 let parent_path = &key[..parent];
                 if !parent_path.is_empty() {
-                    self.ensure_directory(&mut client, parent_path).await?;
-                    client.cwd(&format!("/{}/{}", self.root, parent_path))
+                    let full_parent = format!("{}/{}", self.root, parent_path);
+                    self.ensure_directory(&mut client, &full_parent).await?;
+                    client
+                        .cwd(&format!("/{}", full_parent))
                         .await?;
                 }
             }
 
-            // 上传文件
             let filename = key.rfind('/').map(|i| &key[i + 1..]).unwrap_or(key);
 
-            // 读取文件并上传
-            let mut file = tokio::fs::File::open(local_path)
+            // 读取文件内容到内存，用 async_std::io::Cursor 包装后上传
+            let data = tokio::fs::read(local_path)
                 .await
-                .map_err(|e| AppError::file_system(format!("打开文件失败：{}", e)))?;
+                .map_err(|e| AppError::file_system(format!("读取文件失败：{}", e)))?;
 
-            // 创建临时文件用于上传（suppaftp 需要文件路径）
-            let temp_file = tempfile::Builder::new()
-                .prefix("ftp-upload-")
-                .tempfile()
-                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
-            let temp_path = temp_file.path().to_path_buf();
-
-            // 复制文件内容
-            let mut temp_writer = tokio::fs::File::create(&temp_path)
-                .await
-                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
-            tokio::io::copy(&mut file, &mut temp_writer)
-                .await
-                .map_err(|e| AppError::file_system(format!("复制文件失败：{}", e)))?;
-            temp_writer
-                .flush()
-                .await
-                .map_err(|e| AppError::file_system(format!("刷新临时文件失败：{}", e)))?;
-            drop(temp_writer);
-
-            // 上传
-            client.put_file(&temp_path).await?;
+            let mut cursor = async_std::io::Cursor::new(&data[..]);
+            client.put_file(filename, &mut cursor).await?;
 
             // 报告进度
             if let Some(ref cb) = progress {
                 cb(file_size, file_size);
             }
-
-            // 清理临时文件
-            let _ = std::fs::remove_file(&temp_path);
 
             client.quit().await?;
 
@@ -708,7 +736,9 @@ impl CloudStorage for FtpStorage {
                 cb(0, total_size);
             }
 
-            // 切换到根目录
+            // 确保根目录存在并切换
+            client.cwd("/").await?;
+            self.ensure_directory(&mut client, &self.root).await?;
             client.cwd(&format!("/{}", self.root)).await?;
 
             // 切换到文件所在目录
@@ -716,7 +746,8 @@ impl CloudStorage for FtpStorage {
             if let Some(parent) = key.rfind('/') {
                 let parent_path = &key[..parent];
                 if !parent_path.is_empty() {
-                    client.cwd(parent_path).await?;
+                    let full_parent = format!("{}/{}", self.root, parent_path);
+                    client.cwd(&format!("/{}", full_parent)).await?;
                 }
             }
 
@@ -727,41 +758,13 @@ impl CloudStorage for FtpStorage {
                     .map_err(|e| AppError::file_system(format!("创建目录失败：{}", e)))?;
             }
 
-            // 创建临时下载文件
-            let temp_file = tempfile::Builder::new()
-                .prefix("ftp-download-")
-                .tempfile_in(local_path.parent().unwrap_or(Path::new(".")))
-                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
-            let temp_path = temp_file.path().to_path_buf();
-
-            // 下载文件
-            client.get_file(&temp_path).await?;
+            // 下载到内存
+            let data = client.retr_to_vec(filename).await?;
             client.quit().await?;
 
-            // 计算校验和并读取文件
+            // 计算校验和
             let mut hasher = Sha256::new();
-            let mut file = tokio::fs::File::open(&temp_path)
-                .await
-                .map_err(|e| AppError::file_system(format!("打开临时文件失败：{}", e)))?;
-            let mut buffer = vec![0u8; 8192];
-            let mut downloaded = 0u64;
-
-            loop {
-                let bytes_read = file
-                    .read(&mut buffer)
-                    .await
-                    .map_err(|e| AppError::file_system(format!("读取临时文件失败：{}", e)))?;
-                if bytes_read == 0 {
-                    break;
-                }
-                hasher.update(&buffer[..bytes_read]);
-                downloaded += bytes_read as u64;
-
-                if let Some(ref cb) = progress {
-                    cb(downloaded, total_size);
-                }
-            }
-
+            hasher.update(&data);
             let checksum = format!("{:x}", hasher.finalize());
 
             // 验证校验和
@@ -775,14 +778,25 @@ impl CloudStorage for FtpStorage {
                 }
             }
 
-            // 移动到目标位置
-            tokio::fs::rename(&temp_path, local_path)
+            // 写入临时文件
+            let temp_file = tempfile::Builder::new()
+                .prefix("ftp-download-")
+                .tempfile_in(local_path.parent().unwrap_or_else(|| Path::new(".")))
+                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
+            let temp_path = temp_file.path().to_path_buf();
+
+            tokio::fs::write(&temp_path, &data)
                 .await
-                .map_err(|e| AppError::file_system(format!("保存文件失败：{}", e)))?;
+                .map_err(|e| AppError::file_system(format!("写入临时文件失败：{}", e)))?;
 
             if let Some(ref cb) = progress {
                 cb(total_size, total_size);
             }
+
+            // 原子重命名
+            tokio::fs::rename(&temp_path, local_path)
+                .await
+                .map_err(|e| AppError::file_system(format!("保存文件失败：{}", e)))?;
 
             Ok(checksum)
         })
@@ -797,8 +811,14 @@ mod tests {
     #[test]
     fn test_join_paths() {
         assert_eq!(FtpStorage::join_paths("root", "file.txt"), "root/file.txt");
-        assert_eq!(FtpStorage::join_paths("root/", "file.txt"), "root/file.txt");
-        assert_eq!(FtpStorage::join_paths("root", "/file.txt"), "root/file.txt");
+        assert_eq!(
+            FtpStorage::join_paths("root/", "file.txt"),
+            "root/file.txt"
+        );
+        assert_eq!(
+            FtpStorage::join_paths("root", "/file.txt"),
+            "root/file.txt"
+        );
         assert_eq!(FtpStorage::join_paths("", "file.txt"), "file.txt");
         assert_eq!(FtpStorage::join_paths("root", ""), "root");
         assert_eq!(FtpStorage::join_paths("", ""), "");

--- a/src-tauri/src/cloud_storage/ftp.rs
+++ b/src-tauri/src/cloud_storage/ftp.rs
@@ -1,0 +1,843 @@
+//! FTP/FTPS 存储实现
+//!
+//! 基于 suppaftp 的异步 FTP 客户端，支持显式 FTPS（AUTH TLS）
+
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use suppaftp::{AsyncFtpStream, AsyncNativeTlsFtpStream, AsyncNativeTlsConnector};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use super::config::FtpConfig;
+use super::traits::{
+    CloudStorage, DownloadProgressCallback, FileInfo, Result, UploadProgressCallback,
+};
+use crate::models::AppError;
+
+/// FTP/FTPS 存储实现
+pub struct FtpStorage {
+    host: String,
+    port: u16,
+    username: String,
+    password: String,
+    use_tls: bool,
+    root: String,
+}
+
+impl FtpStorage {
+    /// 创建 FTP 存储实例
+    pub fn new(config: FtpConfig, root: String) -> Result<Self> {
+        if config.host.trim().is_empty() {
+            return Err(AppError::validation("FTP host 不能为空"));
+        }
+
+        let is_local = Self::is_local_ftp_host(&config.host);
+        if !is_local && !config.use_tls {
+            return Err(AppError::configuration(
+                "FTP 连接必须使用 TLS 以保护凭据（仅 localhost 允许明文）".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            host: config.host.trim().to_string(),
+            port: config.port,
+            username: config.username,
+            password: config.password,
+            use_tls: config.use_tls,
+            root: root.trim_matches('/').to_string(),
+        })
+    }
+
+    /// 判断 FTP host 是否为本地地址
+    fn is_local_ftp_host(host: &str) -> bool {
+        let host = host.trim().to_lowercase();
+        matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1")
+    }
+
+    /// 创建 FTP 客户端连接
+    async fn create_client(&self) -> Result<FtpClient> {
+        let address = format!("{}:{}", self.host, self.port);
+
+        tracing::debug!("[FtpStorage] 正在连接到 {}", address);
+
+        let mut stream = AsyncFtpStream::connect(&address)
+            .await
+            .map_err(|e| AppError::network(format!("FTP 连接失败 {}: {}", address, e)))?;
+
+        // 设置被动模式（PASV）
+        stream
+            .transfer_type(suppaftp::types::FileType::Binary)
+            .await
+            .map_err(|e| AppError::internal(format!("设置 FTP 传输类型失败：{}", e)))?;
+
+        // 如果配置了 TLS，升级为安全连接
+        if self.use_tls {
+            tracing::debug!("[FtpStorage] 正在升级到 TLS...");
+            let mut secure_stream = stream
+                .into_secure(AsyncNativeTlsConnector::new(), &self.host)
+                .await
+                .map_err(|e| AppError::network(format!("FTP TLS 升级失败：{}", e)))?;
+
+            // 登录
+            secure_stream
+                .login(&self.username, &self.password)
+                .await
+                .map_err(|e| AppError::authentication(format!("FTP 登录失败：{}", e)))?;
+
+            Ok(FtpClient::Secure(secure_stream))
+        } else {
+            // 明文登录（仅 localhost 允许）
+            stream
+                .login(&self.username, &self.password)
+                .await
+                .map_err(|e| AppError::authentication(format!("FTP 登录失败：{}", e)))?;
+
+            Ok(FtpClient::Plain(stream))
+        }
+    }
+
+    /// 将相对 key 组合成 FTP 根目录下的远程路径
+    fn remote_path(&self, key: &str) -> String {
+        Self::join_paths(&self.root, key)
+    }
+
+    /// 拼接两个路径片段，去掉首尾斜杠
+    fn join_paths(base: &str, child: &str) -> String {
+        let base = base.trim_matches('/');
+        let preserve_trailing_slash = child.ends_with('/') && !child.trim_matches('/').is_empty();
+        let child = child.trim_matches('/');
+
+        match (base.is_empty(), child.is_empty()) {
+            (true, true) => String::new(),
+            (true, false) => {
+                if preserve_trailing_slash {
+                    format!("{child}/")
+                } else {
+                    child.to_string()
+                }
+            }
+            (false, true) => base.to_string(),
+            (false, false) => {
+                if preserve_trailing_slash {
+                    format!("{base}/{child}/")
+                } else {
+                    format!("{base}/{child}")
+                }
+            }
+        }
+    }
+
+    /// 确保远程目录存在（递归创建）
+    async fn ensure_directory(&self, client: &mut FtpClient, path: &str) -> Result<()> {
+        let parts: Vec<&str> = path
+            .trim_matches('/')
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        let mut current = String::new();
+        for part in parts {
+            if !current.is_empty() {
+                current.push('/');
+            }
+            current.push_str(part);
+
+            // 尝试创建目录
+            match client.mkdir(&format!("/{}", current)).await {
+                Ok(_) => {
+                    tracing::debug!("[FtpStorage] 创建目录：/{}", current);
+                }
+                Err(e) => {
+                    // 550 表示目录已存在，可以忽略
+                    let err_str = e.to_string();
+                    if !err_str.contains("550") && !err_str.contains("already exists") {
+                        tracing::debug!("[FtpStorage] MKDIR /{} 失败：{}", current, e);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// 带重试的 FTP 操作
+    async fn with_retry<T, F, Fut>(&self, operation: F) -> Result<T>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        let max_retries = 3;
+        let mut last_error = None;
+
+        for attempt in 0..max_retries {
+            if attempt > 0 {
+                let delay = Duration::from_millis(500 * (1 << attempt));
+                tokio::time::sleep(delay).await;
+                tracing::debug!("[FtpStorage] 重试 {}/{}", attempt + 1, max_retries);
+            }
+
+            match operation().await {
+                Ok(result) => return Ok(result),
+                Err(e) => {
+                    last_error = Some(e);
+                    if attempt == max_retries - 1 {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Err(last_error.unwrap())
+    }
+}
+
+/// FTP 客户端枚举（支持明文和安全连接）
+enum FtpClient {
+    Plain(AsyncFtpStream),
+    Secure(AsyncNativeTlsFtpStream),
+}
+
+impl FtpClient {
+    async fn cwd(&mut self, path: &str) -> Result<()> {
+        match self {
+            FtpClient::Plain(stream) => stream
+                .cwd(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP CWD 失败：{}", e)))?,
+            FtpClient::Secure(stream) => stream
+                .cwd(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP CWD 失败：{}", e)))?,
+        }
+        Ok(())
+    }
+
+    async fn mkdir(&mut self, path: &str) -> Result<()> {
+        match self {
+            FtpClient::Plain(stream) => stream
+                .mkdir(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP MKDIR 失败：{}", e)))?,
+            FtpClient::Secure(stream) => stream
+                .mkdir(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP MKDIR 失败：{}", e)))?,
+        }
+        Ok(())
+    }
+
+    async fn put_file<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+        match self {
+            FtpClient::Plain(stream) => stream
+                .put_file(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP 上传失败：{}", e)))?,
+            FtpClient::Secure(stream) => stream
+                .put_file(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP 上传失败：{}", e)))?,
+        }
+        Ok(())
+    }
+
+    async fn get_file<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+        match self {
+            FtpClient::Plain(stream) => stream
+                .get_file(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP 下载失败：{}", e)))?,
+            FtpClient::Secure(stream) => stream
+                .get_file(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP 下载失败：{}", e)))?,
+        }
+        Ok(())
+    }
+
+    async fn list(&mut self, path: Option<&str>) -> Result<Vec<String>> {
+        match self {
+            FtpClient::Plain(stream) => Ok(stream
+                .list(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP LIST 失败：{}", e)))?
+                .unwrap_or_default()),
+            FtpClient::Secure(stream) => Ok(stream
+                .list(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP LIST 失败：{}", e)))?
+                .unwrap_or_default()),
+        }
+    }
+
+    async fn delete(&mut self, path: &str) -> Result<()> {
+        match self {
+            FtpClient::Plain(stream) => stream
+                .delete(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP DELETE 失败：{}", e)))?,
+            FtpClient::Secure(stream) => stream
+                .delete(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP DELETE 失败：{}", e)))?,
+        }
+        Ok(())
+    }
+
+    async fn size(&mut self, path: &str) -> Result<u64> {
+        match self {
+            FtpClient::Plain(stream) => Ok(stream
+                .size(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP SIZE 失败：{}", e)))?
+                .unwrap_or(0)),
+            FtpClient::Secure(stream) => Ok(stream
+                .size(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP SIZE 失败：{}", e)))?
+                .unwrap_or(0)),
+        }
+    }
+
+    async fn mdtm(&mut self, path: &str) -> Result<chrono::DateTime<chrono::Utc>> {
+        match self {
+            FtpClient::Plain(stream) => Ok(stream
+                .mdtm(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP MDTM 失败：{}", e)))?
+                .unwrap_or_else(|| chrono::Utc::now())),
+            FtpClient::Secure(stream) => Ok(stream
+                .mdtm(path)
+                .await
+                .map_err(|e| AppError::file_system(format!("FTP MDTM 失败：{}", e)))?
+                .unwrap_or_else(|| chrono::Utc::now())),
+        }
+    }
+
+    async fn quit(&mut self) -> Result<()> {
+        match self {
+            FtpClient::Plain(stream) => stream
+                .quit()
+                .await
+                .map_err(|e| AppError::network(format!("FTP 断开失败：{}", e)))?,
+            FtpClient::Secure(stream) => stream
+                .quit()
+                .await
+                .map_err(|e| AppError::network(format!("FTP 断开失败：{}", e)))?,
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl CloudStorage for FtpStorage {
+    fn provider_name(&self) -> &'static str {
+        "FTP"
+    }
+
+    async fn check_connection(&self) -> Result<()> {
+        self.with_retry(|| async {
+            let mut client = self.create_client().await?;
+            // 尝试切换到根目录
+            client.cwd(&format!("/{}", self.root)).await?;
+            client.quit().await?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn put(&self, key: &str, data: &[u8]) -> Result<()> {
+        self.with_retry(|| async {
+            let mut client = self.create_client().await?;
+
+            // 确保根目录存在
+            client.cwd("/").await?;
+            self.ensure_directory(&mut client, &self.root).await?;
+
+            // 切换到根目录
+            client.cwd(&format!("/{}", self.root)).await?;
+
+            // 确保父目录存在
+            if let Some(parent) = key.rfind('/') {
+                let parent_path = &key[..parent];
+                if !parent_path.is_empty() {
+                    self.ensure_directory(&mut client, parent_path).await?;
+                    client.cwd(&format!("/{}/{}", self.root, parent_path))
+                        .await?;
+                }
+            }
+
+            // 创建临时文件
+            let temp_file = tempfile::Builder::new()
+                .prefix("ftp-upload-")
+                .tempfile()
+                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
+            let temp_path = temp_file.path().to_path_buf();
+
+            // 写入数据
+            let mut file = tokio::fs::File::create(&temp_path)
+                .await
+                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
+            file.write_all(data)
+                .await
+                .map_err(|e| AppError::file_system(format!("写入临时文件失败：{}", e)))?;
+            file.flush()
+                .await
+                .map_err(|e| AppError::file_system(format!("刷新临时文件失败：{}", e)))?;
+            drop(file);
+
+            // 上传文件
+            let filename = key.rfind('/').map(|i| &key[i + 1..]).unwrap_or(key);
+            client.put_file(&temp_path).await?;
+
+            // 清理临时文件
+            let _ = std::fs::remove_file(&temp_path);
+
+            client.quit().await?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        self.with_retry(|| async {
+            let mut client = self.create_client().await?;
+
+            // 切换到根目录
+            client.cwd(&format!("/{}", self.root)).await?;
+
+            // 检查文件是否存在
+            let filename = key.rfind('/').map(|i| &key[i + 1..]).unwrap_or(key);
+            if let Some(parent) = key.rfind('/') {
+                let parent_path = &key[..parent];
+                if !parent_path.is_empty() {
+                    client.cwd(parent_path).await?;
+                }
+            }
+
+            // 获取文件大小
+            let size = client.size(filename).await?;
+            if size == 0 {
+                // 尝试获取修改时间来判断文件是否存在
+                match client.mdtm(filename).await {
+                    Ok(_) => {}
+                    Err(_) => {
+                        client.quit().await?;
+                        return Ok(None);
+                    }
+                }
+            }
+
+            // 创建临时文件
+            let temp_file = tempfile::Builder::new()
+                .prefix("ftp-download-")
+                .tempfile()
+                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
+            let temp_path = temp_file.path().to_path_buf();
+
+            // 下载文件
+            client.get_file(&temp_path).await?;
+            client.quit().await?;
+
+            // 读取文件内容
+            let data = tokio::fs::read(&temp_path)
+                .await
+                .map_err(|e| AppError::file_system(format!("读取临时文件失败：{}", e)))?;
+
+            // 清理临时文件
+            let _ = std::fs::remove_file(&temp_path);
+
+            Ok(Some(data))
+        })
+        .await
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<FileInfo>> {
+        self.with_retry(|| async {
+            let mut client = self.create_client().await?;
+
+            // 切换到根目录
+            client.cwd(&format!("/{}", self.root)).await?;
+
+            // 如果有 prefix，切换到对应目录
+            if !prefix.is_empty() {
+                let prefix_path = prefix.trim_matches('/');
+                client.cwd(prefix_path).await?;
+            }
+
+            // 列出文件
+            let entries = client.list(None).await?;
+            let mut files = Vec::new();
+
+            for entry in entries {
+                // 解析 LIST 输出（格式：-rw-r--r--  1 user group  1234 Jun  3 12:00 filename）
+                let parts: Vec<&str> = entry.split_whitespace().collect();
+                if parts.len() < 9 {
+                    continue;
+                }
+
+                // 跳过目录
+                let perms = parts[0];
+                if perms.starts_with('d') {
+                    continue;
+                }
+
+                // 提取文件名和大小
+                let size = parts[4].parse::<u64>().unwrap_or(0);
+                let filename = parts[8..].join(" ");
+
+                // 跳过隐藏文件
+                if filename.starts_with('.') {
+                    continue;
+                }
+
+                // 构建完整路径
+                let full_key = if prefix.is_empty() {
+                    filename.clone()
+                } else {
+                    format!("{}/{}", prefix.trim_matches('/'), filename)
+                };
+
+                // 获取修改时间
+                let file_path = if prefix.is_empty() {
+                    filename.clone()
+                } else {
+                    format!("{}/{}", prefix.trim_matches('/'), filename)
+                };
+
+                let modified = client.mdtm(&file_path).await.unwrap_or_else(|_| chrono::Utc::now());
+
+                files.push(FileInfo {
+                    key: full_key,
+                    size,
+                    last_modified: modified,
+                    etag: None,
+                });
+            }
+
+            client.quit().await?;
+
+            // 按修改时间降序排列
+            files.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+            Ok(files)
+        })
+        .await
+    }
+
+    async fn delete(&self, key: &str) -> Result<()> {
+        self.with_retry(|| async {
+            let mut client = self.create_client().await?;
+
+            // 切换到根目录
+            client.cwd(&format!("/{}", self.root)).await?;
+
+            // 切换到文件所在目录
+            let filename = key.rfind('/').map(|i| &key[i + 1..]).unwrap_or(key);
+            if let Some(parent) = key.rfind('/') {
+                let parent_path = &key[..parent];
+                if !parent_path.is_empty() {
+                    client.cwd(parent_path).await?;
+                }
+            }
+
+            // 删除文件
+            match client.delete(filename).await {
+                Ok(_) => {}
+                Err(e) => {
+                    // 文件不存在也算成功
+                    let err_str = e.to_string();
+                    if !err_str.contains("550") && !err_str.contains("not found") {
+                        return Err(e);
+                    }
+                }
+            }
+
+            client.quit().await?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn stat(&self, key: &str) -> Result<Option<FileInfo>> {
+        self.with_retry(|| async {
+            let mut client = self.create_client().await?;
+
+            // 切换到根目录
+            client.cwd(&format!("/{}", self.root)).await?;
+
+            // 切换到文件所在目录
+            let filename = key.rfind('/').map(|i| &key[i + 1..]).unwrap_or(key);
+            if let Some(parent) = key.rfind('/') {
+                let parent_path = &key[..parent];
+                if !parent_path.is_empty() {
+                    client.cwd(parent_path).await?;
+                }
+            }
+
+            // 获取文件大小
+            let size = match client.size(filename).await {
+                Ok(size) => size,
+                Err(_) => {
+                    client.quit().await?;
+                    return Ok(None);
+                }
+            };
+
+            // 获取修改时间
+            let modified = client.mdtm(filename).await?;
+
+            client.quit().await?;
+
+            Ok(Some(FileInfo {
+                key: key.to_string(),
+                size,
+                last_modified: modified,
+                etag: None,
+            }))
+        })
+        .await
+    }
+
+    async fn put_file(
+        &self,
+        key: &str,
+        local_path: &Path,
+        progress: Option<UploadProgressCallback>,
+    ) -> Result<String> {
+        self.with_retry(|| async {
+            let metadata = tokio::fs::metadata(local_path)
+                .await
+                .map_err(|e| AppError::file_system(format!("读取文件元信息失败：{}", e)))?;
+            let file_size = metadata.len();
+
+            // 计算 SHA256
+            let checksum = tokio::task::spawn_blocking({
+                let path = local_path.to_path_buf();
+                move || {
+                    use crate::backup_common::calculate_file_hash;
+                    calculate_file_hash(&path)
+                }
+            })
+            .await
+            .map_err(|e| AppError::internal(format!("计算校验和任务失败：{}", e)))??;
+
+            if let Some(ref cb) = progress {
+                cb(0, file_size);
+            }
+
+            let mut client = self.create_client().await?;
+
+            // 确保根目录存在
+            client.cwd("/").await?;
+            self.ensure_directory(&mut client, &self.root).await?;
+
+            // 切换到根目录
+            client.cwd(&format!("/{}", self.root)).await?;
+
+            // 确保父目录存在
+            if let Some(parent) = key.rfind('/') {
+                let parent_path = &key[..parent];
+                if !parent_path.is_empty() {
+                    self.ensure_directory(&mut client, parent_path).await?;
+                    client.cwd(&format!("/{}/{}", self.root, parent_path))
+                        .await?;
+                }
+            }
+
+            // 上传文件
+            let filename = key.rfind('/').map(|i| &key[i + 1..]).unwrap_or(key);
+
+            // 读取文件并上传
+            let mut file = tokio::fs::File::open(local_path)
+                .await
+                .map_err(|e| AppError::file_system(format!("打开文件失败：{}", e)))?;
+
+            // 创建临时文件用于上传（suppaftp 需要文件路径）
+            let temp_file = tempfile::Builder::new()
+                .prefix("ftp-upload-")
+                .tempfile()
+                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
+            let temp_path = temp_file.path().to_path_buf();
+
+            // 复制文件内容
+            let mut temp_writer = tokio::fs::File::create(&temp_path)
+                .await
+                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
+            tokio::io::copy(&mut file, &mut temp_writer)
+                .await
+                .map_err(|e| AppError::file_system(format!("复制文件失败：{}", e)))?;
+            temp_writer
+                .flush()
+                .await
+                .map_err(|e| AppError::file_system(format!("刷新临时文件失败：{}", e)))?;
+            drop(temp_writer);
+
+            // 上传
+            client.put_file(&temp_path).await?;
+
+            // 报告进度
+            if let Some(ref cb) = progress {
+                cb(file_size, file_size);
+            }
+
+            // 清理临时文件
+            let _ = std::fs::remove_file(&temp_path);
+
+            client.quit().await?;
+
+            Ok(checksum)
+        })
+        .await
+    }
+
+    async fn get_file(
+        &self,
+        key: &str,
+        local_path: &Path,
+        expected_checksum: Option<&str>,
+        progress: Option<DownloadProgressCallback>,
+    ) -> Result<String> {
+        self.with_retry(|| async {
+            let mut client = self.create_client().await?;
+
+            // 获取文件大小
+            let stat = self.stat(key).await?;
+            let total_size = stat.as_ref().map(|s| s.size).unwrap_or(0);
+
+            if let Some(ref cb) = progress {
+                cb(0, total_size);
+            }
+
+            // 切换到根目录
+            client.cwd(&format!("/{}", self.root)).await?;
+
+            // 切换到文件所在目录
+            let filename = key.rfind('/').map(|i| &key[i + 1..]).unwrap_or(key);
+            if let Some(parent) = key.rfind('/') {
+                let parent_path = &key[..parent];
+                if !parent_path.is_empty() {
+                    client.cwd(parent_path).await?;
+                }
+            }
+
+            // 确保目标目录存在
+            if let Some(parent) = local_path.parent() {
+                tokio::fs::create_dir_all(parent)
+                    .await
+                    .map_err(|e| AppError::file_system(format!("创建目录失败：{}", e)))?;
+            }
+
+            // 创建临时下载文件
+            let temp_file = tempfile::Builder::new()
+                .prefix("ftp-download-")
+                .tempfile_in(local_path.parent().unwrap_or(Path::new(".")))
+                .map_err(|e| AppError::file_system(format!("创建临时文件失败：{}", e)))?;
+            let temp_path = temp_file.path().to_path_buf();
+
+            // 下载文件
+            client.get_file(&temp_path).await?;
+            client.quit().await?;
+
+            // 计算校验和并读取文件
+            let mut hasher = Sha256::new();
+            let mut file = tokio::fs::File::open(&temp_path)
+                .await
+                .map_err(|e| AppError::file_system(format!("打开临时文件失败：{}", e)))?;
+            let mut buffer = vec![0u8; 8192];
+            let mut downloaded = 0u64;
+
+            loop {
+                let bytes_read = file
+                    .read(&mut buffer)
+                    .await
+                    .map_err(|e| AppError::file_system(format!("读取临时文件失败：{}", e)))?;
+                if bytes_read == 0 {
+                    break;
+                }
+                hasher.update(&buffer[..bytes_read]);
+                downloaded += bytes_read as u64;
+
+                if let Some(ref cb) = progress {
+                    cb(downloaded, total_size);
+                }
+            }
+
+            let checksum = format!("{:x}", hasher.finalize());
+
+            // 验证校验和
+            if let Some(expected) = expected_checksum {
+                if checksum != expected {
+                    return Err(AppError::validation(format!(
+                        "校验和不匹配：期望 {}, 实际 {}",
+                        &expected[..8.min(expected.len())],
+                        &checksum[..8]
+                    )));
+                }
+            }
+
+            // 移动到目标位置
+            tokio::fs::rename(&temp_path, local_path)
+                .await
+                .map_err(|e| AppError::file_system(format!("保存文件失败：{}", e)))?;
+
+            if let Some(ref cb) = progress {
+                cb(total_size, total_size);
+            }
+
+            Ok(checksum)
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_join_paths() {
+        assert_eq!(FtpStorage::join_paths("root", "file.txt"), "root/file.txt");
+        assert_eq!(FtpStorage::join_paths("root/", "file.txt"), "root/file.txt");
+        assert_eq!(FtpStorage::join_paths("root", "/file.txt"), "root/file.txt");
+        assert_eq!(FtpStorage::join_paths("", "file.txt"), "file.txt");
+        assert_eq!(FtpStorage::join_paths("root", ""), "root");
+        assert_eq!(FtpStorage::join_paths("", ""), "");
+    }
+
+    #[test]
+    fn test_remote_path() {
+        let storage = FtpStorage::new(
+            FtpConfig {
+                host: "localhost".into(),
+                port: 21,
+                username: "user".into(),
+                password: "pass".into(),
+                use_tls: false,
+            },
+            "deep-student-sync".into(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            storage.remote_path("objects/basic/hello.txt"),
+            "deep-student-sync/objects/basic/hello.txt"
+        );
+    }
+
+    #[test]
+    fn test_is_local_ftp_host() {
+        assert!(FtpStorage::is_local_ftp_host("localhost"));
+        assert!(FtpStorage::is_local_ftp_host("127.0.0.1"));
+        assert!(FtpStorage::is_local_ftp_host("::1"));
+        assert!(FtpStorage::is_local_ftp_host("  localhost  "));
+
+        assert!(
+            !FtpStorage::is_local_ftp_host("ftp.example.com"),
+            "remote host should not be treated as local"
+        );
+        assert!(
+            !FtpStorage::is_local_ftp_host("localhost.evil.com"),
+            "localhost.evil.com should not be treated as local"
+        );
+    }
+}

--- a/src-tauri/src/cloud_storage/mod.rs
+++ b/src-tauri/src/cloud_storage/mod.rs
@@ -26,8 +26,9 @@ mod s3;
 mod sync_manager;
 mod traits;
 mod webdav;
+mod ftp;
 
-pub use config::{CloudStorageConfig, S3Config, StorageProvider, WebDavConfig};
+pub use config::{CloudStorageConfig, FtpConfig, S3Config, StorageProvider, WebDavConfig};
 pub use sync_manager::{
     get_device_id, BackupVersion, CloudManifest, CloudSyncManager, DownloadResult, SyncStatus,
     UploadResult,
@@ -41,6 +42,7 @@ use crate::models::AppError;
 #[cfg(feature = "cloud_storage_s3")]
 use s3::S3Storage;
 use webdav::WebDavStorage;
+use ftp::FtpStorage;
 
 /// 云同步操作进度事件（通过 `cloud-sync-progress` 事件发送到前端）
 #[derive(Debug, Clone, Serialize)]
@@ -101,6 +103,14 @@ pub async fn create_storage(config: &CloudStorageConfig) -> Result<Box<dyn Cloud
         StorageProvider::S3 => Err(AppError::configuration(
             "S3 存储支持未启用，请在编译时启用 cloud_storage_s3 feature".to_string(),
         )),
+        StorageProvider::Ftp => {
+            let ftp_config = config
+                .ftp
+                .clone()
+                .ok_or_else(|| AppError::validation("缺少 FTP 配置"))?;
+            let storage = FtpStorage::new(ftp_config, root)?;
+            Ok(Box::new(storage))
+        }
     }
 }
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1013,6 +1013,10 @@ impl AppError {
         Self::new(AppErrorType::Network, message)
     }
 
+    pub fn authentication(message: impl Into<String>) -> Self {
+        Self::new(AppErrorType::Network, message)
+    }
+
     pub fn unknown(message: impl Into<String>) -> Self {
         Self::new(AppErrorType::Unknown, message)
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -88,7 +88,7 @@
       }
     },
     "android": {
-      "versionCode": 13350
+      "versionCode": 13354
     }
   },
   "plugins": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -88,7 +88,7 @@
       }
     },
     "android": {
-      "versionCode": 13354
+      "versionCode": 13355
     }
   },
   "plugins": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -88,7 +88,7 @@
       }
     },
     "android": {
-      "versionCode": 13896
+      "versionCode": 13349
     }
   },
   "plugins": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -88,7 +88,7 @@
       }
     },
     "android": {
-      "versionCode": 13349
+      "versionCode": 13350
     }
   },
   "plugins": {

--- a/src/features/settings/components/CloudStorageSection.tsx
+++ b/src/features/settings/components/CloudStorageSection.tsx
@@ -70,6 +70,13 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
     region: '',
     pathStyle: false,
   });
+  const [ftpConfig, setFtpConfig] = useState<cloudApi.FtpConfig>({
+    host: '',
+    port: 21,
+    username: '',
+    password: '',
+    useTls: false,
+  });
   const [root, setRoot] = useState('deep-student-sync');
 
   // 端到端加密密码（可选）
@@ -79,6 +86,7 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
   // UI 状态
   const [showPassword, setShowPassword] = useState(false);
   const [showSecretKey, setShowSecretKey] = useState(false);
+  const [showFtpPassword, setShowFtpPassword] = useState(false);
   const [testing, setTesting] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState<'unknown' | 'connected' | 'failed'>('unknown');
   
@@ -150,6 +158,9 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
           if (config.s3) {
             setS3Config(prev => ({ ...prev, ...config.s3, secretAccessKey: '' }));
           }
+          if (config.ftp) {
+            setFtpConfig(prev => ({ ...prev, ...config.ftp, password: '' }));
+          }
           if (config.root) setRoot(config.root);
           configLoaded = true;
         } catch (e: unknown) {
@@ -210,6 +221,9 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
           if (credentials.s3SecretAccessKey) {
             setS3Config(prev => ({ ...prev, secretAccessKey: credentials.s3SecretAccessKey! }));
           }
+          if (credentials.ftpPassword) {
+            setFtpConfig(prev => ({ ...prev, password: credentials.ftpPassword! }));
+          }
           if (credentials.encryptionPassword) {
             setEncryptionPassword(credentials.encryptionPassword);
           }
@@ -228,10 +242,11 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
       provider,
       webdav: provider === 'webdav' ? webdavConfig : undefined,
       s3: provider === 's3' ? s3Config : undefined,
+      ftp: provider === 'ftp' ? ftpConfig : undefined,
       root,
       encryptionPassword: encryptionPassword || undefined,
     };
-  }, [provider, webdavConfig, s3Config, root, encryptionPassword]);
+  }, [provider, webdavConfig, s3Config, ftpConfig, root, encryptionPassword]);
 
   // 保存配置
   const saveConfig = useCallback(async () => {
@@ -250,6 +265,7 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
       await cloudApi.saveCredentials({
         webdavPassword: webdavConfig.password || undefined,
         s3SecretAccessKey: s3Config.secretAccessKey || undefined,
+        ftpPassword: ftpConfig.password || undefined,
         encryptionPassword: encryptionPassword || undefined,
       });
       showGlobalNotification('success', t('cloudStorage:messages.configSaved'));
@@ -258,7 +274,7 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
       showGlobalNotification('warning', t('cloudStorage:messages.configSavedButCredentialsFailed'));
     }
     onConfigChanged?.();
-  }, [buildConfig, webdavConfig.password, s3Config.secretAccessKey, encryptionPassword, t, onConfigChanged]);
+  }, [buildConfig, webdavConfig.password, s3Config.secretAccessKey, ftpConfig.password, encryptionPassword, t, onConfigChanged]);
 
   // 清除配置
   const clearConfig = useCallback(async () => {
@@ -274,6 +290,7 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
     setOpProgress(null);
     setWebdavConfig({ endpoint: '', username: '', password: '' });
     setS3Config({ endpoint: '', bucket: '', accessKeyId: '', secretAccessKey: '', region: '', pathStyle: false });
+    setFtpConfig({ host: '', port: 21, username: '', password: '', useTls: false });
     setRoot('deep-student-sync');
     setEncryptionPassword('');
     setConnectionStatus('unknown');
@@ -648,6 +665,26 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
               : t('cloudStorage:provider.s3Desc')}
           </span>
         </NotionButton>
+        <NotionButton
+          variant="ghost"
+          size="sm"
+          onClick={() => setProvider('ftp')}
+          className={`relative !h-auto !justify-start flex-col items-start gap-1 !rounded-lg border-2 !p-3 text-left ${
+            provider === 'ftp'
+              ? 'border-primary bg-primary/5'
+              : 'border-border bg-transparent hover:bg-[var(--interactive-hover)]'
+          }`}
+        >
+          {provider === 'ftp' && (
+            <div className="absolute right-2 top-2">
+              <CheckCircle size={16} className="text-primary" />
+            </div>
+          )}
+          <span className="font-medium">{t('cloudStorage:provider.ftp')}</span>
+          <span className="text-xs text-muted-foreground line-clamp-2">
+            {t('cloudStorage:provider.ftpDesc')}
+          </span>
+        </NotionButton>
       </div>
 
       <Tabs value={provider} onValueChange={(v) => setProvider(v as cloudApi.StorageProvider)}>
@@ -763,6 +800,71 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
                   </span>
                 </Label>
               </div>
+            </div>
+          </TabsContent>
+
+          {/* FTP 配置 */}
+          <TabsContent value="ftp" className="space-y-4 mt-0">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="ftp-host">{t('cloudStorage:ftp.host')}</Label>
+                <Input
+                  id="ftp-host"
+                  placeholder={t('cloudStorage:ftp.hostPlaceholder')}
+                  value={ftpConfig.host}
+                  onChange={(e) => setFtpConfig({ ...ftpConfig, host: e.target.value })}
+                />
+                <p className="text-xs text-muted-foreground">{t('cloudStorage:ftp.hostHint')}</p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="ftp-port">{t('cloudStorage:ftp.port')}</Label>
+                <Input
+                  id="ftp-port"
+                  type="number"
+                  placeholder={t('cloudStorage:ftp.portPlaceholder')}
+                  value={ftpConfig.port}
+                  onChange={(e) => setFtpConfig({ ...ftpConfig, port: parseInt(e.target.value) || 21 })}
+                />
+                <p className="text-xs text-muted-foreground">{t('cloudStorage:ftp.portHint')}</p>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="ftp-username">{t('cloudStorage:ftp.username')}</Label>
+                <Input
+                  id="ftp-username"
+                  placeholder={t('cloudStorage:ftp.usernamePlaceholder')}
+                  value={ftpConfig.username}
+                  onChange={(e) => setFtpConfig({ ...ftpConfig, username: e.target.value })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="ftp-password">{t('cloudStorage:ftp.password')}</Label>
+                <ApiKeyField
+                  id="ftp-password"
+                  placeholder={t('cloudStorage:ftp.passwordPlaceholder')}
+                  value={ftpConfig.password}
+                  onChange={(e) => setFtpConfig({ ...ftpConfig, password: e.target.value })}
+                  revealed={showFtpPassword}
+                  canReveal={ftpConfig.password.trim().length > 0}
+                  onToggle={() => setShowFtpPassword(!showFtpPassword)}
+                  showLabel={t('common:securePassword.showPassword')}
+                  hideLabel={t('common:securePassword.hidePassword')}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="ftp-use-tls"
+                  checked={ftpConfig.useTls}
+                  onCheckedChange={(checked) => setFtpConfig({ ...ftpConfig, useTls: checked })}
+                />
+                <Label htmlFor="ftp-use-tls" className="font-normal">
+                  {t('cloudStorage:ftp.useTls')}
+                </Label>
+              </div>
+              <p className="text-xs text-muted-foreground">{t('cloudStorage:ftp.useTlsHint')}</p>
             </div>
           </TabsContent>
         </Tabs>

--- a/src/features/settings/components/CloudStorageSection.tsx
+++ b/src/features/settings/components/CloudStorageSection.tsx
@@ -350,7 +350,7 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
         if (!['http:', 'https:'].includes(url.protocol)) return false;
       } catch { return false; }
       return true;
-    } else {
+    } else if (provider === 's3') {
       const endpoint = s3Config.endpoint.trim();
       if (!endpoint || !s3Config.bucket.trim() || !s3Config.accessKeyId.trim() || !s3Config.secretAccessKey.trim()) return false;
       try {
@@ -358,8 +358,17 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
         if (!['http:', 'https:'].includes(url.protocol)) return false;
       } catch { return false; }
       return true;
+    } else {
+      // FTP provider
+      const host = ftpConfig.host.trim();
+      const username = ftpConfig.username.trim();
+      const password = ftpConfig.password.trim();
+      if (!host || !username || !password) return false;
+      // Validate port range
+      if (ftpConfig.port < 1 || ftpConfig.port > 65535) return false;
+      return true;
     }
-  }, [provider, webdavConfig, s3Config]);
+  }, [provider, webdavConfig, s3Config, ftpConfig]);
 
   const resolveBackupId = useCallback((job: BackupJobSummary | null): string | null => {
     const stats = job?.result?.stats as Record<string, unknown> | undefined;

--- a/src/locales/en-US/cloudStorage.json
+++ b/src/locales/en-US/cloudStorage.json
@@ -8,7 +8,9 @@
     "webdavDesc": "Jianguoyun, Nextcloud, self-hosted WebDAV, etc.",
     "s3": "S3 Compatible",
     "s3Desc": "AWS S3, Cloudflare R2, Aliyun OSS, MinIO, etc.",
-    "s3Disabled": "Not enabled (requires S3 feature at compile time)"
+    "s3Disabled": "Not enabled (requires S3 feature at compile time)",
+    "ftp": "FTP/FTPS",
+    "ftpDesc": "Traditional FTP servers with explicit FTPS encryption support"
   },
   
   "webdav": {
@@ -37,6 +39,21 @@
     "regionHint": "Some S3-compatible services may not require this",
     "pathStyle": "Use Path Style",
     "pathStyleHint": "Required for self-hosted services like MinIO"
+  },
+  
+  "ftp": {
+    "host": "Server Host",
+    "hostPlaceholder": "ftp.example.com",
+    "hostHint": "FTP server hostname or IP address",
+    "port": "Port",
+    "portPlaceholder": "21",
+    "portHint": "FTP port (default: 21)",
+    "username": "Username",
+    "usernamePlaceholder": "ftpuser",
+    "password": "Password",
+    "passwordPlaceholder": "Your FTP password",
+    "useTls": "Use FTPS Encryption",
+    "useTlsHint": "Enable explicit FTPS (AUTH TLS) to protect credentials (plaintext allowed for localhost only)"
   },
   
   "root": {

--- a/src/locales/zh-CN/cloudStorage.json
+++ b/src/locales/zh-CN/cloudStorage.json
@@ -8,7 +8,9 @@
     "webdavDesc": "坚果云、Nextcloud、自建 WebDAV 等",
     "s3": "S3 兼容存储",
     "s3Desc": "AWS S3、Cloudflare R2、阿里云 OSS、MinIO 等",
-    "s3Disabled": "未启用（需编译时启用 S3 feature）"
+    "s3Disabled": "未启用（需编译时启用 S3 feature）",
+    "ftp": "FTP/FTPS",
+    "ftpDesc": "传统 FTP 服务器、支持显式 FTPS 加密"
   },
   
   "webdav": {
@@ -37,6 +39,21 @@
     "regionHint": "某些 S3 兼容服务可能不需要",
     "pathStyle": "使用 Path Style",
     "pathStyleHint": "MinIO 等自建服务需要启用"
+  },
+  
+  "ftp": {
+    "host": "服务器地址",
+    "hostPlaceholder": "ftp.example.com",
+    "hostHint": "FTP 服务器的主机名或 IP 地址",
+    "port": "端口",
+    "portPlaceholder": "21",
+    "portHint": "FTP 端口（默认 21）",
+    "username": "用户名",
+    "usernamePlaceholder": "ftpuser",
+    "password": "密码",
+    "passwordPlaceholder": "您的 FTP 密码",
+    "useTls": "使用 FTPS 加密",
+    "useTlsHint": "启用显式 FTPS（AUTH TLS）以保护凭据（仅 localhost 允许明文）"
   },
   
   "root": {

--- a/src/types/dataGovernance.ts
+++ b/src/types/dataGovernance.ts
@@ -678,38 +678,18 @@ export function formatDuration(ms: number): string {
 
 // ==================== 云存储同步类型 ====================
 
-/** 云存储提供商类型（与后端 `StorageProvider` 对齐） */
-export type CloudStorageProvider = 'webdav' | 's3';
+// 云存储类型统一从 cloudStorageApi 导入，避免重复定义导致类型不一致
+// 新增 provider（如 ftp）时只需修改 cloudStorageApi.ts 一处即可
+import type {
+  StorageProvider,
+  WebDavConfig,
+  S3Config,
+  FtpConfig,
+  CloudStorageConfig,
+} from '@/utils/cloudStorageApi';
 
-/** WebDAV 配置（与后端 `WebDavConfig` 对齐，camelCase） */
-export interface WebDavConfig {
-  endpoint: string;
-  username: string;
-  /** 密码或应用专用密码（可为空：某些 WebDAV 支持匿名） */
-  password: string;
-}
-
-/** S3 兼容存储配置（与后端 `S3Config` 对齐，camelCase） */
-export interface S3Config {
-  endpoint: string;
-  bucket: string;
-  accessKeyId: string;
-  secretAccessKey: string;
-  region?: string;
-  /** 是否使用 path-style 地址（MinIO 等需要） */
-  pathStyle?: boolean;
-}
-
-/** 云存储配置（与后端 `CloudStorageConfig` 对齐，camelCase） */
-export interface CloudStorageConfig {
-  provider: CloudStorageProvider;
-  webdav?: WebDavConfig;
-  s3?: S3Config;
-  /** 根目录路径（所有操作都在此目录下） */
-  root?: string;
-  /** 端到端加密密码（可选）。非空时备份上传前会用 AES-256-GCM + Argon2id 加密。 */
-  encryptionPassword?: string;
-}
+export type CloudStorageProvider = StorageProvider;
+export type { WebDavConfig, S3Config, FtpConfig, CloudStorageConfig };
 
 /** 同步执行响应 */
 export interface SyncExecutionResponse {

--- a/src/utils/cloudStorageApi.ts
+++ b/src/utils/cloudStorageApi.ts
@@ -10,7 +10,7 @@ import { getErrorMessage } from './errorUtils';
 // ============== 类型定义 ==============
 
 /** 存储提供商类型 */
-export type StorageProvider = 'webdav' | 's3';
+export type StorageProvider = 'webdav' | 's3' | 'ftp';
 
 /** WebDAV 配置 */
 export interface WebDavConfig {
@@ -35,6 +35,20 @@ export interface S3Config {
   pathStyle?: boolean;
 }
 
+/** FTP/FTPS 配置 */
+export interface FtpConfig {
+  /** FTP 服务器主机名或 IP 地址 */
+  host: string;
+  /** FTP 端口（默认 21） */
+  port?: number;
+  /** 用户名 */
+  username: string;
+  /** 密码 */
+  password: string;
+  /** 是否使用 TLS（FTPS 显式加密） */
+  useTls?: boolean;
+}
+
 /** 云存储配置 */
 export interface CloudStorageConfig {
   /** 存储提供商类型 */
@@ -43,6 +57,8 @@ export interface CloudStorageConfig {
   webdav?: WebDavConfig;
   /** S3 配置 */
   s3?: S3Config;
+  /** FTP 配置 */
+  ftp?: FtpConfig;
   /** 根目录路径 */
   root?: string;
   /** 端到端加密密码（可选）
@@ -429,6 +445,28 @@ export function createS3Config(
 }
 
 /**
+ * 创建默认的 FTP 配置
+ */
+export function createFtpConfig(
+  host: string,
+  username: string,
+  password: string,
+  options?: { port?: number; useTls?: boolean; root?: string }
+): CloudStorageConfig {
+  return {
+    provider: 'ftp',
+    ftp: {
+      host,
+      port: options?.port ?? 21,
+      username,
+      password,
+      useTls: options?.useTls ?? false,
+    },
+    root: options?.root,
+  };
+}
+
+/**
  * 检查 S3 存储是否已启用（编译时 feature）
  */
 export async function isS3Enabled(): Promise<boolean> {
@@ -448,6 +486,8 @@ export interface CloudStorageCredentials {
   webdavPassword?: string;
   /** S3 Secret Access Key */
   s3SecretAccessKey?: string;
+  /** FTP 密码 */
+  ftpPassword?: string;
   /** 端到端加密密码 */
   encryptionPassword?: string;
 }


### PR DESCRIPTION
### Summary

本 PR 为云存储备份功能添加了部分的 FTP 支持。用户现在可以连接自建的 FTP 服务器或使用第三方 FTP 服务进行数据备份。

### Changes

- 后端新增 FTP 模块，支持 FTP 和 FTPS 协议（显式/隐式 TLS）
- 支持被动模式，自动处理连接和传输通道
- 前端云存储配置界面新增 FTP 选项


### How to test

- 在云存储设置中选择 FTP 类型（与webdav, s3存储并列）
- 填写 FTP 服务器信息（主机、端口、用户名、密码、根路径）
- 点击"测试连接"确认能够成功连接
- 执行一次数据备份，确认文件能够成功上传到 FTP 服务器
- 尝试恢复数据，确认文件能够成功下载
- 测试 FTPS 连接（如果服务器支持）

### 可能存在的问题
- 仅在Windows端测试，其他系统表现不清楚
- 仅在内网通过测试
- 仅测试了ftp协议，ftps支持不详（理论上来说是没问题的）

### 已知的问题
- 双向同步系列功能无用（在本机测试webdav也有此问题，可关联[issue#56](https://github.com/helixnow/deep-student/issues/57))
- 暂**未支持ftp主动模式**

### Screenshots / Logs

无（无 UI 大幅变更）

### Third-party content

<!-- 如包含第三方代码，请勾选并在此说明详情 -->

- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist

- [x] I ran `npm run build` and `cargo build` locally
- [x] I updated docs/README if needed
- [x] I linked the related Issue(s)
- [x] I have read the `https://github.com/000haoji/deep-student/blob/main/.github/CLA.md` and will sign it when prompted by the CLA bot

### 备注
我尽可能地模仿webdav对信息同步的实现，所以可能出现与之类似的bug
我有意对此功能贡献维护，关联到我提的[issue#91](https://github.com/helixnow/deep-student/issues/91)