### PR TITLE
fix(ci): isolate Android recovery queues

### DIFF
--- a/.github/workflows/rebuild-android.yml
+++ b/.github/workflows/rebuild-android.yml
@@ -40,7 +40,10 @@ on:
         type: boolean
 
 concurrency:
-  group: rebuild-android-${{ github.event.inputs.tag_name }}
+  # Keep retries for the same workflow revision serialized, but do not let a
+  # runner that is permanently stuck on an older revision block a recovery
+  # workflow after its fix has been merged.
+  group: rebuild-android-${{ github.event.inputs.tag_name }}-${{ github.workflow_sha }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
## Summary
- include the workflow revision SHA in the Android rebuild concurrency group
- preserve serialization for retries from the same workflow revision
- allow a fixed workflow revision to recover when an older GitHub-hosted runner is permanently stuck

## Context
Run 30874643731 lost its hosted runner and remained `in_progress` even after normal and force-cancel requests, blocking the APK-only recovery run in the old concurrency group.

## Validation
- workflow YAML parsed successfully
- no application or test code changed