### PR TITLE
fix(ci): build only NSIS on Windows releases

### DIFF
--- a/.github/workflows/reusable-build-windows.yml
+++ b/.github/workflows/reusable-build-windows.yml
@@ -151,7 +151,7 @@ jobs:
           SILICONFLOW_BUILTIN_EMBED_KEY: ${{ secrets.SILICONFLOW_BUILTIN_EMBED_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-        run: npx tauri build --target x86_64-pc-windows-msvc -- --locked
+        run: npx tauri build --target x86_64-pc-windows-msvc --bundles nsis -- --locked
 
       - name: Upload native symbols to Sentry
         if: ${{ env.SENTRY_UPLOAD_ENABLED == 'true' }}


### PR DESCRIPTION
## Summary
- limit the Windows Tauri release build to the NSIS bundle
- avoid an unrelated WiX MSI packaging failure
- keep the existing updater signature and release manifest flow unchanged

## Validation
- actionlint -shellcheck= .github/workflows/reusable-build-windows.yml
- git diff --check -- .github/workflows/reusable-build-windows.yml

The v0.9.43 release manifest consumes only the NSIS installer and its updater signature.