### PR TITLE
fix(ci): restore GitHub Actions release workflow parsing

### DIFF
--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -34,6 +34,7 @@ jobs:
     timeout-minutes: 120
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
+      SENTRY_UPLOAD_ENABLED: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' && 'true' || 'false' }}
     steps:
       # ── updater 签名密钥预检（fail-closed, 在任何耗时步骤之前）──
       - name: Preflight — require updater signing key (fail-closed)
@@ -97,7 +98,7 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Install Sentry CLI (pinned)
-        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' }}
+        if: ${{ env.SENTRY_UPLOAD_ENABLED == 'true' }}
         run: npm install --global "@sentry/cli@${SENTRY_CLI_VERSION}"
 
       - name: Print build tool manifest
@@ -130,7 +131,7 @@ jobs:
         run: npx tauri build --target x86_64-unknown-linux-gnu --bundles deb,rpm,appimage -- --locked
 
       - name: Upload native symbols to Sentry
-        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' }}
+        if: ${{ env.SENTRY_UPLOAD_ENABLED == 'true' }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -46,6 +46,7 @@ jobs:
     timeout-minutes: 120
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
+      SENTRY_UPLOAD_ENABLED: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' && 'true' || 'false' }}
     strategy:
       fail-fast: false
       matrix:
@@ -110,7 +111,7 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Install Sentry CLI (pinned)
-        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' }}
+        if: ${{ env.SENTRY_UPLOAD_ENABLED == 'true' }}
         run: npm install --global "@sentry/cli@${SENTRY_CLI_VERSION}"
 
       - name: Print build tool manifest
@@ -278,7 +279,7 @@ jobs:
           echo "✅ Updater archive + signature present"
 
       - name: Upload native symbols to Sentry
-        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' }}
+        if: ${{ env.SENTRY_UPLOAD_ENABLED == 'true' }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/reusable-build-windows.yml
+++ b/.github/workflows/reusable-build-windows.yml
@@ -43,6 +43,7 @@ jobs:
     timeout-minutes: 120
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
+      SENTRY_UPLOAD_ENABLED: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' && 'true' || 'false' }}
     steps:
       # ── 生产签名 secrets 预检（fail-closed, 在任何耗时步骤之前）──
       - name: Preflight — require production signing secrets (fail-closed)
@@ -102,7 +103,7 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Install Sentry CLI (pinned)
-        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' }}
+        if: ${{ env.SENTRY_UPLOAD_ENABLED == 'true' }}
         shell: bash
         run: npm install --global "@sentry/cli@${SENTRY_CLI_VERSION}"
 
@@ -134,7 +135,7 @@ jobs:
         run: npx tauri build --target x86_64-pc-windows-msvc -- --locked
 
       - name: Upload native symbols to Sentry
-        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' }}
+        if: ${{ env.SENTRY_UPLOAD_ENABLED == 'true' }}
         shell: bash
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary\n- move optional Sentry secret checks out of step-level conditions\n- use a job environment flag accepted by reusable workflows\n- restore Release workflow parsing after the os merge\n\n## Validation\n- actionlint: no workflow syntax/expression errors (only pre-existing ShellCheck informational findings)