### PR TITLE
feat(cloud-storage): add insecure connection warning for WebDAV and S3

### DIFF
--- a/src/features/settings/components/CloudStorageSection.tsx
+++ b/src/features/settings/components/CloudStorageSection.tsx
@@ -119,8 +119,10 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [pendingDeleteVersionId, setPendingDeleteVersionId] = useState<string | null>(null);
 
-  // 不安全 FTP 警告对话框状态
+  // 不安全连接警告对话框状态
   const [showInsecureFtpWarning, setShowInsecureFtpWarning] = useState(false);
+  const [showInsecureWebdavWarning, setShowInsecureWebdavWarning] = useState(false);
+  const [showInsecureS3Warning, setShowInsecureS3Warning] = useState(false);
 
   // 监听后端 cloud-sync-progress 事件（字节级传输进度）
   useEffect(() => {
@@ -373,7 +375,7 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
     onConfigChanged?.();
   }, [buildConfig, webdavConfig.password, s3Config.secretAccessKey, ftpConfig.password, encryptionPassword, t, onConfigChanged]);
 
-  // 保存配置（先检查不安全 FTP）
+  // 保存配置（先检查不安全连接）
   const saveConfig = useCallback(async () => {
     const config = buildConfig();
     if (
@@ -391,12 +393,36 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
       return;
     }
 
+    // WebDAV HTTP 连接警告：如果 endpoint 以 http:// 开头（非 https://），弹窗确认
+    if (config.provider === 'webdav' && webdavConfig.endpoint.trim().toLowerCase().startsWith('http://')) {
+      setShowInsecureWebdavWarning(true);
+      return;
+    }
+
+    // S3 HTTP 连接警告：如果 endpoint 以 http:// 开头（非 https://），弹窗确认
+    if (config.provider === 's3' && s3Config.endpoint.trim().toLowerCase().startsWith('http://')) {
+      setShowInsecureS3Warning(true);
+      return;
+    }
+
     await doSaveConfig();
-  }, [buildConfig, webdavConfig.password, s3Config.secretAccessKey, ftpConfig, encryptionPassword, t, doSaveConfig]);
+  }, [buildConfig, webdavConfig.password, webdavConfig.endpoint, s3Config.secretAccessKey, s3Config.endpoint, ftpConfig, encryptionPassword, t, doSaveConfig]);
 
   // 确认保存不安全 FTP 配置
   const handleConfirmInsecureFtpSave = useCallback(async () => {
     setShowInsecureFtpWarning(false);
+    await doSaveConfig();
+  }, [doSaveConfig]);
+
+  // 确认保存不安全 WebDAV 配置
+  const handleConfirmInsecureWebdavSave = useCallback(async () => {
+    setShowInsecureWebdavWarning(false);
+    await doSaveConfig();
+  }, [doSaveConfig]);
+
+  // 确认保存不安全 S3 配置
+  const handleConfirmInsecureS3Save = useCallback(async () => {
+    setShowInsecureS3Warning(false);
     await doSaveConfig();
   }, [doSaveConfig]);
 
@@ -1281,6 +1307,34 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
     />
   );
 
+  // 不安全 WebDAV 连接警告对话框
+  const insecureWebdavWarningDialog = (
+    <NotionAlertDialog
+      open={showInsecureWebdavWarning}
+      onOpenChange={(open) => { if (!open) setShowInsecureWebdavWarning(false); }}
+      title={t('cloudStorage:webdav.insecureWarning.title')}
+      description={t('cloudStorage:webdav.insecureWarning.description')}
+      confirmText={t('cloudStorage:webdav.insecureWarning.confirm')}
+      cancelText={t('common:actions.cancel')}
+      confirmVariant="warning"
+      onConfirm={handleConfirmInsecureWebdavSave}
+    />
+  );
+
+  // 不安全 S3 连接警告对话框
+  const insecureS3WarningDialog = (
+    <NotionAlertDialog
+      open={showInsecureS3Warning}
+      onOpenChange={(open) => { if (!open) setShowInsecureS3Warning(false); }}
+      title={t('cloudStorage:s3.insecureWarning.title')}
+      description={t('cloudStorage:s3.insecureWarning.description')}
+      confirmText={t('cloudStorage:s3.insecureWarning.confirm')}
+      cancelText={t('common:actions.cancel')}
+      confirmVariant="warning"
+      onConfirm={handleConfirmInsecureS3Save}
+    />
+  );
+
   // Dialog 模式下直接渲染内容
   if (isDialog) {
     return (
@@ -1298,6 +1352,8 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
         {restoreConfirmDialog}
         {deleteConfirmDialog}
         {insecureFtpWarningDialog}
+        {insecureWebdavWarningDialog}
+        {insecureS3WarningDialog}
       </>
     );
   }
@@ -1320,6 +1376,8 @@ export const CloudStorageSection: React.FC<CloudStorageSectionProps> = ({
       {restoreConfirmDialog}
       {deleteConfirmDialog}
       {insecureFtpWarningDialog}
+      {insecureWebdavWarningDialog}
+      {insecureS3WarningDialog}
     </>
   );
 };

--- a/src/locales/en-US/cloudStorage.json
+++ b/src/locales/en-US/cloudStorage.json
@@ -22,7 +22,12 @@
     "usernamePlaceholder": "your@email.com",
     "password": "Password",
     "passwordPlaceholder": "App-specific password",
-    "passwordHint": "Recommended to use app-specific password instead of login password"
+    "passwordHint": "Recommended to use app-specific password instead of login password",
+    "insecureWarning": {
+      "title": "Insecure WebDAV Connection",
+      "description": "You are using plaintext HTTP (http://) to connect to the WebDAV server. Your username, password, and data will be transmitted in cleartext over the network and may be intercepted. It is recommended to use HTTPS (https://) for encrypted connections.",
+      "confirm": "Use Plaintext Anyway"
+    }
   },
   
   "s3": {
@@ -39,7 +44,12 @@
     "regionPlaceholder": "us-east-1",
     "regionHint": "Some S3-compatible services may not require this",
     "pathStyle": "Use Path Style",
-    "pathStyleHint": "Required for self-hosted services like MinIO"
+    "pathStyleHint": "Required for self-hosted services like MinIO",
+    "insecureWarning": {
+      "title": "Insecure S3 Connection",
+      "description": "You are using plaintext HTTP (http://) to connect to the S3 service. Your Access Key, Secret Key, and data will be transmitted in cleartext over the network and may be intercepted. It is recommended to use HTTPS (https://) for encrypted connections.",
+      "confirm": "Use Plaintext Anyway"
+    }
   },
   
   "ftp": {

--- a/src/locales/zh-CN/cloudStorage.json
+++ b/src/locales/zh-CN/cloudStorage.json
@@ -22,7 +22,12 @@
     "usernamePlaceholder": "your@email.com",
     "password": "密码",
     "passwordPlaceholder": "应用专用密码",
-    "passwordHint": "建议使用应用专用密码而非登录密码"
+    "passwordHint": "建议使用应用专用密码而非登录密码",
+    "insecureWarning": {
+      "title": "不安全的 WebDAV 连接",
+      "description": "您正在使用明文 HTTP（http://）连接 WebDAV 服务器，用户名、密码以及传输的数据将以明文形式在网络中传输，可能被中间人窃取。建议使用 HTTPS（https://）加密连接。",
+      "confirm": "确认使用明文"
+    }
   },
   
   "s3": {
@@ -39,7 +44,12 @@
     "regionPlaceholder": "us-east-1",
     "regionHint": "某些 S3 兼容服务可能不需要",
     "pathStyle": "使用 Path Style",
-    "pathStyleHint": "MinIO 等自建服务需要启用"
+    "pathStyleHint": "MinIO 等自建服务需要启用",
+    "insecureWarning": {
+      "title": "不安全的 S3 连接",
+      "description": "您正在使用明文 HTTP（http://）连接 S3 服务，Access Key、Secret Key 以及传输的数据将以明文形式在网络中传输，可能被中间人窃取。建议使用 HTTPS（https://）加密连接。",
+      "confirm": "确认使用明文"
+    }
   },
   
   "ftp": {


### PR DESCRIPTION
fix: 为 WebDAV 和 S3 云同步添加 HTTP 明文连接警告

## PR 描述

### 问题描述

在我之前的 [PR（`e41f3a7`）](https://github.com/helixnow/deep-student/pull/106) 中为 FTP 非本地服务器云同步添加了"显式警告并确认"机制来防止用户误用明文连接。并在提交信息中**称** WebDAV 和 S3 有同样的逻辑。
但该 PR 实际上遗漏了 WebDAV 和 S3 两种云同步方式同样支持 HTTP 明文连接处理，导致实际无法使用非本地的http协议的服务云同步。

非常抱歉之前没有做好这项工作，这次补全了相关功能。

### 修复内容

- WebDAV：当 endpoint 使用 `http://`（非 HTTPS）时，弹出显式安全警告对话框
- S3：当 endpoint 使用 `http://`（非 HTTPS）时，弹出显式安全警告对话框
- 行为与 FTP 的明文警告完全一致，需要用户主动确认"确认使用明文"后才能保存配置
- 同步完善了中英文国际化翻译

### 影响范围

仅前端安全提醒，不影响已有功能逻辑。使用 HTTPS 的用户不会受到任何影响。