### PR TITLE
Fix/auto assign models

### DIFF
--- a/src/features/chat/readiness/autoAssignModel.ts
+++ b/src/features/chat/readiness/autoAssignModel.ts
@@ -55,6 +55,7 @@ function isRerankerModel(api: ApiConfig): boolean {
 
 /** 是否为可用的图像生成模型（与 useSettingsVendorState.isImageGenerationApi 一致） */
 function isImageGenerationModel(api: ApiConfig): boolean {
+  if (!api.enabled) return false;
   if (api.isEmbedding || api.isReranker) return false;
   if (api.isImageGeneration === true) return true;
   const caps = inferApiCapabilities({
@@ -90,8 +91,6 @@ interface AssignmentSlot {
   field: keyof ModelAssignments;
   /** 过滤函数 */
   filter: (api: ApiConfig) => boolean;
-  /** 在通知中显示的中文/英文标签 */
-  label: string;
 }
 
 /**
@@ -99,19 +98,20 @@ interface AssignmentSlot {
  * 注意：不包含 translation_display_mode（非模型字段）
  */
 const SLOTS: AssignmentSlot[] = [
-  { field: 'model2_config_id', filter: isChatModel, label: '对话模型' },
-  { field: 'anki_card_model_config_id', filter: isChatModel, label: 'Anki 卡片生成' },
-  { field: 'qbank_ai_grading_model_config_id', filter: isChatModel, label: '题库 AI 评分' },
-  { field: 'chat_title_model_config_id', filter: isChatModel, label: '聊天标题生成' },
-  { field: 'translation_model_config_id', filter: isChatModel, label: '翻译' },
-  { field: 'memory_decision_model_config_id', filter: isChatModel, label: '记忆决策' },
-  { field: 'image_generation_model_config_id', filter: isImageGenerationModel, label: '图像生成' },
-  { field: 'voice_input_asr_model_config_id', filter: isAsrModel, label: '语音输入 ASR' },
-  { field: 'reranker_model_config_id', filter: isRerankerModel, label: '重排序' },
-  { field: 'vl_reranker_model_config_id', filter: isRerankerModel, label: '多模态重排序' },
-  { field: 'embedding_model_config_id', filter: isEmbeddingModel, label: '嵌入' },
-  { field: 'vl_embedding_model_config_id', filter: isEmbeddingModel, label: '多模态嵌入' },
-  { field: 'exam_sheet_ocr_model_config_id', filter: isMultimodalModel, label: '试卷 OCR' },
+  { field: 'model2_config_id', filter: isChatModel },
+  { field: 'review_analysis_model_config_id', filter: isChatModel },
+  { field: 'anki_card_model_config_id', filter: isChatModel },
+  { field: 'qbank_ai_grading_model_config_id', filter: isChatModel },
+  { field: 'chat_title_model_config_id', filter: isChatModel },
+  { field: 'translation_model_config_id', filter: isChatModel },
+  { field: 'memory_decision_model_config_id', filter: isChatModel },
+  { field: 'image_generation_model_config_id', filter: isImageGenerationModel },
+  { field: 'voice_input_asr_model_config_id', filter: isAsrModel },
+  { field: 'reranker_model_config_id', filter: isRerankerModel },
+  { field: 'vl_reranker_model_config_id', filter: isRerankerModel },
+  { field: 'embedding_model_config_id', filter: isEmbeddingModel },
+  { field: 'vl_embedding_model_config_id', filter: isEmbeddingModel },
+  { field: 'exam_sheet_ocr_model_config_id', filter: isMultimodalModel },
 ];
 
 // ============================================================================
@@ -154,13 +154,29 @@ export async function autoAssignAllModels(): Promise<AutoAssignResult> {
     const assignedNames: string[] = [];
 
     for (const slot of SLOTS) {
-      // 跳过已分配的槽位
       const currentValue = currentAssignments[slot.field];
-      if (currentValue && currentValue !== '' && currentValue !== null) {
+      const isAssigned = currentValue && currentValue !== '' && currentValue !== null;
+
+      if (isAssigned) {
+        // 已分配的槽位：检查模型是否被禁用或不存在
+        const assignedApi = sortedConfigs.find(c => c.id === currentValue);
+        if (!assignedApi || !assignedApi.enabled) {
+          // 模型被禁用或已删除，需要重新分配
+          const matched = sortedConfigs.find(slot.filter);
+          if (matched) {
+            changes[slot.field] = matched.id as any;
+            assignedNames.push(matched.name || matched.model);
+          } else {
+            // 一个能用的都没有，清空为 null
+            changes[slot.field] = null as any;
+            assignedNames.push('(无)');
+          }
+        }
+        // 模型存在且启用，跳过
         continue;
       }
 
-      // 按过滤条件找第一个
+      // 未分配的槽位：找第一个可用模型
       const matched = sortedConfigs.find(slot.filter);
       if (matched) {
         changes[slot.field] = matched.id as any;

--- a/src/features/chat/readiness/autoAssignModel.ts
+++ b/src/features/chat/readiness/autoAssignModel.ts
@@ -114,6 +114,21 @@ const SLOTS: AssignmentSlot[] = [
   { field: 'exam_sheet_ocr_model_config_id', filter: isMultimodalModel },
 ];
 
+/**
+ * OCR 引擎信息
+ */
+interface OcrEngineEntry {
+  config_id: string;
+  model: string;
+  engine_type: string;
+  name: string;
+  is_free: boolean;
+  enabled: boolean;
+  priority: number;
+}
+
+const SYSTEM_OCR_CONFIG_ID = '__system_ocr__';
+
 // ============================================================================
 // 广播事件
 // ============================================================================
@@ -125,6 +140,69 @@ function broadcastModelAssignmentsChange(): void {
     }
   } catch {
     // 非浏览器环境忽略
+  }
+}
+
+/**
+ * 为指定 API 配置注册 OCR 引擎，确保系统 OCR 优先级最低
+ */
+async function ensureOcrEngineRegistered(apiConfig: ApiConfig): Promise<void> {
+  try {
+    // 读取现有 OCR 引擎列表
+    let existingEngines: OcrEngineEntry[] = [];
+    try {
+      existingEngines = await invoke<OcrEngineEntry[]>('get_available_ocr_models');
+    } catch {
+      // 无列表，从空开始
+    }
+
+    // 检查该 API 配置是否已注册为 OCR 引擎
+    const alreadyExists = existingEngines.some(e => e.config_id === apiConfig.id);
+    if (alreadyExists) return;
+
+    // 推断 engine_type
+    const caps = inferApiCapabilities({
+      id: apiConfig.model,
+      name: apiConfig.name,
+      providerScope: apiConfig.providerScope ?? apiConfig.providerType,
+    });
+    // 有 vision 能力的多模态模型作为 OCR 引擎
+    const engineType = caps.vision ? 'generic_vlm' : 'generic_vlm';
+
+    // 注册新 OCR 引擎
+    await invoke('add_ocr_engine', {
+      configId: apiConfig.id,
+      model: apiConfig.model,
+      name: apiConfig.name || apiConfig.model,
+      engineType,
+    });
+
+    // 确保系统 OCR 优先级最低：重新排列优先级
+    // 读取最新列表
+    let updatedEngines: OcrEngineEntry[] = [];
+    try {
+      updatedEngines = await invoke<OcrEngineEntry[]>('get_available_ocr_models');
+    } catch {
+      return;
+    }
+
+    // 找出系统 OCR 的当前优先级
+    const systemOcr = updatedEngines.find(e => e.config_id === SYSTEM_OCR_CONFIG_ID);
+    if (!systemOcr) return;
+
+    // 如果系统 OCR 不是优先级最低的，把它移到最后
+    const maxPriority = Math.max(...updatedEngines.map(e => e.priority));
+    if (systemOcr.priority !== maxPriority) {
+      const reordered = updatedEngines
+        .filter(e => e.config_id !== SYSTEM_OCR_CONFIG_ID)
+        .map((e, i) => ({ configId: e.config_id, enabled: e.enabled }));
+      // 系统 OCR 放在最后
+      reordered.push({ configId: SYSTEM_OCR_CONFIG_ID, enabled: systemOcr.enabled });
+
+      await invoke('update_ocr_engine_priority', { engineList: reordered });
+    }
+  } catch (err) {
+    console.error('[autoAssignModel] Failed to register OCR engine:', err);
   }
 }
 
@@ -166,6 +244,10 @@ export async function autoAssignAllModels(): Promise<AutoAssignResult> {
           if (matched) {
             changes[slot.field] = matched.id as any;
             assignedNames.push(matched.name || matched.model);
+            // OCR 槽位变更时注册为 OCR 引擎
+            if (slot.field === 'exam_sheet_ocr_model_config_id') {
+              void ensureOcrEngineRegistered(matched);
+            }
           } else {
             // 一个能用的都没有，清空为 null
             changes[slot.field] = null as any;
@@ -181,6 +263,10 @@ export async function autoAssignAllModels(): Promise<AutoAssignResult> {
       if (matched) {
         changes[slot.field] = matched.id as any;
         assignedNames.push(matched.name || matched.model);
+        // OCR 槽位分配时注册为 OCR 引擎
+        if (slot.field === 'exam_sheet_ocr_model_config_id') {
+          void ensureOcrEngineRegistered(matched);
+        }
       }
     }
 

--- a/src/features/settings/components/ApisTab.tsx
+++ b/src/features/settings/components/ApisTab.tsx
@@ -66,6 +66,26 @@ interface ApisTabProps {
 export const ApisTab: React.FC<ApisTabProps> = (props) => {
   const { t } = useTranslation(['settings', 'common']);
 
+  // 组件卸载时执行一次自动分配模型
+  React.useEffect(() => {
+    return () => {
+      console.log('[ApisTab] Leaving model service page, running auto-assign...');
+      (async () => {
+        try {
+          const { autoAssignAllModels } = await import('@/features/chat/readiness/autoAssignModel');
+          const result = await autoAssignAllModels();
+          if (result.assigned) {
+            console.log(`[ApisTab] Auto-assigned ${result.assignedCount} model(s): ${result.assignedModelNames.join(', ')}`);
+          } else {
+            console.log(`[ApisTab] Auto-assign skipped: ${result.reason ?? 'no changes'}`);
+          }
+        } catch (err) {
+          console.error('[ApisTab] Auto-assign failed:', err);
+        }
+      })();
+    };
+  }, []);
+
   // 将 props 映射为 Context value
   const contextValue: VendorSettingsContextValue = {
     vendors: props.vendors,


### PR DESCRIPTION
## 概述

将 `fix/auto-assign-models` 分支合并到 `nightly`。该分支优化了自动分配模型逻辑，新增 OCR 引擎自动注册功能，并修复了已分配模型被禁用后未重新分配的问题。

## 变更内容

### 1. OCR 引擎自动注册

- 在自动分配模型时，如果分配/变更的槽位是 `exam_sheet_ocr_model_config_id`，自动将该模型注册为 OCR 引擎
- 注册后确保系统 OCR 引擎优先级最低（排在最后）
- 新增 `ensureOcrEngineRegistered` 辅助函数，处理 OCR 引擎注册和优先级重排

### 2. 已分配槽位模型有效性检查

- 已分配的模型槽位不再直接跳过，而是检查关联的 API 配置是否存在且处于启用状态
- 如果模型被禁用或已删除，自动重新分配该槽位到第一个可用的模型
- 如果没有可用模型，则清空该槽位为 `null`

### 3. 离开 API 设置页面时触发自动分配

- 在 `ApisTab` 组件卸载时（离开模型服务页面）自动执行一次 `autoAssignAllModels`
- 确保用户修改 API 配置后离开页面时，模型分配状态自动更新

## 涉及文件

| 文件 | 变更说明 |
|------|---------|
| `src/features/chat/readiness/autoAssignModel.ts` | 新增 OCR 引擎注册逻辑 + 已分配槽位有效性检查 |
| `src/features/settings/components/ApisTab.tsx` | 组件卸载时触发自动分配模型 |

## 相关提交

- `086ec42d` refactor(apis-tab): optimize auto model assignment logic
- `372fac17` feat(chat/autoAssign): add OCR engine auto registration logic
