### PR TITLE
fix(ci): refresh release lock metadata before packaging

### DIFF
--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -147,6 +147,11 @@ jobs:
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
+      - name: Refresh release lock metadata and third-party notices
+        run: |
+          (cd src-tauri && cargo metadata --format-version 1 > /dev/null)
+          npm run licenses:generate
+
       - name: Print build tool manifest
         run: |
           echo "=== Android build tool manifest ==="

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -97,6 +97,11 @@ jobs:
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
+      - name: Refresh release lock metadata and third-party notices
+        run: |
+          (cd src-tauri && cargo metadata --format-version 1 > /dev/null)
+          npm run licenses:generate
+
       - name: Install Sentry CLI (pinned)
         if: ${{ env.SENTRY_UPLOAD_ENABLED == 'true' }}
         run: npm install --global "@sentry/cli@${SENTRY_CLI_VERSION}"

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -122,6 +122,11 @@ jobs:
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
+      - name: Refresh release lock metadata and third-party notices
+        run: |
+          (cd src-tauri && cargo metadata --format-version 1 > /dev/null)
+          npm run licenses:generate
+
       - name: Install Sentry CLI (pinned)
         if: ${{ env.SENTRY_UPLOAD_ENABLED == 'true' }}
         run: npm install --global "@sentry/cli@${SENTRY_CLI_VERSION}"

--- a/.github/workflows/reusable-build-windows.yml
+++ b/.github/workflows/reusable-build-windows.yml
@@ -115,6 +115,12 @@ jobs:
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
+      - name: Refresh release lock metadata and third-party notices
+        shell: bash
+        run: |
+          (cd src-tauri && cargo metadata --format-version 1 > /dev/null)
+          npm run licenses:generate
+
       - name: Install Sentry CLI (pinned)
         if: ${{ env.SENTRY_UPLOAD_ENABLED == 'true' }}
         shell: bash


### PR DESCRIPTION
## Summary
- refresh the release tag's root Cargo.lock package version in each packaging runner
- regenerate third-party notices from the effective release locks before the existing compliance check

## Validation
- isolated v0.9.43 worktree: cargo metadata changed only deep-student 0.9.42 -> 0.9.43 in Cargo.lock
- npm run licenses:generate
- npm run licenses:check
- actionlint (workflow syntax/expressions)
- git diff --check