### PR TITLE
Harden ToolPack edge handling and regressions

### DIFF
--- a/src-tauri/src/chat_v2/tools/executor_registry.rs
+++ b/src-tauri/src/chat_v2/tools/executor_registry.rs
@@ -299,6 +299,10 @@ impl ToolExecutorRegistry {
             .unwrap_or(false)
     }
 
+    pub(crate) fn is_no_timeout_tool(&self, tool_name: &str) -> bool {
+        get_tool_timeout_secs(tool_name) == NO_TOOL_TIMEOUT_SECS
+    }
+
     /// 获取已注册的执行器数量
     pub fn len(&self) -> usize {
         self.executors.len()
@@ -432,6 +436,15 @@ mod tests {
     fn ask_user_tool_is_not_subject_to_global_timeout() {
         assert_eq!(get_tool_timeout_secs("builtin-ask_user"), 0);
         assert_eq!(get_tool_timeout_secs("ask_user"), 0);
+    }
+
+    #[test]
+    fn ask_user_is_no_timeout_tool_for_pack_validation() {
+        let registry = ToolExecutorRegistry::new();
+        assert!(registry.is_no_timeout_tool("builtin-ask_user"));
+        assert!(registry.is_no_timeout_tool("ask_user"));
+        assert!(!registry.is_no_timeout_tool("builtin-template_validate"));
+        assert!(!registry.is_no_timeout_tool("builtin-tool_pack"));
     }
 
     #[test]

--- a/src-tauri/src/chat_v2/tools/tool_pack_executor.rs
+++ b/src-tauri/src/chat_v2/tools/tool_pack_executor.rs
@@ -256,71 +256,17 @@ impl ToolExecutor for ToolPackExecutor {
             let registry_clone = registry.clone();
             let sem = semaphore.clone();
             let token = child_token.clone();
-            let parent_block_id = ctx.block_id.clone();
-            let session_id = ctx.session_id.clone();
-            let message_id = ctx.message_id.clone();
-            let variant_id = ctx.variant_id.clone();
-            let skill_state_version = ctx.skill_state_version;
-            let round_id = ctx.round_id.clone();
-            let emitter = ctx.emitter.clone();
-            let canvas_note_id = ctx.canvas_note_id.clone();
-            let notes_manager = ctx.notes_manager.clone();
-            let tool_registry = ctx.tool_registry.clone();
-            let main_db = ctx.main_db.clone();
-            let anki_db = ctx.anki_db.clone();
-            let window = ctx.window.clone();
-            let vfs_db = ctx.vfs_db.clone();
-            let vfs_lance_store = ctx.vfs_lance_store.clone();
-            let llm_manager = ctx.llm_manager.clone();
-            let chat_v2_db = ctx.chat_v2_db.clone();
-            let question_bank_service = ctx.question_bank_service.clone();
-            let skill_contents = ctx.skill_contents.clone();
-            let skill_embedded_tools = ctx.skill_embedded_tools.clone();
-            let rag_top_k = ctx.rag_top_k;
-            let rag_enable_reranking = ctx.rag_enable_reranking;
-            let pdf_processing_service = ctx.pdf_processing_service.clone();
-            let memory_enabled = ctx.memory_enabled;
-            let rag_enabled = ctx.rag_enabled;
-            let web_search_enabled = ctx.web_search_enabled;
+            let sub_block_id = format!("{}-tool_pack-{}", ctx.block_id, sub.index);
+            let sub_call_id = format!("{}-tp-{}", ctx.block_id, sub.index);
+            let sub_ctx = create_sub_context(ctx, sub_block_id.clone(), token.clone());
 
             let handle = tokio::spawn(async move {
                 let sub_start = Instant::now();
-                let sub_block_id = format!("{}-tool_pack-{}", parent_block_id, sub.index);
-                let sub_call_id = format!("{}-tp-{}", parent_block_id, sub.index);
 
                 // Create sub-tool call/context before preflight so synthetic failures
                 // can close and persist the exact sub-tool block.
                 let sub_call =
                     ToolCall::new(sub_call_id.clone(), sub.name.clone(), sub.args.clone());
-                let sub_ctx = ExecutionContext {
-                    session_id,
-                    message_id,
-                    variant_id,
-                    skill_state_version,
-                    round_id,
-                    block_id: sub_block_id.clone(),
-                    emitter,
-                    canvas_note_id,
-                    notes_manager,
-                    tool_registry,
-                    main_db,
-                    anki_db,
-                    window,
-                    vfs_db,
-                    vfs_lance_store,
-                    llm_manager,
-                    chat_v2_db,
-                    question_bank_service,
-                    skill_contents,
-                    skill_embedded_tools,
-                    cancellation_token: Some(token.clone()),
-                    rag_top_k,
-                    rag_enable_reranking,
-                    pdf_processing_service,
-                    memory_enabled,
-                    rag_enabled,
-                    web_search_enabled,
-                };
 
                 // Cancellation check (early exit)
                 if token.is_cancelled() {
@@ -375,7 +321,7 @@ impl ToolExecutor for ToolPackExecutor {
                 let is_rag_tool = sub_short_name.starts_with("rag_");
                 let is_web_search_tool = sub_short_name == "web_search";
 
-                if is_memory_tool && !memory_enabled {
+                if is_memory_tool && !sub_ctx.memory_enabled {
                     let result = ToolResultInfo::failure(
                         Some(sub_call_id),
                         Some(sub_block_id),
@@ -387,7 +333,7 @@ impl ToolExecutor for ToolPackExecutor {
                     finalize_synthetic_sub_result(&sub_ctx, &result, true);
                     return result;
                 }
-                if is_rag_tool && !rag_enabled {
+                if is_rag_tool && !sub_ctx.rag_enabled {
                     let result = ToolResultInfo::failure(
                         Some(sub_call_id),
                         Some(sub_block_id),
@@ -399,7 +345,7 @@ impl ToolExecutor for ToolPackExecutor {
                     finalize_synthetic_sub_result(&sub_ctx, &result, true);
                     return result;
                 }
-                if is_web_search_tool && !web_search_enabled {
+                if is_web_search_tool && !sub_ctx.web_search_enabled {
                     let result = ToolResultInfo::failure(
                         Some(sub_call_id),
                         Some(sub_block_id),

--- a/src-tauri/src/chat_v2/tools/tool_pack_executor.rs
+++ b/src-tauri/src/chat_v2/tools/tool_pack_executor.rs
@@ -23,7 +23,6 @@ use futures::FutureExt;
 use serde_json::{json, Value};
 use tokio::sync::Semaphore;
 use tokio::time::{timeout, Duration};
-use tokio_util::sync::CancellationToken;
 
 use super::executor::{ExecutionContext, ToolExecutor, ToolSensitivity};
 use super::executor_registry::ToolExecutorRegistry;
@@ -155,6 +154,15 @@ impl ToolExecutor for ToolPackExecutor {
                 }
                 prefixed
             };
+
+            if registry.is_no_timeout_tool(&effective_name) {
+                let msg = format!(
+                    "tool_pack cannot execute blocking/no-timeout tool '{}'",
+                    effective_name
+                );
+                ctx.emit_tool_call_error(&msg);
+                return Err(msg);
+            }
 
             sub_tools.push(SubTool {
                 name: effective_name,
@@ -474,6 +482,47 @@ impl ToolExecutor for ToolPackExecutor {
                             args.clone(),
                             "tool_pack timeout: sub-tool did not complete within grace period".to_string(),
                             pack_timeout_secs * 1000,
+                        ));
+                        completed_indices.insert(sub_index);
+                    }
+                    break;
+                }
+                _ = child_token.cancelled() => {
+                    log::info!("[ToolPack] Pack cancelled, draining completed sub-tools");
+                    let grace = Duration::from_secs(CANCEL_GRACE_PERIOD_SECS);
+                    while let Ok(Some((sub_index, join_result))) = timeout(grace, futs.next()).await {
+                        match join_result {
+                            Ok(tool_result) => {
+                                completed_indices.insert(sub_index);
+                                results.push(tool_result);
+                            }
+                            Err(join_err) => {
+                                completed_indices.insert(sub_index);
+                                let (tool_name, args) = expected_sub_tools
+                                    .get(sub_index)
+                                    .cloned()
+                                    .unwrap_or_else(|| ("unknown".to_string(), json!(null)));
+                                results.push(ToolResultInfo::failure(
+                                    Some(format!("{}-tp-{}", ctx.block_id, sub_index)),
+                                    Some(format!("{}-tool_pack-{}", ctx.block_id, sub_index)),
+                                    tool_name,
+                                    args,
+                                    format!("task join error: {}", join_err),
+                                    0,
+                                ));
+                            }
+                        }
+                    }
+                    for (sub_index, (tool_name, args)) in expected_sub_tools.iter().enumerate() {
+                        if completed_indices.contains(&sub_index) {
+                            continue;
+                        }
+                        results.push(ToolResultInfo::cancelled(
+                            Some(format!("{}-tp-{}", ctx.block_id, sub_index)),
+                            Some(format!("{}-tool_pack-{}", ctx.block_id, sub_index)),
+                            tool_name.clone(),
+                            args.clone(),
+                            start.elapsed().as_millis() as u64,
                         ));
                         completed_indices.insert(sub_index);
                     }

--- a/src-tauri/src/chat_v2/tools/tool_pack_executor.rs
+++ b/src-tauri/src/chat_v2/tools/tool_pack_executor.rs
@@ -23,6 +23,7 @@ use futures::FutureExt;
 use serde_json::{json, Value};
 use tokio::sync::Semaphore;
 use tokio::time::{timeout, Duration};
+use tokio_util::sync::CancellationToken;
 
 use super::executor::{ExecutionContext, ToolExecutor, ToolSensitivity};
 use super::executor_registry::ToolExecutorRegistry;
@@ -47,6 +48,69 @@ impl ToolPackExecutor {
     /// Create new ToolPackExecutor
     pub fn new(registry_ref: Weak<ToolExecutorRegistry>) -> Self {
         Self { registry_ref }
+    }
+}
+
+fn create_sub_context(
+    parent: &ExecutionContext,
+    block_id: String,
+    token: CancellationToken,
+) -> ExecutionContext {
+    ExecutionContext {
+        session_id: parent.session_id.clone(),
+        message_id: parent.message_id.clone(),
+        variant_id: parent.variant_id.clone(),
+        skill_state_version: parent.skill_state_version,
+        round_id: parent.round_id.clone(),
+        block_id,
+        emitter: parent.emitter.clone(),
+        canvas_note_id: parent.canvas_note_id.clone(),
+        notes_manager: parent.notes_manager.clone(),
+        tool_registry: parent.tool_registry.clone(),
+        main_db: parent.main_db.clone(),
+        anki_db: parent.anki_db.clone(),
+        window: parent.window.clone(),
+        vfs_db: parent.vfs_db.clone(),
+        vfs_lance_store: parent.vfs_lance_store.clone(),
+        llm_manager: parent.llm_manager.clone(),
+        chat_v2_db: parent.chat_v2_db.clone(),
+        question_bank_service: parent.question_bank_service.clone(),
+        skill_contents: parent.skill_contents.clone(),
+        skill_embedded_tools: parent.skill_embedded_tools.clone(),
+        cancellation_token: Some(token),
+        rag_top_k: parent.rag_top_k,
+        rag_enable_reranking: parent.rag_enable_reranking,
+        pdf_processing_service: parent.pdf_processing_service.clone(),
+        memory_enabled: parent.memory_enabled,
+        rag_enabled: parent.rag_enabled,
+        web_search_enabled: parent.web_search_enabled,
+    }
+}
+
+fn finalize_synthetic_sub_result(
+    ctx: &ExecutionContext,
+    result: &ToolResultInfo,
+    emit_start: bool,
+) {
+    if emit_start {
+        ctx.emit_tool_call_start(
+            &result.tool_name,
+            result.input.clone(),
+            result.tool_call_id.as_deref(),
+        );
+    }
+
+    if let Some(error) = result.error.as_deref() {
+        ctx.emit_tool_call_error(error);
+    } else {
+        ctx.emit_tool_call_end(Some(json!({
+            "result": result.output.clone(),
+            "durationMs": result.duration_ms.unwrap_or(0),
+        })));
+    }
+
+    if let Err(e) = ctx.save_tool_block(result) {
+        log::warn!("[ToolPack] Failed to save synthetic sub-tool result: {}", e);
     }
 }
 
@@ -224,51 +288,10 @@ impl ToolExecutor for ToolPackExecutor {
                 let sub_block_id = format!("{}-tool_pack-{}", parent_block_id, sub.index);
                 let sub_call_id = format!("{}-tp-{}", parent_block_id, sub.index);
 
-                // Cancellation check (early exit)
-                if token.is_cancelled() {
-                    return ToolResultInfo::cancelled(
-                        Some(sub_call_id),
-                        Some(sub_block_id),
-                        sub.name,
-                        sub.args,
-                        0,
-                    );
-                }
-
-                // Acquire semaphore permit with cancellation-aware select
-                let _permit = tokio::select! {
-                    result = sem.acquire() => {
-                        match result {
-                            Ok(permit) => permit,
-                            Err(e) => {
-                                log::error!("[ToolPack] Semaphore acquire error for '{}': {}", sub.name, e);
-                                return ToolResultInfo::failure(
-                                    Some(sub_call_id),
-                                    Some(sub_block_id),
-                                    sub.name,
-                                    sub.args,
-                                    format!("Concurrency limit error: {}", e),
-                                    0,
-                                );
-                            }
-                        }
-                    }
-                    _ = token.cancelled() => {
-                        return ToolResultInfo::cancelled(
-                            Some(sub_call_id),
-                            Some(sub_block_id),
-                            sub.name,
-                            sub.args,
-                            0,
-                        );
-                    }
-                };
-
-                // Create sub-tool call
+                // Create sub-tool call/context before preflight so synthetic failures
+                // can close and persist the exact sub-tool block.
                 let sub_call =
                     ToolCall::new(sub_call_id.clone(), sub.name.clone(), sub.args.clone());
-
-                // Create sub-context
                 let sub_ctx = ExecutionContext {
                     session_id,
                     message_id,
@@ -299,6 +322,52 @@ impl ToolExecutor for ToolPackExecutor {
                     web_search_enabled,
                 };
 
+                // Cancellation check (early exit)
+                if token.is_cancelled() {
+                    let result = ToolResultInfo::cancelled(
+                        Some(sub_call_id),
+                        Some(sub_block_id),
+                        sub.name.clone(),
+                        sub.args.clone(),
+                        0,
+                    );
+                    finalize_synthetic_sub_result(&sub_ctx, &result, true);
+                    return result;
+                }
+
+                // Acquire semaphore permit with cancellation-aware select
+                let _permit = tokio::select! {
+                    result = sem.acquire() => {
+                        match result {
+                            Ok(permit) => permit,
+                            Err(e) => {
+                                log::error!("[ToolPack] Semaphore acquire error for '{}': {}", sub.name, e);
+                                let result = ToolResultInfo::failure(
+                                    Some(sub_call_id),
+                                    Some(sub_block_id),
+                                    sub.name.clone(),
+                                    sub.args.clone(),
+                                    format!("Concurrency limit error: {}", e),
+                                    0,
+                                );
+                                finalize_synthetic_sub_result(&sub_ctx, &result, true);
+                                return result;
+                            }
+                        }
+                    }
+                    _ = token.cancelled() => {
+                        let result = ToolResultInfo::cancelled(
+                            Some(sub_call_id),
+                            Some(sub_block_id),
+                            sub.name.clone(),
+                            sub.args.clone(),
+                            0,
+                        );
+                        finalize_synthetic_sub_result(&sub_ctx, &result, true);
+                        return result;
+                    }
+                };
+
                 // === Security preflight checks (mirrors pipeline execute_single_tool) ===
                 // Feature flag checks
                 let sub_short_name = sub.name.strip_prefix("builtin-").unwrap_or(&sub.name);
@@ -307,34 +376,40 @@ impl ToolExecutor for ToolPackExecutor {
                 let is_web_search_tool = sub_short_name == "web_search";
 
                 if is_memory_tool && !memory_enabled {
-                    return ToolResultInfo::failure(
+                    let result = ToolResultInfo::failure(
                         Some(sub_call_id),
                         Some(sub_block_id),
-                        sub.name,
-                        sub.args,
+                        sub.name.clone(),
+                        sub.args.clone(),
                         "memory function disabled, sub-tool blocked".to_string(),
                         0,
                     );
+                    finalize_synthetic_sub_result(&sub_ctx, &result, true);
+                    return result;
                 }
                 if is_rag_tool && !rag_enabled {
-                    return ToolResultInfo::failure(
+                    let result = ToolResultInfo::failure(
                         Some(sub_call_id),
                         Some(sub_block_id),
-                        sub.name,
-                        sub.args,
+                        sub.name.clone(),
+                        sub.args.clone(),
                         "RAG function disabled, sub-tool blocked".to_string(),
                         0,
                     );
+                    finalize_synthetic_sub_result(&sub_ctx, &result, true);
+                    return result;
                 }
                 if is_web_search_tool && !web_search_enabled {
-                    return ToolResultInfo::failure(
+                    let result = ToolResultInfo::failure(
                         Some(sub_call_id),
                         Some(sub_block_id),
-                        sub.name,
-                        sub.args,
+                        sub.name.clone(),
+                        sub.args.clone(),
                         "WebSearch function disabled, sub-tool blocked".to_string(),
                         0,
                     );
+                    finalize_synthetic_sub_result(&sub_ctx, &result, true);
+                    return result;
                 }
 
                 // Sensitivity check — block high-sensitivity tools that require user approval
@@ -346,11 +421,11 @@ impl ToolExecutor for ToolPackExecutor {
                             sub.name,
                             sensitivity
                         );
-                        return ToolResultInfo::failure(
+                        let result = ToolResultInfo::failure(
                             Some(sub_call_id),
                             Some(sub_block_id),
                             sub.name.clone(),
-                            sub.args,
+                            sub.args.clone(),
                             format!(
                                 "Tool '{}' requires user approval (sensitivity: {:?}) and cannot be executed inside tool_pack",
                                 sub.name,
@@ -358,6 +433,8 @@ impl ToolExecutor for ToolPackExecutor {
                             ),
                             0,
                         );
+                        finalize_synthetic_sub_result(&sub_ctx, &result, true);
+                        return result;
                     }
                 }
 
@@ -371,14 +448,18 @@ impl ToolExecutor for ToolPackExecutor {
 
                 match result {
                     Ok(Ok(tool_result)) => tool_result,
-                    Ok(Err(err_msg)) => ToolResultInfo::failure(
-                        Some(sub_call_id),
-                        Some(sub_block_id),
-                        sub.name,
-                        sub.args,
-                        err_msg,
-                        elapsed,
-                    ),
+                    Ok(Err(err_msg)) => {
+                        let result = ToolResultInfo::failure(
+                            Some(sub_call_id),
+                            Some(sub_block_id),
+                            sub.name,
+                            sub.args,
+                            err_msg,
+                            elapsed,
+                        );
+                        finalize_synthetic_sub_result(&sub_ctx, &result, false);
+                        result
+                    }
                     Err(panic_info) => {
                         let panic_msg = if let Some(s) = panic_info.downcast_ref::<String>() {
                             s.clone()
@@ -388,14 +469,16 @@ impl ToolExecutor for ToolPackExecutor {
                             "task panicked".to_string()
                         };
                         log::error!("[ToolPack] Sub-tool '{}' panicked: {}", sub.name, panic_msg);
-                        ToolResultInfo::failure(
+                        let result = ToolResultInfo::failure(
                             Some(sub_call_id),
                             Some(sub_block_id),
                             sub.name,
                             sub.args,
                             format!("task panicked: {}", panic_msg),
                             elapsed,
-                        )
+                        );
+                        finalize_synthetic_sub_result(&sub_ctx, &result, false);
+                        result
                     }
                 }
             });
@@ -405,7 +488,7 @@ impl ToolExecutor for ToolPackExecutor {
 
         // Wait for all sub-tools with pack-level timeout
         let pack_timeout_duration = Duration::from_secs(pack_timeout_secs);
-        let mut results: Vec<ToolResultInfo> = Vec::with_capacity(total);
+        let mut results: Vec<(usize, ToolResultInfo)> = Vec::with_capacity(total);
         let mut completed_indices: HashSet<usize> = HashSet::with_capacity(total);
         let pack_deadline = tokio::time::sleep(pack_timeout_duration);
         tokio::pin!(pack_deadline);
@@ -416,7 +499,7 @@ impl ToolExecutor for ToolPackExecutor {
                     match join_result {
                         Ok(tool_result) => {
                             completed_indices.insert(sub_index);
-                            results.push(tool_result);
+                            results.push((sub_index, tool_result));
                         }
                         Err(join_err) => {
                             log::error!("[ToolPack] Task join error: {}", join_err);
@@ -425,14 +508,21 @@ impl ToolExecutor for ToolPackExecutor {
                                 .get(sub_index)
                                 .cloned()
                                 .unwrap_or_else(|| ("unknown".to_string(), json!(null)));
-                            results.push(ToolResultInfo::failure(
+                            let result = ToolResultInfo::failure(
                                 Some(format!("{}-tp-{}", ctx.block_id, sub_index)),
                                 Some(format!("{}-tool_pack-{}", ctx.block_id, sub_index)),
                                 tool_name,
                                 args,
                                 format!("task join error: {}", join_err),
                                 0,
-                            ));
+                            );
+                            let sub_ctx = create_sub_context(
+                                ctx,
+                                format!("{}-tool_pack-{}", ctx.block_id, sub_index),
+                                child_token.clone(),
+                            );
+                            finalize_synthetic_sub_result(&sub_ctx, &result, true);
+                            results.push((sub_index, result));
                         }
                     }
                     if completed_indices.len() == total {
@@ -443,7 +533,7 @@ impl ToolExecutor for ToolPackExecutor {
                     log::warn!(
                         "[ToolPack] Pack timeout after {}s, cancelling {} remaining sub-tools",
                         pack_timeout_secs,
-                        total - results.len()
+                        total - completed_indices.len()
                     );
                     child_token.cancel();
                     // Grace period: wait for running sub-tools to exit
@@ -452,7 +542,7 @@ impl ToolExecutor for ToolPackExecutor {
                         match join_result {
                             Ok(tool_result) => {
                                 completed_indices.insert(sub_index);
-                                results.push(tool_result);
+                                results.push((sub_index, tool_result));
                             }
                             Err(join_err) => {
                                 completed_indices.insert(sub_index);
@@ -460,14 +550,21 @@ impl ToolExecutor for ToolPackExecutor {
                                     .get(sub_index)
                                     .cloned()
                                     .unwrap_or_else(|| ("unknown".to_string(), json!(null)));
-                                results.push(ToolResultInfo::failure(
+                                let result = ToolResultInfo::failure(
                                     Some(format!("{}-tp-{}", ctx.block_id, sub_index)),
                                     Some(format!("{}-tool_pack-{}", ctx.block_id, sub_index)),
                                     tool_name,
                                     args,
                                     format!("task join error: {}", join_err),
                                     0,
-                                ));
+                                );
+                                let sub_ctx = create_sub_context(
+                                    ctx,
+                                    format!("{}-tool_pack-{}", ctx.block_id, sub_index),
+                                    child_token.clone(),
+                                );
+                                finalize_synthetic_sub_result(&sub_ctx, &result, true);
+                                results.push((sub_index, result));
                             }
                         }
                     }
@@ -475,14 +572,21 @@ impl ToolExecutor for ToolPackExecutor {
                         if completed_indices.contains(&sub_index) {
                             continue;
                         }
-                        results.push(ToolResultInfo::failure(
+                        let result = ToolResultInfo::failure(
                             Some(format!("{}-tp-{}", ctx.block_id, sub_index)),
                             Some(format!("{}-tool_pack-{}", ctx.block_id, sub_index)),
                             tool_name.clone(),
                             args.clone(),
                             "tool_pack timeout: sub-tool did not complete within grace period".to_string(),
                             pack_timeout_secs * 1000,
-                        ));
+                        );
+                        let sub_ctx = create_sub_context(
+                            ctx,
+                            format!("{}-tool_pack-{}", ctx.block_id, sub_index),
+                            child_token.clone(),
+                        );
+                        finalize_synthetic_sub_result(&sub_ctx, &result, true);
+                        results.push((sub_index, result));
                         completed_indices.insert(sub_index);
                     }
                     break;
@@ -494,7 +598,7 @@ impl ToolExecutor for ToolPackExecutor {
                         match join_result {
                             Ok(tool_result) => {
                                 completed_indices.insert(sub_index);
-                                results.push(tool_result);
+                                results.push((sub_index, tool_result));
                             }
                             Err(join_err) => {
                                 completed_indices.insert(sub_index);
@@ -502,14 +606,21 @@ impl ToolExecutor for ToolPackExecutor {
                                     .get(sub_index)
                                     .cloned()
                                     .unwrap_or_else(|| ("unknown".to_string(), json!(null)));
-                                results.push(ToolResultInfo::failure(
+                                let result = ToolResultInfo::failure(
                                     Some(format!("{}-tp-{}", ctx.block_id, sub_index)),
                                     Some(format!("{}-tool_pack-{}", ctx.block_id, sub_index)),
                                     tool_name,
                                     args,
                                     format!("task join error: {}", join_err),
                                     0,
-                                ));
+                                );
+                                let sub_ctx = create_sub_context(
+                                    ctx,
+                                    format!("{}-tool_pack-{}", ctx.block_id, sub_index),
+                                    child_token.clone(),
+                                );
+                                finalize_synthetic_sub_result(&sub_ctx, &result, true);
+                                results.push((sub_index, result));
                             }
                         }
                     }
@@ -517,13 +628,20 @@ impl ToolExecutor for ToolPackExecutor {
                         if completed_indices.contains(&sub_index) {
                             continue;
                         }
-                        results.push(ToolResultInfo::cancelled(
+                        let result = ToolResultInfo::cancelled(
                             Some(format!("{}-tp-{}", ctx.block_id, sub_index)),
                             Some(format!("{}-tool_pack-{}", ctx.block_id, sub_index)),
                             tool_name.clone(),
                             args.clone(),
                             start.elapsed().as_millis() as u64,
-                        ));
+                        );
+                        let sub_ctx = create_sub_context(
+                            ctx,
+                            format!("{}-tool_pack-{}", ctx.block_id, sub_index),
+                            child_token.clone(),
+                        );
+                        finalize_synthetic_sub_result(&sub_ctx, &result, true);
+                        results.push((sub_index, result));
                         completed_indices.insert(sub_index);
                     }
                     break;
@@ -532,14 +650,17 @@ impl ToolExecutor for ToolPackExecutor {
         }
 
         // === Aggregate Results ===
+        results.sort_by_key(|(index, _)| *index);
         let total_ms = start.elapsed().as_millis() as u64;
-        let succeeded = results.iter().filter(|r| r.success).count();
+        let succeeded = results.iter().filter(|(_, r)| r.success).count();
         let failed = results.len() - succeeded;
 
         let results_json: Vec<Value> = results
             .iter()
-            .map(|r| {
+            .map(|(index, r)| {
                 json!({
+                    "index": index,
+                    "tool_call_id": r.tool_call_id,
                     "tool_name": r.tool_name,
                     "success": r.success,
                     "output": r.output,

--- a/src-tauri/tests/tool_pack_integration_tests.rs
+++ b/src-tauri/tests/tool_pack_integration_tests.rs
@@ -1,9 +1,12 @@
+use deep_student_lib::chat_v2::database::ChatV2Database;
 use deep_student_lib::chat_v2::events::ChatV2EventEmitter;
 use deep_student_lib::chat_v2::tools::{
-    AskUserExecutor, ExecutionContext, GeneralToolExecutor, TemplateDesignerExecutor, ToolExecutor,
-    ToolExecutorRegistry, ToolPackExecutor,
+    AskUserExecutor, ExecutionContext, GeneralToolExecutor, SessionToolExecutor,
+    TemplateDesignerExecutor, ToolExecutor, ToolExecutorRegistry, ToolPackExecutor,
 };
 use deep_student_lib::chat_v2::types::{ToolCall, ToolResultInfo};
+use deep_student_lib::data_governance::migration::coordinator::MigrationCoordinator;
+use deep_student_lib::data_governance::schema_registry::DatabaseId;
 use deep_student_lib::tools::ToolRegistry;
 use serde_json::{json, Value};
 use std::sync::{
@@ -40,6 +43,7 @@ fn create_tool_pack_registry() -> Arc<ToolExecutorRegistry> {
     Arc::new_cyclic(|weak| {
         ToolExecutorRegistry::from_vec(vec![
             Arc::new(TemplateDesignerExecutor::new()) as Arc<dyn ToolExecutor>,
+            Arc::new(SessionToolExecutor::new()),
             Arc::new(AskUserExecutor::new()),
             Arc::new(ToolPackExecutor::new(weak.clone())),
             Arc::new(GeneralToolExecutor::new()),
@@ -274,6 +278,41 @@ fn create_timeout_registry(
     })
 }
 
+fn create_chat_v2_db() -> (tempfile::TempDir, Arc<ChatV2Database>) {
+    let temp_dir = tempfile::TempDir::new().expect("failed to create Chat V2 temp dir");
+    let mut coordinator =
+        MigrationCoordinator::new(temp_dir.path().to_path_buf()).with_audit_db(None);
+    coordinator
+        .migrate_single(DatabaseId::ChatV2)
+        .expect("Chat V2 migrations should apply cleanly");
+    let db = ChatV2Database::new(temp_dir.path()).expect("failed to create Chat V2 database");
+    (temp_dir, Arc::new(db))
+}
+
+fn valid_template_fixture() -> Value {
+    json!({
+        "name": "Phase 3 Valid Template",
+        "noteType": "Basic",
+        "fields": ["Front", "Back"],
+        "frontTemplate": "{{Front}}",
+        "backTemplate": "{{Back}}",
+        "cssStyle": ".card { font-family: arial; }",
+        "generationPrompt": "Create a concise study card.",
+        "fieldExtractionRules": {
+            "Front": {
+                "field_type": "Text",
+                "is_required": true,
+                "description": "Question side"
+            },
+            "Back": {
+                "field_type": "Text",
+                "is_required": true,
+                "description": "Answer side"
+            }
+        }
+    })
+}
+
 fn tool_pack_call(arguments: Value) -> ToolCall {
     ToolCall::new(
         "phase-3-pack-call".to_string(),
@@ -293,6 +332,133 @@ async fn tool_pack_harness_constructs_execution_context() {
     assert_eq!(harness.context.window.label(), "tool-pack-test");
     assert_eq!(harness.context.emitter.session_id(), "phase-3-session");
     assert!(harness.registry.has_specific_executor("builtin-tool_pack"));
+}
+
+#[tokio::test]
+async fn tool_pack_executes_real_builtin_tools_and_returns_one_aggregate() {
+    let registry = create_tool_pack_registry();
+    let (_temp_dir, chat_v2_db) = create_chat_v2_db();
+    let mut harness = create_execution_context("parent-block", registry.clone());
+    harness.context = harness.context.with_chat_v2_db(Some(chat_v2_db));
+    let call = tool_pack_call(json!({
+        "tools": [
+            {
+                "name": "builtin-template_validate",
+                "args": { "template": valid_template_fixture() }
+            },
+            {
+                "name": "builtin-session_list",
+                "args": { "limit": 5, "include_tags": false }
+            }
+        ]
+    }));
+
+    let result = registry
+        .execute(&call, &harness.context)
+        .await
+        .expect("valid real built-in pack should return aggregate result");
+
+    assert!(result.success);
+    assert_eq!(result.tool_name, "builtin-tool_pack");
+    assert_eq!(result.output["succeeded"], 2);
+    assert_eq!(result.output["failed"], 0);
+
+    let results = result.output["results"].as_array().unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().all(|item| !item["duration_ms"].is_null()));
+    assert!(results.iter().all(|item| !item["block_id"].is_null()));
+    assert!(results.iter().any(|item| {
+        item["tool_name"] == "builtin-template_validate"
+            && item["success"] == true
+            && item["output"]["valid"] == true
+    }));
+    assert!(results.iter().any(|item| {
+        item["tool_name"] == "builtin-session_list"
+            && item["success"] == true
+            && item["output"]["sessions"].is_array()
+    }));
+
+    let block_ids: Vec<&str> = results
+        .iter()
+        .filter_map(|item| item["block_id"].as_str())
+        .collect();
+    assert!(block_ids.contains(&"parent-block-tool_pack-0"));
+    assert!(block_ids.contains(&"parent-block-tool_pack-1"));
+}
+
+#[tokio::test]
+async fn tool_pack_mixed_success_failure_preserves_successful_results() {
+    let registry = create_tool_pack_registry();
+    let harness = create_execution_context("mixed-pack", registry.clone());
+    let call = tool_pack_call(json!({
+        "tools": [
+            {
+                "name": "builtin-template_validate",
+                "args": { "template": valid_template_fixture() }
+            },
+            {
+                "name": "builtin-template_validate",
+                "args": {}
+            }
+        ]
+    }));
+
+    let result = registry
+        .execute(&call, &harness.context)
+        .await
+        .expect("registered sub-tool runtime failure should return aggregate result");
+
+    assert!(result.success);
+    assert_eq!(result.output["succeeded"], 1);
+    assert_eq!(result.output["failed"], 1);
+
+    let results = result.output["results"].as_array().unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().any(|item| {
+        item["tool_name"] == "builtin-template_validate" && item["success"] == true
+    }));
+    assert!(results.iter().any(|item| {
+        item["tool_name"] == "builtin-template_validate"
+            && item["success"] == false
+            && item["error"]
+                .as_str()
+                .map(|error| !error.is_empty())
+                .unwrap_or(false)
+    }));
+}
+
+#[tokio::test]
+async fn tool_pack_blocks_sensitive_subtool_without_bypassing_approval() {
+    let registry = create_tool_pack_registry();
+    let harness = create_execution_context("sensitive-pack", registry.clone());
+    let call = tool_pack_call(json!({
+        "tools": [
+            {
+                "name": "builtin-template_delete",
+                "args": { "templateId": "phase-3-sensitive" }
+            }
+        ]
+    }));
+
+    let result = registry
+        .execute(&call, &harness.context)
+        .await
+        .expect("sensitive sub-tool should be blocked inside aggregate result");
+
+    assert!(result.success);
+    assert_eq!(result.output["succeeded"], 0);
+    assert_eq!(result.output["failed"], 1);
+
+    let results = result.output["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    let failed = &results[0];
+    assert_eq!(failed["tool_name"], "builtin-template_delete");
+    assert_eq!(failed["success"], false);
+    assert!(failed["output"].is_null());
+    assert!(failed["error"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("requires user approval"));
 }
 
 #[tokio::test]

--- a/src-tauri/tests/tool_pack_integration_tests.rs
+++ b/src-tauri/tests/tool_pack_integration_tests.rs
@@ -1,0 +1,523 @@
+use deep_student_lib::chat_v2::events::ChatV2EventEmitter;
+use deep_student_lib::chat_v2::tools::{
+    AskUserExecutor, ExecutionContext, GeneralToolExecutor, TemplateDesignerExecutor, ToolExecutor,
+    ToolExecutorRegistry, ToolPackExecutor,
+};
+use deep_student_lib::chat_v2::types::{ToolCall, ToolResultInfo};
+use deep_student_lib::tools::ToolRegistry;
+use serde_json::{json, Value};
+use std::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Arc,
+};
+use std::time::Instant;
+use tokio::sync::Notify;
+use tokio::time::{timeout, Duration};
+use tokio_util::sync::CancellationToken;
+
+struct ToolPackTestHarness {
+    _app: tauri::App,
+    registry: Arc<ToolExecutorRegistry>,
+    context: ExecutionContext,
+}
+
+fn create_default_runtime_window(label: &str) -> (tauri::App, tauri::Window) {
+    // Tauri 2.10 does not expose tauri::test::mock_context / noop_assets to
+    // dependency integration tests unless the dependency feature is enabled.
+    // Use the crate context and public WebviewWindowBuilder default runtime.
+    let app = tauri::Builder::default()
+        .build(tauri::generate_context!())
+        .expect("failed to build default-runtime tauri app");
+    let webview_window =
+        tauri::WebviewWindowBuilder::new(&app, label, tauri::WebviewUrl::default())
+            .build()
+            .expect("failed to build default-runtime window");
+    let window = webview_window.as_ref().window();
+    (app, window)
+}
+
+fn create_tool_pack_registry() -> Arc<ToolExecutorRegistry> {
+    Arc::new_cyclic(|weak| {
+        ToolExecutorRegistry::from_vec(vec![
+            Arc::new(TemplateDesignerExecutor::new()) as Arc<dyn ToolExecutor>,
+            Arc::new(AskUserExecutor::new()),
+            Arc::new(ToolPackExecutor::new(weak.clone())),
+            Arc::new(GeneralToolExecutor::new()),
+        ])
+    })
+}
+
+fn create_execution_context(
+    block_id: &str,
+    registry: Arc<ToolExecutorRegistry>,
+) -> ToolPackTestHarness {
+    let (app, window) = create_default_runtime_window("tool-pack-test");
+    let emitter = Arc::new(ChatV2EventEmitter::new(
+        window.clone(),
+        "phase-3-session".to_string(),
+    ));
+    let context = ExecutionContext::new(
+        "phase-3-session".to_string(),
+        "phase-3-message".to_string(),
+        block_id.to_string(),
+        emitter,
+        Arc::new(ToolRegistry::new()),
+        window,
+    )
+    .with_feature_flags(true, true, true);
+
+    ToolPackTestHarness {
+        _app: app,
+        registry,
+        context,
+    }
+}
+
+struct Phase3ConcurrencyProbeExecutor {
+    started: Arc<AtomicUsize>,
+    in_flight: Arc<AtomicUsize>,
+    max_in_flight: Arc<AtomicUsize>,
+    started_ten: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+#[async_trait::async_trait]
+impl ToolExecutor for Phase3ConcurrencyProbeExecutor {
+    fn can_handle(&self, tool_name: &str) -> bool {
+        tool_name == "builtin-phase3_concurrency_probe"
+    }
+
+    async fn execute(
+        &self,
+        call: &ToolCall,
+        _ctx: &ExecutionContext,
+    ) -> Result<ToolResultInfo, String> {
+        let current_started = self.started.fetch_add(1, Ordering::SeqCst) + 1;
+        let current_in_flight = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+
+        let mut observed = self.max_in_flight.load(Ordering::SeqCst);
+        while current_in_flight > observed {
+            match self.max_in_flight.compare_exchange(
+                observed,
+                current_in_flight,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => break,
+                Err(next) => observed = next,
+            }
+        }
+
+        if current_started >= 10 {
+            self.started_ten.notify_waiters();
+        }
+
+        self.release.notified().await;
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+
+        Ok(ToolResultInfo::success(
+            Some(call.id.clone()),
+            None,
+            call.name.clone(),
+            call.arguments.clone(),
+            json!({"phase3": "concurrency_probe"}),
+            1,
+        ))
+    }
+
+    fn name(&self) -> &'static str {
+        "Phase3ConcurrencyProbeExecutor"
+    }
+}
+
+struct Phase3FastSuccessExecutor {
+    fast_completed: Arc<AtomicBool>,
+    notify: Arc<Notify>,
+}
+
+#[async_trait::async_trait]
+impl ToolExecutor for Phase3FastSuccessExecutor {
+    fn can_handle(&self, tool_name: &str) -> bool {
+        tool_name == "builtin-phase3_fast_success"
+    }
+
+    async fn execute(
+        &self,
+        call: &ToolCall,
+        _ctx: &ExecutionContext,
+    ) -> Result<ToolResultInfo, String> {
+        self.fast_completed.store(true, Ordering::SeqCst);
+        self.notify.notify_waiters();
+
+        Ok(ToolResultInfo::success(
+            Some(call.id.clone()),
+            None,
+            call.name.clone(),
+            call.arguments.clone(),
+            json!({"phase3": "fast_success"}),
+            1,
+        ))
+    }
+
+    fn name(&self) -> &'static str {
+        "Phase3FastSuccessExecutor"
+    }
+}
+
+struct Phase3SlowCancelExecutor;
+
+#[async_trait::async_trait]
+impl ToolExecutor for Phase3SlowCancelExecutor {
+    fn can_handle(&self, tool_name: &str) -> bool {
+        tool_name == "builtin-phase3_slow_cancel"
+    }
+
+    async fn execute(
+        &self,
+        call: &ToolCall,
+        ctx: &ExecutionContext,
+    ) -> Result<ToolResultInfo, String> {
+        let start = Instant::now();
+        ctx.cancellation_token()
+            .expect("slow cancel executor requires cancellation token")
+            .cancelled()
+            .await;
+
+        Ok(ToolResultInfo::cancelled(
+            Some(call.id.clone()),
+            Some(ctx.block_id.clone()),
+            call.name.clone(),
+            call.arguments.clone(),
+            start.elapsed().as_millis() as u64,
+        ))
+    }
+
+    fn name(&self) -> &'static str {
+        "Phase3SlowCancelExecutor"
+    }
+}
+
+struct Phase3NeverCompletesExecutor;
+
+#[async_trait::async_trait]
+impl ToolExecutor for Phase3NeverCompletesExecutor {
+    fn can_handle(&self, tool_name: &str) -> bool {
+        tool_name == "builtin-phase3_never_finishes"
+    }
+
+    async fn execute(
+        &self,
+        _call: &ToolCall,
+        _ctx: &ExecutionContext,
+    ) -> Result<ToolResultInfo, String> {
+        std::future::pending::<Result<ToolResultInfo, String>>().await
+    }
+
+    fn name(&self) -> &'static str {
+        "Phase3NeverCompletesExecutor"
+    }
+}
+
+fn create_concurrency_registry(
+    started: Arc<AtomicUsize>,
+    in_flight: Arc<AtomicUsize>,
+    max_in_flight: Arc<AtomicUsize>,
+    started_ten: Arc<Notify>,
+    release: Arc<Notify>,
+) -> Arc<ToolExecutorRegistry> {
+    Arc::new_cyclic(|weak| {
+        ToolExecutorRegistry::from_vec(vec![
+            Arc::new(Phase3ConcurrencyProbeExecutor {
+                started,
+                in_flight,
+                max_in_flight,
+                started_ten,
+                release,
+            }) as Arc<dyn ToolExecutor>,
+            Arc::new(ToolPackExecutor::new(weak.clone())),
+            Arc::new(GeneralToolExecutor::new()),
+        ])
+    })
+}
+
+fn create_cancellation_registry(
+    fast_completed: Arc<AtomicBool>,
+    notify: Arc<Notify>,
+) -> Arc<ToolExecutorRegistry> {
+    Arc::new_cyclic(|weak| {
+        ToolExecutorRegistry::from_vec(vec![
+            Arc::new(Phase3FastSuccessExecutor {
+                fast_completed,
+                notify,
+            }) as Arc<dyn ToolExecutor>,
+            Arc::new(Phase3SlowCancelExecutor),
+            Arc::new(ToolPackExecutor::new(weak.clone())),
+            Arc::new(GeneralToolExecutor::new()),
+        ])
+    })
+}
+
+fn create_timeout_registry(
+    fast_completed: Arc<AtomicBool>,
+    notify: Arc<Notify>,
+) -> Arc<ToolExecutorRegistry> {
+    Arc::new_cyclic(|weak| {
+        ToolExecutorRegistry::from_vec(vec![
+            Arc::new(Phase3FastSuccessExecutor {
+                fast_completed,
+                notify,
+            }) as Arc<dyn ToolExecutor>,
+            Arc::new(Phase3NeverCompletesExecutor),
+            Arc::new(ToolPackExecutor::new(weak.clone())),
+            Arc::new(GeneralToolExecutor::new()),
+        ])
+    })
+}
+
+fn tool_pack_call(arguments: Value) -> ToolCall {
+    ToolCall::new(
+        "phase-3-pack-call".to_string(),
+        "builtin-tool_pack".to_string(),
+        arguments,
+    )
+}
+
+#[tokio::test]
+async fn tool_pack_harness_constructs_execution_context() {
+    let registry = create_tool_pack_registry();
+    let harness = create_execution_context("harness-block", registry.clone());
+
+    assert_eq!(harness.context.session_id, "phase-3-session");
+    assert_eq!(harness.context.message_id, "phase-3-message");
+    assert_eq!(harness.context.block_id, "harness-block");
+    assert_eq!(harness.context.window.label(), "tool-pack-test");
+    assert_eq!(harness.context.emitter.session_id(), "phase-3-session");
+    assert!(harness.registry.has_specific_executor("builtin-tool_pack"));
+}
+
+#[tokio::test]
+async fn tool_pack_rejects_empty_tools_array() {
+    let registry = create_tool_pack_registry();
+    let harness = create_execution_context("empty-pack", registry.clone());
+    let call = tool_pack_call(json!({ "tools": [] }));
+
+    let error = registry
+        .execute(&call, &harness.context)
+        .await
+        .expect_err("empty tools should be rejected");
+
+    assert!(error.contains("tool_pack requires at least 1 sub-tool"));
+}
+
+#[tokio::test]
+async fn tool_pack_rejects_unknown_specific_tool_before_execution() {
+    let registry = create_tool_pack_registry();
+    let harness = create_execution_context("unknown-pack", registry.clone());
+    let call = tool_pack_call(json!({
+        "tools": [
+            { "name": "builtin-not_a_real_tool", "args": {} }
+        ]
+    }));
+
+    let error = registry
+        .execute(&call, &harness.context)
+        .await
+        .expect_err("unknown sub-tool should be rejected");
+
+    assert!(error.contains("not found in tool registry"));
+}
+
+#[tokio::test]
+async fn tool_pack_rejects_recursive_subtool() {
+    let registry = create_tool_pack_registry();
+    let harness = create_execution_context("recursive-pack", registry.clone());
+    let call = tool_pack_call(json!({
+        "tools": [
+            { "name": "builtin-tool_pack", "args": { "tools": [] } }
+        ]
+    }));
+
+    let error = registry
+        .execute(&call, &harness.context)
+        .await
+        .expect_err("recursive sub-tool should be rejected");
+
+    assert!(error.contains("cannot invoke itself"));
+}
+
+#[tokio::test]
+async fn tool_pack_rejects_more_than_20_subtools() {
+    let registry = create_tool_pack_registry();
+    let harness = create_execution_context("too-many-pack", registry.clone());
+    let tools: Vec<Value> = (0..21)
+        .map(|_| json!({ "name": "builtin-template_validate", "args": {} }))
+        .collect();
+    let call = tool_pack_call(json!({ "tools": tools }));
+
+    let error = registry
+        .execute(&call, &harness.context)
+        .await
+        .expect_err("more than 20 sub-tools should be rejected");
+
+    assert!(error.contains("supports at most 20 sub-tools"));
+}
+
+#[tokio::test]
+async fn tool_pack_rejects_ask_user_no_timeout_subtool() {
+    let registry = create_tool_pack_registry();
+    let harness = create_execution_context("ask-user-pack", registry.clone());
+    let call = tool_pack_call(json!({
+        "tools": [
+            {
+                "name": "builtin-ask_user",
+                "args": {
+                    "question": "Continue?",
+                    "options": ["Yes", "No"]
+                }
+            }
+        ]
+    }));
+
+    let error = registry
+        .execute(&call, &harness.context)
+        .await
+        .expect_err("no-timeout sub-tool should be rejected");
+
+    assert!(error.contains("cannot execute blocking/no-timeout tool"));
+}
+
+#[tokio::test]
+async fn tool_pack_executes_subtools_concurrently_and_respects_max_concurrency() {
+    let started = Arc::new(AtomicUsize::new(0));
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let max_in_flight = Arc::new(AtomicUsize::new(0));
+    let started_ten = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let registry = create_concurrency_registry(
+        started.clone(),
+        in_flight.clone(),
+        max_in_flight.clone(),
+        started_ten.clone(),
+        release.clone(),
+    );
+    let harness = create_execution_context("parallel-pack", registry.clone());
+    let tools: Vec<Value> = (0..12)
+        .map(|_| json!({ "name": "builtin-phase3_concurrency_probe", "args": {} }))
+        .collect();
+    let call = tool_pack_call(json!({ "tools": tools, "timeout": 30 }));
+
+    let pack = registry.execute(&call, &harness.context);
+    tokio::pin!(pack);
+
+    timeout(Duration::from_secs(2), started_ten.notified())
+        .await
+        .expect("first 10 sub-tools should start before release");
+
+    assert_eq!(started.load(Ordering::SeqCst), 10);
+    assert!(max_in_flight.load(Ordering::SeqCst) >= 2);
+    assert!(max_in_flight.load(Ordering::SeqCst) <= 10);
+
+    release.notify_waiters();
+
+    let result = pack.await.expect("tool_pack should complete");
+    let output = result.output;
+    assert_eq!(output["succeeded"], 12);
+    assert_eq!(output["failed"], 0);
+    assert_eq!(output["results"].as_array().unwrap().len(), 12);
+}
+
+#[tokio::test]
+async fn tool_pack_subtool_timeout_isolated_to_one_failed_result() {
+    let fast_completed = Arc::new(AtomicBool::new(false));
+    let fast_notify = Arc::new(Notify::new());
+    let registry = create_timeout_registry(fast_completed.clone(), fast_notify.clone());
+    let harness = create_execution_context("timeout-pack", registry.clone());
+    let call = tool_pack_call(json!({
+        "timeout": 1,
+        "tools": [
+            { "name": "builtin-phase3_fast_success", "args": {} },
+            { "name": "builtin-phase3_never_finishes", "args": {} }
+        ]
+    }));
+
+    let result = timeout(
+        Duration::from_secs(5),
+        registry.execute(&call, &harness.context),
+    )
+    .await
+    .expect("pack timeout test should not hang")
+    .expect("pack should return aggregate result");
+
+    let output = result.output;
+    let results = output["results"].as_array().unwrap();
+    assert_eq!(output["succeeded"], 1);
+    assert_eq!(output["failed"], 1);
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().any(|item| {
+        item["tool_name"] == "builtin-phase3_fast_success" && item["success"] == true
+    }));
+    assert!(results.iter().any(|item| {
+        item["tool_name"] == "builtin-phase3_never_finishes"
+            && item["success"] == false
+            && item["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("timeout")
+    }));
+    assert!(fast_completed.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn tool_pack_parent_cancellation_preserves_completed_results() {
+    let fast_completed = Arc::new(AtomicBool::new(false));
+    let fast_notify = Arc::new(Notify::new());
+    let parent_token = CancellationToken::new();
+    let registry = create_cancellation_registry(fast_completed.clone(), fast_notify.clone());
+    let mut harness = create_execution_context("cancel-pack", registry.clone());
+    harness.context = harness
+        .context
+        .with_cancellation_token(parent_token.clone());
+
+    let call = tool_pack_call(json!({
+        "timeout": 30,
+        "tools": [
+            { "name": "builtin-phase3_fast_success", "args": {} },
+            { "name": "builtin-phase3_slow_cancel", "args": {} }
+        ]
+    }));
+
+    let pack = registry.execute(&call, &harness.context);
+    tokio::pin!(pack);
+
+    timeout(Duration::from_secs(2), fast_notify.notified())
+        .await
+        .expect("fast sub-tool should signal completion");
+    assert!(fast_completed.load(Ordering::SeqCst));
+
+    parent_token.cancel();
+
+    let result = timeout(Duration::from_secs(5), &mut pack)
+        .await
+        .expect("cancelled pack should return within 5 seconds")
+        .expect("cancelled pack should return aggregate result");
+
+    let output = result.output;
+    let results = output["results"].as_array().unwrap();
+    assert_eq!(output["succeeded"], 1);
+    assert_eq!(output["failed"], 1);
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().any(|item| {
+        item["tool_name"] == "builtin-phase3_fast_success" && item["success"] == true
+    }));
+    assert!(results.iter().any(|item| {
+        item["tool_name"] == "builtin-phase3_slow_cancel"
+            && item["success"] == false
+            && item["error"]
+                .as_str()
+                .unwrap_or_default()
+                .to_ascii_lowercase()
+                .contains("cancel")
+    }));
+
+    let _keep_app_alive = &harness._app;
+}

--- a/src-tauri/tests/tool_pack_integration_tests.rs
+++ b/src-tauri/tests/tool_pack_integration_tests.rs
@@ -85,6 +85,7 @@ struct Phase3ConcurrencyProbeExecutor {
     in_flight: Arc<AtomicUsize>,
     max_in_flight: Arc<AtomicUsize>,
     started_ten: Arc<Notify>,
+    released: Arc<AtomicBool>,
     release: Arc<Notify>,
 }
 
@@ -119,7 +120,13 @@ impl ToolExecutor for Phase3ConcurrencyProbeExecutor {
             self.started_ten.notify_waiters();
         }
 
-        self.release.notified().await;
+        loop {
+            let release_notified = self.release.notified();
+            if self.released.load(Ordering::SeqCst) {
+                break;
+            }
+            release_notified.await;
+        }
         self.in_flight.fetch_sub(1, Ordering::SeqCst);
 
         Ok(ToolResultInfo::success(
@@ -230,6 +237,7 @@ fn create_concurrency_registry(
     in_flight: Arc<AtomicUsize>,
     max_in_flight: Arc<AtomicUsize>,
     started_ten: Arc<Notify>,
+    released: Arc<AtomicBool>,
     release: Arc<Notify>,
 ) -> Arc<ToolExecutorRegistry> {
     Arc::new_cyclic(|weak| {
@@ -239,6 +247,7 @@ fn create_concurrency_registry(
                 in_flight,
                 max_in_flight,
                 started_ten,
+                released,
                 release,
             }) as Arc<dyn ToolExecutor>,
             Arc::new(ToolPackExecutor::new(weak.clone())),
@@ -394,9 +403,11 @@ fn tool_pack_selected_real_subtools_shared_state_audit_matches_allowed_paths() {
     assert!(user_todo_source.contains("VfsTodoRepo::create_todo_item"));
     assert!(session_source.contains("ChatV2Database") || session_source.contains("chat_v2_db"));
     assert!(executor_source.contains("save_tool_block"));
-    assert!(template_source.contains("emit_tool_call")
-        || session_source.contains("emit_tool_call")
-        || user_todo_source.contains("emit_tool_call"));
+    assert!(
+        template_source.contains("emit_tool_call")
+            || session_source.contains("emit_tool_call")
+            || user_todo_source.contains("emit_tool_call")
+    );
     assert!(user_todo_source.contains("emit_todo_changed"));
     assert!(tool_pack_source.contains("ToolExecutorRegistry"));
     assert!(tool_pack_source.contains("registry_clone.execute"));
@@ -600,9 +611,7 @@ async fn tool_pack_repeated_vfs_write_load_remains_free_of_sqlite_lock_errors() 
         let block_id = format!("write-repeat-{}", round);
         let mut harness = create_execution_context(&block_id, registry.clone());
         harness.context = harness.context.with_vfs_db(Some(vfs_db.clone()));
-        harness.context = harness
-            .context
-            .with_chat_v2_db(Some(chat_v2_db.clone()));
+        harness.context = harness.context.with_chat_v2_db(Some(chat_v2_db.clone()));
         let call = tool_pack_call(json!({
             "timeout": 30,
             "tools": create_user_todo_create_tools(&format!("phase-3-repeat-{}", round))
@@ -722,12 +731,14 @@ async fn tool_pack_executes_subtools_concurrently_and_respects_max_concurrency()
     let in_flight = Arc::new(AtomicUsize::new(0));
     let max_in_flight = Arc::new(AtomicUsize::new(0));
     let started_ten = Arc::new(Notify::new());
+    let released = Arc::new(AtomicBool::new(false));
     let release = Arc::new(Notify::new());
     let registry = create_concurrency_registry(
         started.clone(),
         in_flight.clone(),
         max_in_flight.clone(),
         started_ten.clone(),
+        released.clone(),
         release.clone(),
     );
     let harness = create_execution_context("parallel-pack", registry.clone());
@@ -739,17 +750,25 @@ async fn tool_pack_executes_subtools_concurrently_and_respects_max_concurrency()
     let pack = registry.execute(&call, &harness.context);
     tokio::pin!(pack);
 
-    timeout(Duration::from_secs(2), started_ten.notified())
-        .await
-        .expect("first 10 sub-tools should start before release");
+    tokio::select! {
+        _ = started_ten.notified() => {}
+        result = &mut pack => panic!("pack completed before concurrency was observed: {:?}", result),
+        _ = tokio::time::sleep(Duration::from_secs(2)) => {
+            panic!("first 10 sub-tools should start before release");
+        }
+    }
 
     assert_eq!(started.load(Ordering::SeqCst), 10);
     assert!(max_in_flight.load(Ordering::SeqCst) >= 2);
     assert!(max_in_flight.load(Ordering::SeqCst) <= 10);
 
+    released.store(true, Ordering::SeqCst);
     release.notify_waiters();
 
-    let result = pack.await.expect("tool_pack should complete");
+    let result = timeout(Duration::from_secs(5), &mut pack)
+        .await
+        .expect("released pack should complete")
+        .expect("tool_pack should complete");
     let output = result.output;
     assert_eq!(output["succeeded"], 12);
     assert_eq!(output["failed"], 0);
@@ -819,9 +838,13 @@ async fn tool_pack_parent_cancellation_preserves_completed_results() {
     let pack = registry.execute(&call, &harness.context);
     tokio::pin!(pack);
 
-    timeout(Duration::from_secs(2), fast_notify.notified())
-        .await
-        .expect("fast sub-tool should signal completion");
+    tokio::select! {
+        _ = fast_notify.notified() => {}
+        result = &mut pack => panic!("pack completed before cancellation handoff: {:?}", result),
+        _ = tokio::time::sleep(Duration::from_secs(2)) => {
+            panic!("fast sub-tool should signal completion");
+        }
+    }
     assert!(fast_completed.load(Ordering::SeqCst));
 
     parent_token.cancel();

--- a/src-tauri/tests/tool_pack_integration_tests.rs
+++ b/src-tauri/tests/tool_pack_integration_tests.rs
@@ -3,11 +3,13 @@ use deep_student_lib::chat_v2::events::ChatV2EventEmitter;
 use deep_student_lib::chat_v2::tools::{
     AskUserExecutor, ExecutionContext, GeneralToolExecutor, SessionToolExecutor,
     TemplateDesignerExecutor, ToolExecutor, ToolExecutorRegistry, ToolPackExecutor,
+    UserTodoExecutor,
 };
 use deep_student_lib::chat_v2::types::{ToolCall, ToolResultInfo};
 use deep_student_lib::data_governance::migration::coordinator::MigrationCoordinator;
 use deep_student_lib::data_governance::schema_registry::DatabaseId;
 use deep_student_lib::tools::ToolRegistry;
+use deep_student_lib::vfs::VfsDatabase;
 use serde_json::{json, Value};
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -44,6 +46,7 @@ fn create_tool_pack_registry() -> Arc<ToolExecutorRegistry> {
         ToolExecutorRegistry::from_vec(vec![
             Arc::new(TemplateDesignerExecutor::new()) as Arc<dyn ToolExecutor>,
             Arc::new(SessionToolExecutor::new()),
+            Arc::new(UserTodoExecutor::new()),
             Arc::new(AskUserExecutor::new()),
             Arc::new(ToolPackExecutor::new(weak.clone())),
             Arc::new(GeneralToolExecutor::new()),
@@ -289,6 +292,17 @@ fn create_chat_v2_db() -> (tempfile::TempDir, Arc<ChatV2Database>) {
     (temp_dir, Arc::new(db))
 }
 
+fn create_vfs_db() -> (tempfile::TempDir, Arc<VfsDatabase>) {
+    let temp_dir = tempfile::TempDir::new().expect("failed to create VFS temp dir");
+    let mut coordinator =
+        MigrationCoordinator::new(temp_dir.path().to_path_buf()).with_audit_db(None);
+    coordinator
+        .migrate_single(DatabaseId::Vfs)
+        .expect("VFS migrations should apply cleanly");
+    let db = VfsDatabase::new(temp_dir.path()).expect("failed to create VFS database");
+    (temp_dir, Arc::new(db))
+}
+
 fn valid_template_fixture() -> Value {
     json!({
         "name": "Phase 3 Valid Template",
@@ -313,6 +327,41 @@ fn valid_template_fixture() -> Value {
     })
 }
 
+fn create_user_todo_create_tools(prefix: &str) -> Vec<Value> {
+    (0..20)
+        .map(|i| {
+            json!({
+                "name": "builtin-user_todo_create_item",
+                "args": {
+                    "title": format!("{}-{}", prefix, i),
+                    "priority": "none"
+                }
+            })
+        })
+        .collect()
+}
+
+fn assert_no_sqlite_lock_errors(results: &[Value]) {
+    for item in results {
+        let error = item["error"].as_str().unwrap_or_default().to_lowercase();
+        assert!(
+            !error.contains("database is locked"),
+            "unexpected SQLite lock error in result: {}",
+            item
+        );
+        assert!(
+            !error.contains("sqlite_busy"),
+            "unexpected SQLITE_BUSY error in result: {}",
+            item
+        );
+        assert!(
+            !error.contains("database table is locked"),
+            "unexpected SQLite table lock error in result: {}",
+            item
+        );
+    }
+}
+
 fn tool_pack_call(arguments: Value) -> ToolCall {
     ToolCall::new(
         "phase-3-pack-call".to_string(),
@@ -332,6 +381,50 @@ async fn tool_pack_harness_constructs_execution_context() {
     assert_eq!(harness.context.window.label(), "tool-pack-test");
     assert_eq!(harness.context.emitter.session_id(), "phase-3-session");
     assert!(harness.registry.has_specific_executor("builtin-tool_pack"));
+}
+
+#[test]
+fn tool_pack_selected_real_subtools_shared_state_audit_matches_allowed_paths() {
+    let template_source = include_str!("../src/chat_v2/tools/template_executor.rs");
+    let session_source = include_str!("../src/chat_v2/tools/session_executor.rs");
+    let user_todo_source = include_str!("../src/chat_v2/tools/user_todo_executor.rs");
+    let tool_pack_source = include_str!("../src/chat_v2/tools/tool_pack_executor.rs");
+    let executor_source = include_str!("../src/chat_v2/tools/executor.rs");
+
+    assert!(user_todo_source.contains("VfsTodoRepo::create_todo_item"));
+    assert!(session_source.contains("ChatV2Database") || session_source.contains("chat_v2_db"));
+    assert!(executor_source.contains("save_tool_block"));
+    assert!(template_source.contains("emit_tool_call")
+        || session_source.contains("emit_tool_call")
+        || user_todo_source.contains("emit_tool_call"));
+    assert!(user_todo_source.contains("emit_todo_changed"));
+    assert!(tool_pack_source.contains("ToolExecutorRegistry"));
+    assert!(tool_pack_source.contains("registry_clone.execute"));
+
+    let selected_sources = [
+        ("template_executor.rs", template_source),
+        ("session_executor.rs", session_source),
+        ("user_todo_executor.rs", user_todo_source),
+    ];
+    let forbidden_patterns = [
+        "AppState",
+        ".state::<",
+        "Mutex<",
+        "RwLock<",
+        ".lock().await",
+        "blocking_lock",
+        "std::sync::Mutex",
+        "tokio::sync::Mutex",
+    ];
+
+    for (label, source) in selected_sources {
+        for pattern in forbidden_patterns {
+            assert!(
+                !source.contains(pattern),
+                "{label} contains forbidden shared-lock pattern {pattern}"
+            );
+        }
+    }
 }
 
 #[tokio::test]
@@ -459,6 +552,77 @@ async fn tool_pack_blocks_sensitive_subtool_without_bypassing_approval() {
         .as_str()
         .unwrap_or_default()
         .contains("requires user approval"));
+}
+
+#[tokio::test]
+async fn tool_pack_vfs_write_load_does_not_surface_sqlite_busy_or_database_locked() {
+    let registry = create_tool_pack_registry();
+    let (_vfs_temp_dir, vfs_db) = create_vfs_db();
+    let (_chat_temp_dir, chat_v2_db) = create_chat_v2_db();
+    let mut harness = create_execution_context("write-pack", registry.clone());
+    harness.context = harness.context.with_vfs_db(Some(vfs_db));
+    harness.context = harness.context.with_chat_v2_db(Some(chat_v2_db));
+    let call = tool_pack_call(json!({
+        "timeout": 30,
+        "tools": create_user_todo_create_tools("phase-3-write")
+    }));
+
+    let result = registry
+        .execute(&call, &harness.context)
+        .await
+        .expect("write-heavy pack should return aggregate result");
+
+    assert!(result.success);
+    assert_eq!(result.output["succeeded"], 20);
+    assert_eq!(result.output["failed"], 0);
+
+    let results = result.output["results"].as_array().unwrap();
+    assert_eq!(results.len(), 20);
+    assert_no_sqlite_lock_errors(results);
+
+    let block_ids: Vec<&str> = results
+        .iter()
+        .filter_map(|item| item["block_id"].as_str())
+        .collect();
+    assert!(block_ids.contains(&"write-pack-tool_pack-0"));
+    assert!(block_ids.contains(&"write-pack-tool_pack-19"));
+
+    let _keep_app_alive = &harness._app;
+}
+
+#[tokio::test]
+async fn tool_pack_repeated_vfs_write_load_remains_free_of_sqlite_lock_errors() {
+    let registry = create_tool_pack_registry();
+    let (_vfs_temp_dir, vfs_db) = create_vfs_db();
+    let (_chat_temp_dir, chat_v2_db) = create_chat_v2_db();
+
+    for round in 0..3 {
+        let block_id = format!("write-repeat-{}", round);
+        let mut harness = create_execution_context(&block_id, registry.clone());
+        harness.context = harness.context.with_vfs_db(Some(vfs_db.clone()));
+        harness.context = harness
+            .context
+            .with_chat_v2_db(Some(chat_v2_db.clone()));
+        let call = tool_pack_call(json!({
+            "timeout": 30,
+            "tools": create_user_todo_create_tools(&format!("phase-3-repeat-{}", round))
+        }));
+
+        let result = registry
+            .execute(&call, &harness.context)
+            .await
+            .expect("repeated write-heavy pack should return aggregate result");
+
+        assert!(result.success);
+        assert_eq!(result.output["succeeded"], 20);
+        assert_eq!(result.output["failed"], 0);
+
+        let results = result.output["results"].as_array().unwrap();
+        assert_eq!(results.len(), 20);
+        assert_no_sqlite_lock_errors(results);
+
+        let _keep_app_alive = &harness._app;
+    }
 }
 
 #[tokio::test]

--- a/tests/vitest/chat-v2/middleware/eventBridge.test.ts
+++ b/tests/vitest/chat-v2/middleware/eventBridge.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@/features/chat/core/middleware/eventBridge';
 import { chunkBuffer } from '@/features/chat/core/middleware/chunkBuffer';
 import { eventRegistry } from '@/features/chat/registry/eventRegistry';
+import { toolCallEventHandler } from '@/features/chat/plugins/events/toolCall';
 import type { ChatStore } from '@/features/chat/core/types';
 
 // ============================================================================
@@ -99,6 +100,11 @@ function createMockStore(overrides: Partial<ChatStore> = {}): ChatStore {
     getOrderedMessages: vi.fn(() => []),
     ...overrides,
   } as unknown as ChatStore;
+}
+
+function registerActualToolCallPlugin() {
+  eventRegistry.clear();
+  eventRegistry.register('tool_call', toolCallEventHandler);
 }
 
 // ============================================================================
@@ -395,6 +401,120 @@ describe('eventBridge', () => {
       });
 
       expect(onEnd).toHaveBeenCalledWith(mockStore, tool1BlockId, { success: true });
+    });
+  });
+
+  describe('tool_pack tool_call bridge interleaving', () => {
+    beforeEach(() => {
+      registerActualToolCallPlugin();
+    });
+
+    it('routes tool_pack tool_call events by explicit backend blockId even when end events are reversed', () => {
+      const resultA = { result: { valid: true, source: 'a' }, durationMs: 11 };
+      const resultB = { result: { success: true, source: 'b' }, durationMs: 7 };
+
+      handleBackendEvent(mockStore, {
+        type: 'tool_call',
+        phase: 'start',
+        messageId: 'msg-1',
+        blockId: 'parent-tool_pack-0',
+        payload: {
+          toolName: 'builtin-template_validate',
+          toolInput: { template: { name: 'A' } },
+          toolCallId: 'parent-tp-0',
+        },
+      });
+
+      handleBackendEvent(mockStore, {
+        type: 'tool_call',
+        phase: 'start',
+        messageId: 'msg-1',
+        blockId: 'parent-tool_pack-1',
+        payload: {
+          toolName: 'builtin-user_todo_create_item',
+          toolInput: { title: 'B' },
+          toolCallId: 'parent-tp-1',
+        },
+      });
+
+      handleBackendEvent(mockStore, {
+        type: 'tool_call',
+        phase: 'end',
+        blockId: 'parent-tool_pack-1',
+        result: resultB,
+      });
+
+      handleBackendEvent(mockStore, {
+        type: 'tool_call',
+        phase: 'end',
+        blockId: 'parent-tool_pack-0',
+        result: resultA,
+      });
+
+      expect(mockStore.createBlockWithId).toHaveBeenNthCalledWith(
+        1,
+        'msg-1',
+        'mcp_tool',
+        'parent-tool_pack-0'
+      );
+      expect(mockStore.createBlockWithId).toHaveBeenNthCalledWith(
+        2,
+        'msg-1',
+        'mcp_tool',
+        'parent-tool_pack-1'
+      );
+      expect(mockStore.setBlockResult).toHaveBeenNthCalledWith(
+        1,
+        'parent-tool_pack-1',
+        resultB
+      );
+      expect(mockStore.setBlockResult).toHaveBeenNthCalledWith(
+        2,
+        'parent-tool_pack-0',
+        resultA
+      );
+    });
+
+    it('routes tool_pack tool_call error by explicit backend blockId', () => {
+      handleBackendEvent(mockStore, {
+        type: 'tool_call',
+        phase: 'start',
+        messageId: 'msg-1',
+        blockId: 'parent-tool_pack-0',
+        payload: {
+          toolName: 'builtin-template_validate',
+          toolInput: { template: { name: 'A' } },
+          toolCallId: 'parent-tp-0',
+        },
+      });
+
+      handleBackendEvent(mockStore, {
+        type: 'tool_call',
+        phase: 'start',
+        messageId: 'msg-1',
+        blockId: 'parent-tool_pack-1',
+        payload: {
+          toolName: 'builtin-user_todo_create_item',
+          toolInput: { title: 'B' },
+          toolCallId: 'parent-tp-1',
+        },
+      });
+
+      handleBackendEvent(mockStore, {
+        type: 'tool_call',
+        phase: 'error',
+        blockId: 'parent-tool_pack-1',
+        error: 'phase 3 bridge failure',
+      });
+
+      expect(mockStore.setBlockError).toHaveBeenCalledWith(
+        'parent-tool_pack-1',
+        'phase 3 bridge failure'
+      );
+      expect(mockStore.setBlockError).not.toHaveBeenCalledWith(
+        'parent-tool_pack-0',
+        'phase 3 bridge failure'
+      );
     });
   });
 });

--- a/tests/vitest/chat-v2/plugins/events/toolCall.test.ts
+++ b/tests/vitest/chat-v2/plugins/events/toolCall.test.ts
@@ -90,6 +90,121 @@ function createMockStore(): ChatStore {
   } as unknown as ChatStore;
 }
 
+function createStatefulToolCallStore(): ChatStore {
+  const store = createMockStore();
+
+  store.messageMap.set('msg-1', {
+    id: 'msg-1',
+    role: 'assistant',
+    blockIds: [],
+  } as any);
+
+  let nextBlock = 0;
+
+  const createBlockWithId = (messageId: string, type: string, blockId: string) => {
+    store.blocks.set(blockId, {
+      id: blockId,
+      messageId,
+      type,
+      content: '',
+      status: 'pending',
+    } as any);
+
+    const message = store.messageMap.get(messageId) as { blockIds?: string[] } | undefined;
+    if (message && !message.blockIds?.includes(blockId)) {
+      message.blockIds = [...(message.blockIds ?? []), blockId];
+    }
+
+    store.activeBlockIds.add(blockId);
+    return blockId;
+  };
+
+  store.createBlockWithId = vi.fn(createBlockWithId) as any;
+  store.createBlock = vi.fn((messageId: string, type: string) => {
+    return createBlockWithId(messageId, type, `stateful-block-${++nextBlock}`);
+  }) as any;
+  store.updateBlock = vi.fn((blockId: string, patch: Record<string, unknown>) => {
+    const block = store.blocks.get(blockId);
+    if (block) {
+      store.blocks.set(blockId, { ...block, ...patch } as any);
+    }
+  }) as any;
+  store.updateBlockStatus = vi.fn((blockId: string, status: string) => {
+    const block = store.blocks.get(blockId);
+    if (block) {
+      store.blocks.set(blockId, { ...block, status } as any);
+    }
+  }) as any;
+  store.setBlockResult = vi.fn((blockId: string, result: unknown) => {
+    const block = store.blocks.get(blockId);
+    if (!block) return;
+
+    const toolOutput = result && typeof result === 'object' && 'result' in result
+      ? (result as { result: unknown }).result
+      : result;
+
+    store.blocks.set(blockId, {
+      ...block,
+      toolOutput,
+      status: 'success',
+    } as any);
+    store.activeBlockIds.delete(blockId);
+  }) as any;
+  store.setBlockError = vi.fn((blockId: string, error: string) => {
+    const block = store.blocks.get(blockId);
+    if (!block) return;
+
+    store.blocks.set(blockId, {
+      ...block,
+      error,
+      status: 'error',
+    } as any);
+    store.activeBlockIds.delete(blockId);
+  }) as any;
+  store.replaceBlockId = vi.fn((oldBlockId: string, newBlockId: string) => {
+    const block = store.blocks.get(oldBlockId);
+    if (!block) return;
+
+    store.blocks.delete(oldBlockId);
+    store.blocks.set(newBlockId, { ...block, id: newBlockId } as any);
+
+    const message = store.messageMap.get((block as any).messageId) as
+      | { blockIds?: string[] }
+      | undefined;
+    if (message) {
+      message.blockIds = (message.blockIds ?? []).map((id) =>
+        id === oldBlockId ? newBlockId : id
+      );
+    }
+
+    if (store.activeBlockIds.has(oldBlockId)) {
+      store.activeBlockIds.delete(oldBlockId);
+      store.activeBlockIds.add(newBlockId);
+    }
+  }) as any;
+  store.deleteBlock = vi.fn((blockId: string) => {
+    const block = store.blocks.get(blockId);
+    if (!block) return;
+
+    store.blocks.delete(blockId);
+    const message = store.messageMap.get((block as any).messageId) as
+      | { blockIds?: string[] }
+      | undefined;
+    if (message) {
+      message.blockIds = (message.blockIds ?? []).filter((id) => id !== blockId);
+    }
+    store.activeBlockIds.delete(blockId);
+  }) as any;
+  store.clearPreparingToolCall = vi.fn((messageId: string) => {
+    const message = store.messageMap.get(messageId) as { _meta?: Record<string, unknown> } | undefined;
+    if (message?._meta) {
+      delete message._meta.preparingToolCall;
+    }
+  }) as any;
+
+  return store;
+}
+
 // ============================================================================
 // tool_call 事件处理器测试
 // ============================================================================
@@ -207,6 +322,154 @@ describe('ToolCallEventHandler', () => {
 // ============================================================================
 // image_gen 事件处理器测试
 // ============================================================================
+
+describe('tool_pack interleaving', () => {
+  let mockStore: ChatStore;
+
+  const resultA = { result: { valid: true, source: 'a' }, durationMs: 11 };
+  const resultB = { result: { success: true, source: 'b' }, durationMs: 7 };
+
+  beforeEach(() => {
+    mockStore = createStatefulToolCallStore();
+    vi.clearAllMocks();
+  });
+
+  it('tool_pack interleaving keeps out-of-order results on their backend block ids', () => {
+    const handler = eventRegistry.get('tool_call');
+    expect(handler).toBeDefined();
+
+    handler!.onStart!(
+      mockStore,
+      'msg-1',
+      {
+        toolName: 'builtin-template_validate',
+        toolInput: { template: { name: 'A' } },
+        toolCallId: 'parent-tp-0',
+      },
+      'parent-tool_pack-0'
+    );
+    handler!.onStart!(
+      mockStore,
+      'msg-1',
+      {
+        toolName: 'builtin-user_todo_create_item',
+        toolInput: { title: 'B' },
+        toolCallId: 'parent-tp-1',
+      },
+      'parent-tool_pack-1'
+    );
+
+    handler!.onEnd!(mockStore, 'parent-tool_pack-1', resultB);
+    handler!.onEnd!(mockStore, 'parent-tool_pack-0', resultA);
+
+    expect(mockStore.setBlockResult).toHaveBeenNthCalledWith(1, 'parent-tool_pack-1', resultB);
+    expect(mockStore.setBlockResult).toHaveBeenNthCalledWith(2, 'parent-tool_pack-0', resultA);
+    expect(mockStore.blocks.get('parent-tool_pack-1')).toMatchObject({
+      toolOutput: { success: true, source: 'b' },
+      status: 'success',
+    });
+    expect(mockStore.blocks.get('parent-tool_pack-0')).toMatchObject({
+      toolOutput: { valid: true, source: 'a' },
+      status: 'success',
+    });
+  });
+
+  it('tool_pack preparing replacement preserves message block order', () => {
+    mockStore.createBlockWithId('msg-1', 'mcp_tool', 'prep-a');
+    mockStore.createBlockWithId('msg-1', 'mcp_tool', 'prep-b');
+    mockStore.updateBlock('prep-a', {
+      toolName: 'builtin-template_validate',
+      toolCallId: 'parent-tp-0',
+      isPreparing: true,
+    } as any);
+    mockStore.updateBlock('prep-b', {
+      toolName: 'builtin-user_todo_create_item',
+      toolCallId: 'parent-tp-1',
+      isPreparing: true,
+    } as any);
+
+    const handler = eventRegistry.get('tool_call');
+
+    handler!.onStart!(
+      mockStore,
+      'msg-1',
+      {
+        toolName: 'builtin-template_validate',
+        toolInput: { template: { name: 'A' } },
+        toolCallId: 'parent-tp-0',
+      },
+      'parent-tool_pack-0'
+    );
+    handler!.onStart!(
+      mockStore,
+      'msg-1',
+      {
+        toolName: 'builtin-user_todo_create_item',
+        toolInput: { title: 'B' },
+        toolCallId: 'parent-tp-1',
+      },
+      'parent-tool_pack-1'
+    );
+
+    expect(mockStore.replaceBlockId).toHaveBeenNthCalledWith(
+      1,
+      'prep-a',
+      'parent-tool_pack-0'
+    );
+    expect(mockStore.replaceBlockId).toHaveBeenNthCalledWith(
+      2,
+      'prep-b',
+      'parent-tool_pack-1'
+    );
+    expect(mockStore.messageMap.get('msg-1')?.blockIds).toEqual([
+      'parent-tool_pack-0',
+      'parent-tool_pack-1',
+    ]);
+  });
+
+  it('tool_pack interleaving keeps error on the explicit failed block id', () => {
+    const handler = eventRegistry.get('tool_call');
+
+    handler!.onStart!(
+      mockStore,
+      'msg-1',
+      {
+        toolName: 'builtin-template_validate',
+        toolInput: { template: { name: 'A' } },
+        toolCallId: 'parent-tp-0',
+      },
+      'parent-tool_pack-0'
+    );
+    handler!.onStart!(
+      mockStore,
+      'msg-1',
+      {
+        toolName: 'builtin-user_todo_create_item',
+        toolInput: { title: 'B' },
+        toolCallId: 'parent-tp-1',
+      },
+      'parent-tool_pack-1'
+    );
+
+    handler!.onEnd!(mockStore, 'parent-tool_pack-0', resultA);
+    handler!.onError!(mockStore, 'parent-tool_pack-1', 'phase 3 failure');
+
+    expect(mockStore.setBlockResult).toHaveBeenCalledWith('parent-tool_pack-0', resultA);
+    expect(mockStore.setBlockError).toHaveBeenCalledWith(
+      'parent-tool_pack-1',
+      'phase 3 failure'
+    );
+    expect(mockStore.blocks.get('parent-tool_pack-0')).toMatchObject({
+      toolOutput: { valid: true, source: 'a' },
+      status: 'success',
+    });
+    expect(mockStore.blocks.get('parent-tool_pack-1')).toMatchObject({
+      error: 'phase 3 failure',
+      status: 'error',
+    });
+    expect(mockStore.blocks.get('parent-tool_pack-0')).not.toHaveProperty('error');
+  });
+});
 
 describe('ImageGenEventHandler', () => {
   let mockStore: ChatStore;


### PR DESCRIPTION
## Summary
- Harden tool_pack edge handling for malformed, missing, cancelled, and contention scenarios
- Add frontend tool-call interleaving regressions and bridge block routing coverage
- Add Rust integration coverage for ToolPack executor edge cases and SQLite contention

## Scope
- Code-only PR: excludes all .planning changes from the local nightly branch

## Verification
- PASS: npm run test -- tests/vitest/chat-v2/plugins/events/toolCall.test.ts tests/vitest/chat-v2/middleware/eventBridge.test.ts
- PARTIAL: cargo test --test tool_pack_integration_tests compiled successfully, but the Windows test binary failed to start with STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139)