### PR TITLE
fix(ci): extend macOS release build timeout

### DIFF
--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -48,7 +48,7 @@ env:
 jobs:
   build:
     runs-on: macos-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
       SENTRY_UPLOAD_ENABLED: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' && 'true' || 'false' }}


### PR DESCRIPTION
## Summary
- extend the macOS release build timeout from 120 to 180 minutes
- prevent both macOS architectures from being cancelled during the full optimized Tauri build

## Validation
- actionlint -shellcheck= .github/workflows/reusable-build-macos.yml
- git diff --check -- .github/workflows/reusable-build-macos.yml

The previous v0.9.43 rebuild reached the 120-minute limit on both macOS architectures while still compiling.