### PR TITLE
fix(anki,skills): unify mobile page header navigation config

### DIFF
--- a/src/components/anki/TaskDashboardPage.tsx
+++ b/src/components/anki/TaskDashboardPage.tsx
@@ -1077,7 +1077,11 @@ export const TaskDashboardPage: React.FC<TaskDashboardPageProps> = ({
   useMobileHeader('task-dashboard', {
     title: t('taskDashboard.title'),
     subtitle: t('taskDashboard.subtitle'),
+    showBackArrow: true,
     suppressGlobalBackButton: true,
+    onMenuClick: () => {
+      window.dispatchEvent(new CustomEvent('navigate-to-tab', { detail: { tabName: 'chat-v2' } }));
+    },
   }, [t]);
 
   // ======== 渲染 ========

--- a/src/components/skills-management/SkillsManagementPage.tsx
+++ b/src/components/skills-management/SkillsManagementPage.tsx
@@ -662,16 +662,17 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
   useMobileHeader('skills-management', {
     title: headerTitle,
     subtitle: headerSubtitle,
-    showMenu: !isEditorView,
-    showBackArrow: isEditorView,
-    suppressGlobalBackButton: !isEditorView,
+    showBackArrow: true,
+    suppressGlobalBackButton: true,
     onMenuClick: isEditorView
       ? () => {
           setEditorOpen(false);
           setRightPanelOpen(false);
           setScreenPosition('center');
         }
-      : undefined,
+      : () => {
+          window.dispatchEvent(new CustomEvent('navigate-to-tab', { detail: { tabName: 'chat-v2' } }));
+        },
     rightActions: !isEditorView ? (
       <NotionButton variant="ghost" size="icon" iconOnly onClick={handleCreate} className="!p-1.5 hover:bg-[var(--interactive-hover)] text-muted-foreground hover:text-foreground" title={t('skills:management.create', '新建技能')} aria-label="create">
         <Plus size={20} />


### PR DESCRIPTION
## 原因
- 竖屏模式下进入以下两个页面无法退出（即使在安卓端使用系统返回，将直接退出应用）只能退出重进

## 变更内容

### TaskDashboardPage

- 新增 `showBackArrow: true`，统一显示返回箭头
- 新增 `onMenuClick` 事件，点击菜单时跳转到 `chat-v2` 标签页

### SkillsManagementPage

- 简化导航逻辑，始终显示返回箭头（`showBackArrow: true`）
- 非编辑视图下菜单点击同样跳转到 `chat-v2` 标签页
- 移除冗余的 `showMenu` 条件判断

## 改动文件

| 文件 | 变更 |
|------|------|
| `src/components/anki/TaskDashboardPage.tsx` | +4 行 |
| `src/components/skills-management/SkillsManagementPage.tsx` | +3 / -4 行 |