### PR TITLE
fix(android): guard desktop-only browser APIs

### DIFF
--- a/src-tauri/src/browser/service.rs
+++ b/src-tauri/src/browser/service.rs
@@ -284,8 +284,8 @@ impl BrowserService {
 
     async fn reject_closed_gate(&self, message: &str) -> BrowserResult<()> {
         // Gate 关闭后不能留下仍可访问网络的 native content window。
-        if let Some(win) = window::content_window(&self.app) {
-            let _ = win.hide();
+        if window::content_window(&self.app).is_some() {
+            let _ = window::set_content_visibility(&self.app, false, false);
         }
         if let Err(error) = self.close_session_inner("gates_closed").await {
             warn!("[browser] gate-close cleanup failed: {}", error);

--- a/src-tauri/src/browser/window.rs
+++ b/src-tauri/src/browser/window.rs
@@ -716,6 +716,15 @@ pub fn set_content_occlusions(
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+pub fn set_content_occlusions(
+    _app: &AppHandle,
+    _occlusions: &[Rect],
+    _input_occlusions: &[Rect],
+) -> Result<(), String> {
+    Err(MOBILE_UNSUPPORTED.into())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 pub fn set_content_bounds(_app: &AppHandle, _bounds: Rect) -> Result<(), String> {
     Err(MOBILE_UNSUPPORTED.into())
 }

--- a/src-tauri/src/chat_v2/skills.rs
+++ b/src-tauri/src/chat_v2/skills.rs
@@ -1599,7 +1599,7 @@ fn atomic_exchange_directories(left: &Path, right: &Path) -> std::io::Result<()>
             left.as_ptr(),
             libc::AT_FDCWD,
             right.as_ptr(),
-            libc::RENAME_EXCHANGE,
+            libc::RENAME_EXCHANGE as libc::c_uint,
         )
     };
     if result == 0 {


### PR DESCRIPTION
## Summary
- route browser visibility changes through the platform abstraction
- add the missing mobile occlusion stub
- normalize Android renameat2 flags to c_uint

## Validation
- cargo fmt --check
- git diff --check
- cargo check --locked

Android-only release build will provide the target-specific verification.