### PR TITLE
fix(ci): shorten Android release compilation

### DIFF
--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -38,7 +38,8 @@ jobs:
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
       CARGO_PROFILE_RELEASE_LTO: 'false'
-      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: '16'
+      CARGO_PROFILE_RELEASE_OPT_LEVEL: '2'
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: '32'
       CARGO_PROFILE_RELEASE_DEBUG: '0'
     steps:
       # ── 签名 secrets 预检（fail-closed, 在 2 小时编译之前）──


### PR DESCRIPTION
## Summary
- use Rust release opt-level 2 for Android CI builds
- increase release codegen units from 16 to 32
- retain no-LTO and stripped debug settings

## Root cause
The APK-only main-source build cleared the Android source errors but the hosted runner disappeared after about 94 minutes, leaving the build step marked in progress with no retrievable log. The Android release path needs a shorter LLVM/codegen window to complete reliably on standard hosted runners.

## Validation
- workflow YAML parsed successfully
- no application or test code changed