### PR TITLE
fix(ci): retry pdfium downloads

### DIFF
--- a/scripts/download-pdfium.sh
+++ b/scripts/download-pdfium.sh
@@ -129,7 +129,15 @@ download_pdfium() {
     
     # 下载
     if command -v curl &> /dev/null; then
-        curl -L -o "$archive_path" "$url"
+        curl \
+            --fail \
+            --location \
+            --retry 5 \
+            --retry-all-errors \
+            --retry-delay 5 \
+            --connect-timeout 30 \
+            --output "$archive_path" \
+            "$url"
     elif command -v wget &> /dev/null; then
         wget -O "$archive_path" "$url"
     else


### PR DESCRIPTION
## Summary
- make PDFium downloads fail on HTTP errors
- retry transient DNS/network failures up to five times
- bound each connection attempt to 30 seconds

## Root cause
The unsigned macOS Intel release job failed before compilation because a single PDFium download attempt hit `curl: (6) Could not resolve host: github.com`. The asset exists; the downloader had no retry policy.

## Validation
- `bash -n scripts/download-pdfium.sh`
- no application or test code changed