### PR TITLE
fix(ci): stabilize release builds across hosted runners

### DIFF
--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -31,10 +31,15 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 150
+    # Pin the mature hosted image: ubuntu-latest/24.04 repeatedly terminated
+    # the runner service mid-build even after the Android Rust errors were fixed.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
+      CARGO_PROFILE_RELEASE_LTO: 'false'
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: '16'
+      CARGO_PROFILE_RELEASE_DEBUG: '0'
     steps:
       # ── 签名 secrets 预检（fail-closed, 在 2 小时编译之前）──
       - name: Preflight — require Android signing secrets (fail-closed)
@@ -143,6 +148,8 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: './src-tauri -> target'
+          shared-key: release-android-aarch64
+          cache-on-failure: true
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
@@ -160,6 +167,7 @@ jobs:
           echo "rustc           : $(rustc --version)"
           echo "cargo           : $(cargo --version)"
           echo "tauri-cli       : $(npx --no-install tauri --version 2>/dev/null || echo 'from package-lock.json')"
+          echo "release profile : lto=${CARGO_PROFILE_RELEASE_LTO}, codegen-units=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS}, debug=${CARGO_PROFILE_RELEASE_DEBUG}"
           echo "java            : $(java -version 2>&1 | head -1)"
           echo "ndk             : 27.0.12077973 (pinned)"
           echo "build-tools     : 35.0.0 (pinned) / platforms: android-35 (pinned)"

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -30,11 +30,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    # Ubuntu 24.04 hosted runners repeatedly received service shutdown signals
+    # during long Rust release builds. Use the mature image for release recovery.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
       SENTRY_UPLOAD_ENABLED: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' && 'true' || 'false' }}
+      CARGO_PROFILE_RELEASE_LTO: 'false'
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: '16'
+      CARGO_PROFILE_RELEASE_DEBUG: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' && '1' || '0' }}
     steps:
       # ── updater 签名密钥预检（fail-closed, 在任何耗时步骤之前）──
       - name: Preflight — require updater signing key (fail-closed)
@@ -93,6 +98,8 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: './src-tauri -> target'
+          shared-key: release-linux-x86_64
+          cache-on-failure: true
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
@@ -114,6 +121,7 @@ jobs:
           echo "rustc           : $(rustc --version)"
           echo "cargo           : $(cargo --version)"
           echo "tauri-cli       : $(npx --no-install tauri --version 2>/dev/null || echo 'from package-lock.json')"
+          echo "release profile : lto=${CARGO_PROFILE_RELEASE_LTO}, codegen-units=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS}, debug=${CARGO_PROFILE_RELEASE_DEBUG}"
           echo "sentry-cli      : ${SENTRY_CLI_VERSION} (pinned; installed only when Sentry secrets present)"
           echo "actions         : checkout v7.0.0 / setup-node v6.5.0 / rust-toolchain stable / setup-protoc v3.0.0 / rust-cache v2.9.1 / upload-artifact v7.0.1 (all SHA-pinned)"
 

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -47,15 +47,29 @@ env:
 
 jobs:
   build:
-    runs-on: macos-latest
-    timeout-minutes: 180
+    # macos-latest is ARM64. Running the Intel target there forces a very slow
+    # cross-architecture release build, so each target must use its native host.
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 240
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
       SENTRY_UPLOAD_ENABLED: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' && 'true' || 'false' }}
+      # The repository release profile uses one codegen unit + ThinLTO + packed
+      # debug info. On standard hosted macOS runners that made the final rustc /
+      # dSYM phase exceed three hours. Keep symbols only when they can actually
+      # be uploaded, and favor a bounded, reproducible release build otherwise.
+      CARGO_PROFILE_RELEASE_LTO: 'false'
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: '16'
+      CARGO_PROFILE_RELEASE_DEBUG: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' && '1' || '0' }}
+      CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != '' && 'packed' || 'off' }}
     strategy:
       fail-fast: false
       matrix:
-        target: [aarch64-apple-darwin, x86_64-apple-darwin]
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-15
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
     steps:
       # ── 生产签名 secrets 预检（fail-closed, 在任何耗时步骤之前）──
       - name: Preflight — require production signing secrets (fail-closed)
@@ -118,6 +132,8 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: './src-tauri -> target'
+          shared-key: release-${{ matrix.target }}
+          cache-on-failure: true
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
@@ -139,6 +155,8 @@ jobs:
           echo "rustc           : $(rustc --version)"
           echo "cargo           : $(cargo --version)"
           echo "tauri-cli       : $(npx --no-install tauri --version 2>/dev/null || echo 'from package-lock.json')"
+          echo "runner          : ${{ matrix.runner }} ($(uname -m))"
+          echo "release profile : lto=${CARGO_PROFILE_RELEASE_LTO}, codegen-units=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS}, debug=${CARGO_PROFILE_RELEASE_DEBUG}, split-debuginfo=${CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO}"
           echo "sentry-cli      : ${SENTRY_CLI_VERSION} (pinned; installed only when Sentry secrets present)"
           echo "xcode           : $(xcodebuild -version | tr '\n' ' ')"
           echo "actions         : checkout v7.0.0 / setup-node v6.5.0 / rust-toolchain stable / setup-protoc v3.0.0 / rust-cache v2.9.1 / upload-artifact v7.0.1 (all SHA-pinned)"


### PR DESCRIPTION
## Root cause
- `macos-latest` is ARM64, so the Intel target was cross-compiled on a 3-core/7GB runner
- the release profile combined one codegen unit, ThinLTO and packed debug info, keeping final rustc/dSYM work alive past 180 minutes
- Ubuntu 24.04 hosted runners repeatedly sent shutdown signals during long Rust builds

## Fix
- run each macOS target on a native architecture runner
- use bounded CI release profile overrides and only retain packed symbols when Sentry upload is enabled
- pin Linux/Android to Ubuntu 22.04 and isolate release caches by target
- allow cache persistence on ordinary failures

## Validation
- actionlint -shellcheck=
- git diff --check