### PR TITLE
fix(ci): build only Android APK

### DIFF
--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -277,7 +277,12 @@ jobs:
         run: |
           set +e
           echo "Starting Android build with 120 minute timeout"
-          timeout --signal=TERM --kill-after=60s 120m npx tauri android build --target aarch64 -- --locked
+          # The default Tauri command builds both APK and AAB. This release path
+          # only signs and publishes the APK, while the redundant AAB task
+          # invokes the Rust Android build again and keeps hosted runners alive
+          # long enough to be reclaimed during the final link.
+          timeout --signal=TERM --kill-after=60s 120m \
+            npx tauri android build --target aarch64 --apk --ci -- --locked
           status=$?
           set -e
 


### PR DESCRIPTION
## Summary
- build only the APK in the reusable Android release workflow
- skip the unused AAB build, which was triggering additional Rust release compilations
- keep the existing signing and APK publishing path unchanged

## Root cause
Recent Android release attempts reached the final Rust build and then lost the GitHub-hosted runner. Historical successful logs show the default Tauri command built both APK and AAB and repeated the Rust Android build several times, keeping the runner occupied for about 68 minutes even though only the APK is published. Passing `--apk --ci` removes that unused work and shortens the vulnerable runner window.

## Validation
- workflow YAML parsed successfully
- `tauri android build --help` confirms `--apk` and `--ci` are supported
- no application or test code changed