### PR TITLE
fix(ci): fetch full history for migration release gate

### DIFF
--- a/.github/workflows/reusable-migration-gate.yml
+++ b/.github/workflows/reusable-migration-gate.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag_name }}
+          fetch-depth: 0
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:


### PR DESCRIPTION
## Summary
- fetch complete Git history in the reusable migration release gate
- allow build.rs to resolve the historical build-number baseline when checking the release tag

## Validation
- actionlint .github/workflows/reusable-migration-gate.yml
- git diff --check

This changes release infrastructure only; no tests are modified.