### PR TITLE
Fix/auto assign models

### DIFF
--- a/src/features/chat/readiness/autoAssignModel.ts
+++ b/src/features/chat/readiness/autoAssignModel.ts
@@ -126,7 +126,6 @@ const SLOTS: AssignmentSlot[] = [
 interface OcrEngineEntry {
   configId: string;
   model: string;
-  engineType: string;
   name: string;
   isFree: boolean;
   enabled: boolean;
@@ -242,8 +241,7 @@ async function ensureAllVisionModelsRegisteredAsOcr(): Promise<void> {
         await invoke('add_ocr_engine', {
           configId: config.id,
           model: config.model,
-          name: config.name || config.model,
-          engineType: 'generic_vlm',
+          name: config.name || config.model
         });
         registeredCount++;
         console.log('[autoAssignModel] 注册 OCR 引擎:', config.name || config.model);

--- a/src/features/chat/readiness/autoAssignModel.ts
+++ b/src/features/chat/readiness/autoAssignModel.ts
@@ -205,7 +205,7 @@ async function ensureAllVisionModelsRegisteredAsOcr(): Promise<void> {
       console.log('[autoAssignModel] 已移除', enginesToRemove.length, '个不可用 OCR 引擎');
     }
 
-    // 重新读取引擎列表，检查是否只剩系统 OCR
+    // 重新读取引擎列表
     let currentEngines: OcrEngineEntry[] = [];
     try {
       currentEngines = await invoke<OcrEngineEntry[]>('get_available_ocr_models');
@@ -214,19 +214,11 @@ async function ensureAllVisionModelsRegisteredAsOcr(): Promise<void> {
     }
 
     const customEngines = currentEngines.filter(e => e.configId !== SYSTEM_OCR_CONFIG_ID);
-    const onlySystemOcrLeft = customEngines.length === 0;
-
     console.log('[autoAssignModel] 清理后剩余自定义 OCR 引擎数量:', customEngines.length);
 
-    // 如果只剩系统 OCR，继续注册新的视觉模型
-    if (!onlySystemOcrLeft) {
-      console.log('[autoAssignModel] 仍有自定义 OCR 模型，跳过注册新引擎');
-      // 但仍需确保系统 OCR 优先级最低
-      await ensureSystemOcrLastPriority();
-      return;
-    }
-
-    console.log('[autoAssignModel] 只剩系统 OCR，开始注册视觉模型...');
+    // 始终注册所有可用的视觉模型，不因已有自定义引擎而跳过
+    // 确保当前槽位分配的模型一定被注册到 OCR 引擎列表中
+    console.log('[autoAssignModel] 开始注册视觉模型...');
 
     const existingConfigIds = new Set(currentEngines.map(e => e.configId));
     let registeredCount = 0;
@@ -342,10 +334,10 @@ export async function autoAssignAllModels(): Promise<AutoAssignResult> {
       const isAssigned = currentValue && currentValue !== '' && currentValue !== null && !isSystemOcr;
 
       if (isAssigned) {
-        // 已分配的槽位：检查模型是否被禁用或不存在
+        // 已分配的槽位：检查模型是否被禁用、不存在或不再满足该槽位类型要求
         const assignedApi = sortedConfigs.find(c => c.id === currentValue);
-        if (!assignedApi || !assignedApi.enabled) {
-          // 模型被禁用或已删除，需要重新分配
+        if (!assignedApi || !assignedApi.enabled || !slot.filter(assignedApi)) {
+          // 模型被禁用、已删除或类型不匹配，需要重新分配
           const matched = sortedConfigs.find(slot.filter);
           if (matched) {
             changes[slot.field] = matched.id as any;

--- a/src/features/chat/readiness/autoAssignModel.ts
+++ b/src/features/chat/readiness/autoAssignModel.ts
@@ -55,6 +55,7 @@ function isRerankerModel(api: ApiConfig): boolean {
 
 /** 是否为可用的图像生成模型（与 useSettingsVendorState.isImageGenerationApi 一致） */
 function isImageGenerationModel(api: ApiConfig): boolean {
+  if (!api.enabled) return false;
   if (api.isEmbedding || api.isReranker) return false;
   if (api.isImageGeneration === true) return true;
   const caps = inferApiCapabilities({
@@ -90,8 +91,6 @@ interface AssignmentSlot {
   field: keyof ModelAssignments;
   /** 过滤函数 */
   filter: (api: ApiConfig) => boolean;
-  /** 在通知中显示的中文/英文标签 */
-  label: string;
 }
 
 /**
@@ -99,19 +98,20 @@ interface AssignmentSlot {
  * 注意：不包含 translation_display_mode（非模型字段）
  */
 const SLOTS: AssignmentSlot[] = [
-  { field: 'model2_config_id', filter: isChatModel, label: '对话模型' },
-  { field: 'anki_card_model_config_id', filter: isChatModel, label: 'Anki 卡片生成' },
-  { field: 'qbank_ai_grading_model_config_id', filter: isChatModel, label: '题库 AI 评分' },
-  { field: 'chat_title_model_config_id', filter: isChatModel, label: '聊天标题生成' },
-  { field: 'translation_model_config_id', filter: isChatModel, label: '翻译' },
-  { field: 'memory_decision_model_config_id', filter: isChatModel, label: '记忆决策' },
-  { field: 'image_generation_model_config_id', filter: isImageGenerationModel, label: '图像生成' },
-  { field: 'voice_input_asr_model_config_id', filter: isAsrModel, label: '语音输入 ASR' },
-  { field: 'reranker_model_config_id', filter: isRerankerModel, label: '重排序' },
-  { field: 'vl_reranker_model_config_id', filter: isRerankerModel, label: '多模态重排序' },
-  { field: 'embedding_model_config_id', filter: isEmbeddingModel, label: '嵌入' },
-  { field: 'vl_embedding_model_config_id', filter: isEmbeddingModel, label: '多模态嵌入' },
-  { field: 'exam_sheet_ocr_model_config_id', filter: isMultimodalModel, label: '试卷 OCR' },
+  { field: 'model2_config_id', filter: isChatModel },
+  { field: 'review_analysis_model_config_id', filter: isChatModel },
+  { field: 'anki_card_model_config_id', filter: isChatModel },
+  { field: 'qbank_ai_grading_model_config_id', filter: isChatModel },
+  { field: 'chat_title_model_config_id', filter: isChatModel },
+  { field: 'translation_model_config_id', filter: isChatModel },
+  { field: 'memory_decision_model_config_id', filter: isChatModel },
+  { field: 'image_generation_model_config_id', filter: isImageGenerationModel },
+  { field: 'voice_input_asr_model_config_id', filter: isAsrModel },
+  { field: 'reranker_model_config_id', filter: isRerankerModel },
+  { field: 'vl_reranker_model_config_id', filter: isRerankerModel },
+  { field: 'embedding_model_config_id', filter: isEmbeddingModel },
+  { field: 'vl_embedding_model_config_id', filter: isEmbeddingModel },
+  { field: 'exam_sheet_ocr_model_config_id', filter: isMultimodalModel },
 ];
 
 // ============================================================================
@@ -154,13 +154,29 @@ export async function autoAssignAllModels(): Promise<AutoAssignResult> {
     const assignedNames: string[] = [];
 
     for (const slot of SLOTS) {
-      // 跳过已分配的槽位
       const currentValue = currentAssignments[slot.field];
-      if (currentValue && currentValue !== '' && currentValue !== null) {
+      const isAssigned = currentValue && currentValue !== '' && currentValue !== null;
+
+      if (isAssigned) {
+        // 已分配的槽位：检查模型是否被禁用或不存在
+        const assignedApi = sortedConfigs.find(c => c.id === currentValue);
+        if (!assignedApi || !assignedApi.enabled) {
+          // 模型被禁用或已删除，需要重新分配
+          const matched = sortedConfigs.find(slot.filter);
+          if (matched) {
+            changes[slot.field] = matched.id as any;
+            assignedNames.push(matched.name || matched.model);
+          } else {
+            // 一个能用的都没有，清空为 null
+            changes[slot.field] = null as any;
+            assignedNames.push('(无)');
+          }
+        }
+        // 模型存在且启用，跳过
         continue;
       }
 
-      // 按过滤条件找第一个
+      // 未分配的槽位：找第一个可用模型
       const matched = sortedConfigs.find(slot.filter);
       if (matched) {
         changes[slot.field] = matched.id as any;

--- a/src/features/chat/readiness/autoAssignModel.ts
+++ b/src/features/chat/readiness/autoAssignModel.ts
@@ -66,9 +66,16 @@ function isImageGenerationModel(api: ApiConfig): boolean {
   return caps.imageModel;
 }
 
-/** 是否为可用的多模态模型 */
+/** 是否为可用的多模态模型（含 vision 能力推断） */
 function isMultimodalModel(api: ApiConfig): boolean {
-  return api.enabled && api.isMultimodal === true && !api.isEmbedding && !api.isReranker;
+  if (!api.enabled || api.isEmbedding || api.isReranker) return false;
+  if (api.isMultimodal === true) return true;
+  const caps = inferApiCapabilities({
+    id: api.model,
+    name: api.name,
+    providerScope: api.providerScope ?? api.providerType,
+  });
+  return caps.vision;
 }
 
 /**
@@ -99,7 +106,6 @@ interface AssignmentSlot {
  */
 const SLOTS: AssignmentSlot[] = [
   { field: 'model2_config_id', filter: isChatModel },
-  { field: 'review_analysis_model_config_id', filter: isChatModel },
   { field: 'anki_card_model_config_id', filter: isChatModel },
   { field: 'qbank_ai_grading_model_config_id', filter: isChatModel },
   { field: 'chat_title_model_config_id', filter: isChatModel },
@@ -115,14 +121,14 @@ const SLOTS: AssignmentSlot[] = [
 ];
 
 /**
- * OCR 引擎信息
+ * OCR 引擎信息（与后端 AvailableOcrModelResponse 对应，camelCase）
  */
 interface OcrEngineEntry {
-  config_id: string;
+  configId: string;
   model: string;
-  engine_type: string;
+  engineType: string;
   name: string;
-  is_free: boolean;
+  isFree: boolean;
   enabled: boolean;
   priority: number;
 }
@@ -144,10 +150,20 @@ function broadcastModelAssignmentsChange(): void {
 }
 
 /**
- * 为指定 API 配置注册 OCR 引擎，确保系统 OCR 优先级最低
+ * 清理不可用的 OCR 引擎，并注册所有视觉模型为 OCR 引擎
+ *
+ * 1. 检查现有 OCR 引擎对应的 API 配置是否可用（未被禁用/删除）
+ * 2. 移除不可用的引擎
+ * 3. 如果移除后只剩系统 OCR，继续注册新的视觉模型
+ * 4. 如果移除后还有其他自定义模型，跳过注册
+ * 5. 调整优先级使系统 OCR 排在最后
  */
-async function ensureOcrEngineRegistered(apiConfig: ApiConfig): Promise<void> {
+async function ensureAllVisionModelsRegisteredAsOcr(): Promise<void> {
   try {
+    // 获取所有 API 配置
+    const configs = await invoke<ApiConfig[]>('get_api_configurations');
+    const configMap = new Map(configs.map(c => [c.id, c]));
+
     // 读取现有 OCR 引擎列表
     let existingEngines: OcrEngineEntry[] = [];
     try {
@@ -156,53 +172,143 @@ async function ensureOcrEngineRegistered(apiConfig: ApiConfig): Promise<void> {
       // 无列表，从空开始
     }
 
-    // 检查该 API 配置是否已注册为 OCR 引擎
-    const alreadyExists = existingEngines.some(e => e.config_id === apiConfig.id);
-    if (alreadyExists) return;
+    console.log('[autoAssignModel] 清理前 OCR 引擎列表:', existingEngines.map(e => ({
+      id: e.configId,
+      name: e.name,
+      priority: e.priority,
+      enabled: e.enabled,
+    })));
 
-    // 推断 engine_type
-    const caps = inferApiCapabilities({
-      id: apiConfig.model,
-      name: apiConfig.name,
-      providerScope: apiConfig.providerScope ?? apiConfig.providerType,
-    });
-    // 有 vision 能力的多模态模型作为 OCR 引擎
-    const engineType = caps.vision ? 'generic_vlm' : 'generic_vlm';
+    // 清理不可用的 OCR 引擎
+    const enginesToRemove: string[] = [];
+    for (const engine of existingEngines) {
+      // 跳过系统 OCR
+      if (engine.configId === SYSTEM_OCR_CONFIG_ID) continue;
 
-    // 注册新 OCR 引擎
-    await invoke('add_ocr_engine', {
-      configId: apiConfig.id,
-      model: apiConfig.model,
-      name: apiConfig.name || apiConfig.model,
-      engineType,
-    });
+      const config = configMap.get(engine.configId);
+      // API 配置不存在或已禁用，需要移除
+      if (!config || !config.enabled) {
+        enginesToRemove.push(engine.configId);
+      }
+    }
 
-    // 确保系统 OCR 优先级最低：重新排列优先级
-    // 读取最新列表
-    let updatedEngines: OcrEngineEntry[] = [];
+    // 移除不可用的引擎
+    for (const configId of enginesToRemove) {
+      try {
+        await invoke('remove_ocr_engine', { configId });
+        console.log('[autoAssignModel] 移除不可用 OCR 引擎:', configId);
+      } catch (err: any) {
+        console.error('[autoAssignModel] 移除 OCR 引擎失败:', configId, err);
+      }
+    }
+
+    if (enginesToRemove.length > 0) {
+      console.log('[autoAssignModel] 已移除', enginesToRemove.length, '个不可用 OCR 引擎');
+    }
+
+    // 重新读取引擎列表，检查是否只剩系统 OCR
+    let currentEngines: OcrEngineEntry[] = [];
     try {
-      updatedEngines = await invoke<OcrEngineEntry[]>('get_available_ocr_models');
+      currentEngines = await invoke<OcrEngineEntry[]>('get_available_ocr_models');
     } catch {
       return;
     }
 
-    // 找出系统 OCR 的当前优先级
-    const systemOcr = updatedEngines.find(e => e.config_id === SYSTEM_OCR_CONFIG_ID);
+    const customEngines = currentEngines.filter(e => e.configId !== SYSTEM_OCR_CONFIG_ID);
+    const onlySystemOcrLeft = customEngines.length === 0;
+
+    console.log('[autoAssignModel] 清理后剩余自定义 OCR 引擎数量:', customEngines.length);
+
+    // 如果只剩系统 OCR，继续注册新的视觉模型
+    if (!onlySystemOcrLeft) {
+      console.log('[autoAssignModel] 仍有自定义 OCR 模型，跳过注册新引擎');
+      // 但仍需确保系统 OCR 优先级最低
+      await ensureSystemOcrLastPriority();
+      return;
+    }
+
+    console.log('[autoAssignModel] 只剩系统 OCR，开始注册视觉模型...');
+
+    const existingConfigIds = new Set(currentEngines.map(e => e.configId));
+    let registeredCount = 0;
+
+    // 遍历所有配置，注册视觉模型
+    for (const config of configs) {
+      if (existingConfigIds.has(config.id)) continue; // 已注册，跳过
+      if (!isMultimodalModel(config)) continue; // 复用已有的多模态判断逻辑
+
+      // 注册为 OCR 引擎
+      try {
+        await invoke('add_ocr_engine', {
+          configId: config.id,
+          model: config.model,
+          name: config.name || config.model,
+          engineType: 'generic_vlm',
+        });
+        registeredCount++;
+        console.log('[autoAssignModel] 注册 OCR 引擎:', config.name || config.model);
+      } catch (err: any) {
+        // 忽略"已存在"错误
+        if (err?.message !== '该模型已在 OCR 引擎列表中') {
+          console.error('[autoAssignModel] 注册 OCR 引擎失败:', config.name || config.model, err);
+        }
+      }
+    }
+
+    if (registeredCount > 0) {
+      console.log('[autoAssignModel] 本次注册了', registeredCount, '个 OCR 引擎');
+    }
+
+    // 确保系统 OCR 优先级最低
+    await ensureSystemOcrLastPriority();
+
+    // 读取最终的 OCR 引擎列表
+    let finalEngines: OcrEngineEntry[] = [];
+    try {
+      finalEngines = await invoke<OcrEngineEntry[]>('get_available_ocr_models');
+    } catch {
+      // 忽略
+    }
+    console.log('[autoAssignModel] 最终 OCR 引擎列表:', finalEngines.map(e => ({
+      id: e.configId,
+      name: e.name,
+      priority: e.priority,
+      enabled: e.enabled,
+    })));
+  } catch (err) {
+    console.error('[autoAssignModel] Failed to register vision models as OCR:', err);
+  }
+}
+
+/**
+ * 确保系统 OCR 在优先级列表中排在最后
+ */
+async function ensureSystemOcrLastPriority(): Promise<void> {
+  try {
+    let engines: OcrEngineEntry[] = [];
+    try {
+      engines = await invoke<OcrEngineEntry[]>('get_available_ocr_models');
+    } catch {
+      return;
+    }
+
+    const systemOcr = engines.find(e => e.configId === SYSTEM_OCR_CONFIG_ID);
     if (!systemOcr) return;
 
-    // 如果系统 OCR 不是优先级最低的，把它移到最后
-    const maxPriority = Math.max(...updatedEngines.map(e => e.priority));
-    if (systemOcr.priority !== maxPriority) {
-      const reordered = updatedEngines
-        .filter(e => e.config_id !== SYSTEM_OCR_CONFIG_ID)
-        .map((e, i) => ({ configId: e.config_id, enabled: e.enabled }));
-      // 系统 OCR 放在最后
-      reordered.push({ configId: SYSTEM_OCR_CONFIG_ID, enabled: systemOcr.enabled });
+    // 检查系统 OCR 是否已在最后
+    const maxPriority = Math.max(...engines.map(e => e.priority));
+    if (systemOcr.priority === maxPriority) return;
 
-      await invoke('update_ocr_engine_priority', { engineList: reordered });
-    }
+    // 重新排列：非系统 OCR 在前，系统 OCR 在最后
+    const reordered = engines
+      .filter(e => e.configId !== SYSTEM_OCR_CONFIG_ID)
+      .map(e => ({ configId: e.configId, enabled: e.enabled }));
+    reordered.push({ configId: SYSTEM_OCR_CONFIG_ID, enabled: systemOcr.enabled });
+
+    await invoke('update_ocr_engine_priority', { engineList: reordered });
+    console.log('[autoAssignModel] 已将系统 OCR 移至优先级最后');
   } catch (err) {
-    console.error('[autoAssignModel] Failed to register OCR engine:', err);
+    console.error('[autoAssignModel] Failed to adjust system OCR priority:', err);
   }
 }
 
@@ -233,7 +339,9 @@ export async function autoAssignAllModels(): Promise<AutoAssignResult> {
 
     for (const slot of SLOTS) {
       const currentValue = currentAssignments[slot.field];
-      const isAssigned = currentValue && currentValue !== '' && currentValue !== null;
+      // OCR 槽位：系统 OCR（__system_ocr__）视为未分配，触发自动分配用用户模型替代
+      const isSystemOcr = slot.field === 'exam_sheet_ocr_model_config_id' && currentValue === SYSTEM_OCR_CONFIG_ID;
+      const isAssigned = currentValue && currentValue !== '' && currentValue !== null && !isSystemOcr;
 
       if (isAssigned) {
         // 已分配的槽位：检查模型是否被禁用或不存在
@@ -244,9 +352,8 @@ export async function autoAssignAllModels(): Promise<AutoAssignResult> {
           if (matched) {
             changes[slot.field] = matched.id as any;
             assignedNames.push(matched.name || matched.model);
-            // OCR 槽位变更时注册为 OCR 引擎
             if (slot.field === 'exam_sheet_ocr_model_config_id') {
-              void ensureOcrEngineRegistered(matched);
+              console.log('[autoAssignModel] OCR 槽位重新分配:', matched.name || matched.model);
             }
           } else {
             // 一个能用的都没有，清空为 null
@@ -263,33 +370,29 @@ export async function autoAssignAllModels(): Promise<AutoAssignResult> {
       if (matched) {
         changes[slot.field] = matched.id as any;
         assignedNames.push(matched.name || matched.model);
-        // OCR 槽位分配时注册为 OCR 引擎
         if (slot.field === 'exam_sheet_ocr_model_config_id') {
-          void ensureOcrEngineRegistered(matched);
+          console.log('[autoAssignModel] OCR 槽位首次分配:', matched.name || matched.model);
         }
       }
     }
 
-    // 4. 若无任何变更，返回
+    // 4. 合并并保存（如有变更）
     const changeKeys = Object.keys(changes);
-    if (changeKeys.length === 0) {
-      return {
-        assigned: false,
-        assignedCount: 0,
-        assignedModelNames: [],
-        reason: 'no_available_models',
-      };
+    if (changeKeys.length > 0) {
+      const merged: ModelAssignments = { ...currentAssignments, ...changes };
+      await invoke('save_model_assignments', { assignments: merged });
+      broadcastModelAssignmentsChange();
     }
 
-    // 5. 合并并保存
-    const merged: ModelAssignments = { ...currentAssignments, ...changes };
-    await invoke('save_model_assignments', { assignments: merged });
-    broadcastModelAssignmentsChange();
+    // 5. 清理不可用的 OCR 引擎，并根据情况注册新引擎
+    // 无论 OCR 槽位状态如何都执行清理，确保列表干净
+    await ensureAllVisionModelsRegisteredAsOcr();
 
     return {
-      assigned: true,
+      assigned: changeKeys.length > 0,
       assignedCount: changeKeys.length,
       assignedModelNames: assignedNames,
+      reason: changeKeys.length === 0 ? 'already_assigned' : undefined,
     };
   } catch (error) {
     console.error('[autoAssignModel] Auto-assignment failed:', error);

--- a/src/features/chat/readiness/autoAssignModel.ts
+++ b/src/features/chat/readiness/autoAssignModel.ts
@@ -114,6 +114,21 @@ const SLOTS: AssignmentSlot[] = [
   { field: 'exam_sheet_ocr_model_config_id', filter: isMultimodalModel },
 ];
 
+/**
+ * OCR 引擎信息
+ */
+interface OcrEngineEntry {
+  config_id: string;
+  model: string;
+  engine_type: string;
+  name: string;
+  is_free: boolean;
+  enabled: boolean;
+  priority: number;
+}
+
+const SYSTEM_OCR_CONFIG_ID = '__system_ocr__';
+
 // ============================================================================
 // 广播事件
 // ============================================================================
@@ -125,6 +140,69 @@ function broadcastModelAssignmentsChange(): void {
     }
   } catch {
     // 非浏览器环境忽略
+  }
+}
+
+/**
+ * 为指定 API 配置注册 OCR 引擎，确保系统 OCR 优先级最低
+ */
+async function ensureOcrEngineRegistered(apiConfig: ApiConfig): Promise<void> {
+  try {
+    // 读取现有 OCR 引擎列表
+    let existingEngines: OcrEngineEntry[] = [];
+    try {
+      existingEngines = await invoke<OcrEngineEntry[]>('get_available_ocr_models');
+    } catch {
+      // 无列表，从空开始
+    }
+
+    // 检查该 API 配置是否已注册为 OCR 引擎
+    const alreadyExists = existingEngines.some(e => e.config_id === apiConfig.id);
+    if (alreadyExists) return;
+
+    // 推断 engine_type
+    const caps = inferApiCapabilities({
+      id: apiConfig.model,
+      name: apiConfig.name,
+      providerScope: apiConfig.providerScope ?? apiConfig.providerType,
+    });
+    // 有 vision 能力的多模态模型作为 OCR 引擎
+    const engineType = caps.vision ? 'generic_vlm' : 'generic_vlm';
+
+    // 注册新 OCR 引擎
+    await invoke('add_ocr_engine', {
+      configId: apiConfig.id,
+      model: apiConfig.model,
+      name: apiConfig.name || apiConfig.model,
+      engineType,
+    });
+
+    // 确保系统 OCR 优先级最低：重新排列优先级
+    // 读取最新列表
+    let updatedEngines: OcrEngineEntry[] = [];
+    try {
+      updatedEngines = await invoke<OcrEngineEntry[]>('get_available_ocr_models');
+    } catch {
+      return;
+    }
+
+    // 找出系统 OCR 的当前优先级
+    const systemOcr = updatedEngines.find(e => e.config_id === SYSTEM_OCR_CONFIG_ID);
+    if (!systemOcr) return;
+
+    // 如果系统 OCR 不是优先级最低的，把它移到最后
+    const maxPriority = Math.max(...updatedEngines.map(e => e.priority));
+    if (systemOcr.priority !== maxPriority) {
+      const reordered = updatedEngines
+        .filter(e => e.config_id !== SYSTEM_OCR_CONFIG_ID)
+        .map((e, i) => ({ configId: e.config_id, enabled: e.enabled }));
+      // 系统 OCR 放在最后
+      reordered.push({ configId: SYSTEM_OCR_CONFIG_ID, enabled: systemOcr.enabled });
+
+      await invoke('update_ocr_engine_priority', { engineList: reordered });
+    }
+  } catch (err) {
+    console.error('[autoAssignModel] Failed to register OCR engine:', err);
   }
 }
 
@@ -166,6 +244,10 @@ export async function autoAssignAllModels(): Promise<AutoAssignResult> {
           if (matched) {
             changes[slot.field] = matched.id as any;
             assignedNames.push(matched.name || matched.model);
+            // OCR 槽位变更时注册为 OCR 引擎
+            if (slot.field === 'exam_sheet_ocr_model_config_id') {
+              void ensureOcrEngineRegistered(matched);
+            }
           } else {
             // 一个能用的都没有，清空为 null
             changes[slot.field] = null as any;
@@ -181,6 +263,10 @@ export async function autoAssignAllModels(): Promise<AutoAssignResult> {
       if (matched) {
         changes[slot.field] = matched.id as any;
         assignedNames.push(matched.name || matched.model);
+        // OCR 槽位分配时注册为 OCR 引擎
+        if (slot.field === 'exam_sheet_ocr_model_config_id') {
+          void ensureOcrEngineRegistered(matched);
+        }
       }
     }
 

--- a/src/features/settings/components/ApisTab.tsx
+++ b/src/features/settings/components/ApisTab.tsx
@@ -66,6 +66,26 @@ interface ApisTabProps {
 export const ApisTab: React.FC<ApisTabProps> = (props) => {
   const { t } = useTranslation(['settings', 'common']);
 
+  // 组件卸载时执行一次自动分配模型
+  React.useEffect(() => {
+    return () => {
+      console.log('[ApisTab] Leaving model service page, running auto-assign...');
+      (async () => {
+        try {
+          const { autoAssignAllModels } = await import('@/features/chat/readiness/autoAssignModel');
+          const result = await autoAssignAllModels();
+          if (result.assigned) {
+            console.log(`[ApisTab] Auto-assigned ${result.assignedCount} model(s): ${result.assignedModelNames.join(', ')}`);
+          } else {
+            console.log(`[ApisTab] Auto-assign skipped: ${result.reason ?? 'no changes'}`);
+          }
+        } catch (err) {
+          console.error('[ApisTab] Auto-assign failed:', err);
+        }
+      })();
+    };
+  }, []);
+
   // 将 props 映射为 Context value
   const contextValue: VendorSettingsContextValue = {
     vendors: props.vendors,

--- a/src/features/settings/components/ApisTab.tsx
+++ b/src/features/settings/components/ApisTab.tsx
@@ -66,26 +66,6 @@ interface ApisTabProps {
 export const ApisTab: React.FC<ApisTabProps> = (props) => {
   const { t } = useTranslation(['settings', 'common']);
 
-  // 组件卸载时执行一次自动分配模型
-  React.useEffect(() => {
-    return () => {
-      console.log('[ApisTab] Leaving model service page, running auto-assign...');
-      (async () => {
-        try {
-          const { autoAssignAllModels } = await import('@/features/chat/readiness/autoAssignModel');
-          const result = await autoAssignAllModels();
-          if (result.assigned) {
-            console.log(`[ApisTab] Auto-assigned ${result.assignedCount} model(s): ${result.assignedModelNames.join(', ')}`);
-          } else {
-            console.log(`[ApisTab] Auto-assign skipped: ${result.reason ?? 'no changes'}`);
-          }
-        } catch (err) {
-          console.error('[ApisTab] Auto-assign failed:', err);
-        }
-      })();
-    };
-  }, []);
-
   // 将 props 映射为 Context value
   const contextValue: VendorSettingsContextValue = {
     vendors: props.vendors,

--- a/src/features/settings/components/Settings.tsx
+++ b/src/features/settings/components/Settings.tsx
@@ -474,6 +474,29 @@ export const Settings: React.FC<SettingsProps> = ({ onBack, mobilePresentation =
     })();
   }, []);
 
+  // 从 API 配置页切换到其他页时，触发一次自动分配模型
+  const prevActiveTabRef = useRef<string | null>(null);
+  useEffect(() => {
+    const prevTab = prevActiveTabRef.current;
+    prevActiveTabRef.current = activeTab;
+
+    if (prevTab === 'apis' && activeTab !== 'apis') {
+      (async () => {
+        try {
+          const { autoAssignAllModels } = await import('@/features/chat/readiness/autoAssignModel');
+          const result = await autoAssignAllModels();
+          if (result.assigned) {
+            console.log(`[Settings] Auto-assigned ${result.assignedCount} model(s): ${result.assignedModelNames.join(', ')}`);
+          } else {
+            console.log(`[Settings] Auto-assign skipped: ${result.reason ?? 'no changes'}`);
+          }
+        } catch (err) {
+          console.error('[Settings] Auto-assign failed:', err);
+        }
+      })();
+    }
+  }, [activeTab]);
+
   // 标签页指示器状态
   const [indicatorStyle, setIndicatorStyle] = useState({ transform: 'translateX(0)', width: 0 });
   const tabsRef = useRef<Map<string, HTMLButtonElement>>(new Map());


### PR DESCRIPTION
## 概述

将 `fix/auto-assign-models` 分支合并到 `nightly`。该分支优化了自动分配模型逻辑，并修复了已分配模型被禁用后未重新分配的问题。

## 变更内容

### 1. OCR 引擎自动注册

- 在自动分配模型时，如果分配/变更的槽位是 `exam_sheet_ocr_model_config_id`，自动将该模型注册为 OCR 引擎
- 注册后确保系统 OCR 引擎优先级最低（排在最后）
- 新增 `ensureOcrEngineRegistered` 辅助函数，处理 OCR 引擎注册和优先级重排

### 2. 已分配槽位模型有效性检查

- 已分配的模型槽位不再直接跳过，而是检查关联的 API 配置是否存在且处于启用状态
- 如果模型被禁用或已删除，自动重新分配该槽位到第一个可用的模型
- 如果没有可用模型，则清空该槽位为 `null`

### 3. 离开 API 设置页面时触发自动分配

- 在 `ApisTab` 组件卸载时（离开模型服务页面）自动执行一次 `autoAssignAllModels`
- 确保用户修改 API 配置后离开页面时，模型分配状态自动更新

## 涉及文件

| 文件 | 变更说明 |
|------|---------|
| `src/features/chat/readiness/autoAssignModel.ts` | 新增 OCR 引擎注册逻辑 + 已分配槽位有效性检查 |
| `src/features/settings/components/ApisTab.tsx` | 组件卸载时触发自动分配模型 |

## 相关提交

- `086ec42d` refactor(apis-tab): optimize auto model assignment logic
- `372fac17` feat(chat/autoAssign): add OCR engine auto registration logic
