### PR TITLE
fix(ci): reduce Android release compile latency

### DIFF
--- a/.github/workflows/hotfix-linux-release.yml
+++ b/.github/workflows/hotfix-linux-release.yml
@@ -112,7 +112,7 @@ jobs:
           gh release view "$TAG" --repo "$GITHUB_REPO" --json assets -q '.assets[].name' > old-assets.txt
           cat old-assets.txt | while IFS= read -r name; do
             [[ -z "$name" ]] && continue
-            if [[ "$name" == *.AppImage || "$name" == *.AppImage.tar.gz || "$name" == *.AppImage.tar.gz.sig || "$name" == *.deb || "$name" == *.rpm ]]; then
+            if [[ "$name" == *.AppImage || "$name" == *.AppImage.sig || "$name" == *.AppImage.tar.gz || "$name" == *.AppImage.tar.gz.sig || "$name" == *.deb || "$name" == *.rpm ]]; then
               echo "Deleting old Linux asset: $name"
               gh release delete-asset "$TAG" "$name" --repo "$GITHUB_REPO" -y || true
             fi
@@ -139,29 +139,23 @@ jobs:
             exit 0
           fi
 
-          TAR=$(find linux-assets -maxdepth 1 -name "*_x86_64.AppImage.tar.gz" | head -1)
-          if [[ -z "$TAR" ]]; then
-            TAR=$(find linux-assets -maxdepth 1 -name "*.AppImage.tar.gz" | head -1)
-          fi
-          if [[ -z "$TAR" ]]; then
-            echo "::error::No AppImage updater tarball found"
+          UPDATER=$(find linux-assets -maxdepth 1 -name "*_x86_64.AppImage" ! -name "*.sig" | head -1)
+          [[ -z "$UPDATER" ]] && UPDATER=$(find linux-assets -maxdepth 1 -name "*_x86_64.AppImage.tar.gz" | head -1)
+          [[ -z "$UPDATER" ]] && UPDATER=$(find linux-assets -maxdepth 1 -name "*.AppImage.tar.gz" | head -1)
+          if [[ -z "$UPDATER" ]]; then
+            echo "::error::No AppImage updater artifact found"
             exit 1
           fi
 
-          SIG_FILE=""
-          if [[ -f "${TAR}.sig" ]]; then
-            SIG_FILE="${TAR}.sig"
-          else
-            SIG_FILE=$(find linux-assets -maxdepth 1 -name "$(basename "$TAR").sig" | head -1)
-          fi
-          if [[ -z "$SIG_FILE" || ! -f "$SIG_FILE" ]]; then
-            echo "::error::No signature found for $(basename "$TAR")"
+          SIG_FILE="${UPDATER}.sig"
+          if [[ ! -f "$SIG_FILE" ]]; then
+            echo "::error::No signature found for $(basename "$UPDATER")"
             exit 1
           fi
 
-          TAR_NAME=$(basename "$TAR")
+          UPDATER_NAME=$(basename "$UPDATER")
           SIGNATURE=$(cat "$SIG_FILE")
-          URL="https://github.com/${GITHUB_REPO}/releases/download/${TAG}/${TAR_NAME}"
+          URL="https://github.com/${GITHUB_REPO}/releases/download/${TAG}/${UPDATER_NAME}"
 
           jq --arg url "$URL" --arg sig "$SIGNATURE" '
             .platforms["linux-x86_64"] = {"url": $url, "signature": $sig}
@@ -228,16 +222,17 @@ jobs:
             exit 0
           fi
 
-          TAR=$(find linux-assets -maxdepth 1 -name "*_x86_64.AppImage.tar.gz" | head -1)
-          [[ -z "$TAR" ]] && TAR=$(find linux-assets -maxdepth 1 -name "*.AppImage.tar.gz" | head -1)
-          if [[ -z "$TAR" || ! -f "${TAR}.sig" ]]; then
-            echo "::error::AppImage tarball or signature missing for R2 latest.json patch"
+          UPDATER=$(find linux-assets -maxdepth 1 -name "*_x86_64.AppImage" ! -name "*.sig" | head -1)
+          [[ -z "$UPDATER" ]] && UPDATER=$(find linux-assets -maxdepth 1 -name "*_x86_64.AppImage.tar.gz" | head -1)
+          [[ -z "$UPDATER" ]] && UPDATER=$(find linux-assets -maxdepth 1 -name "*.AppImage.tar.gz" | head -1)
+          if [[ -z "$UPDATER" || ! -f "${UPDATER}.sig" ]]; then
+            echo "::error::AppImage updater artifact or signature missing for R2 latest.json patch"
             exit 1
           fi
 
-          TAR_NAME=$(basename "$TAR")
-          SIGNATURE=$(cat "${TAR}.sig")
-          jq --arg url "${R2_BASE}/${TAR_NAME}" --arg sig "$SIGNATURE" '
+          UPDATER_NAME=$(basename "$UPDATER")
+          SIGNATURE=$(cat "${UPDATER}.sig")
+          jq --arg url "${R2_BASE}/${UPDATER_NAME}" --arg sig "$SIGNATURE" '
             .platforms["linux-x86_64"] = {"url": $url, "signature": $sig}
           ' /tmp/r2-latest.json > /tmp/r2-latest.patched.json
 

--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -38,8 +38,10 @@ jobs:
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
       CARGO_PROFILE_RELEASE_LTO: 'false'
-      CARGO_PROFILE_RELEASE_OPT_LEVEL: '2'
-      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: '32'
+      # Recovery APKs run on preemptible hosted runners. Keep release semantics
+      # while reducing LLVM work enough to finish before another runner reclaim.
+      CARGO_PROFILE_RELEASE_OPT_LEVEL: '1'
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: '128'
       CARGO_PROFILE_RELEASE_DEBUG: '0'
     steps:
       # ── 签名 secrets 预检（fail-closed, 在 2 小时编译之前）──
@@ -168,7 +170,7 @@ jobs:
           echo "rustc           : $(rustc --version)"
           echo "cargo           : $(cargo --version)"
           echo "tauri-cli       : $(npx --no-install tauri --version 2>/dev/null || echo 'from package-lock.json')"
-          echo "release profile : lto=${CARGO_PROFILE_RELEASE_LTO}, codegen-units=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS}, debug=${CARGO_PROFILE_RELEASE_DEBUG}"
+          echo "release profile : opt-level=${CARGO_PROFILE_RELEASE_OPT_LEVEL}, lto=${CARGO_PROFILE_RELEASE_LTO}, codegen-units=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS}, debug=${CARGO_PROFILE_RELEASE_DEBUG}"
           echo "java            : $(java -version 2>&1 | head -1)"
           echo "ndk             : 27.0.12077973 (pinned)"
           echo "build-tools     : 35.0.0 (pinned) / platforms: android-35 (pinned)"

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -5,6 +5,8 @@
 #
 # fail-closed：updater 签名密钥及密码缺失时立即
 # 失败 —— 否则会静默产出没有 .sig 的 AppImage, 到 publish 阶段才炸。
+# Tauri v2 的 createUpdaterArtifacts=true 使用 AppImage 本体作为 updater
+# 产物；v1Compatible 才会生成 AppImage.tar.gz。这里兼容两种格式。
 
 name: Build Linux (reusable)
 
@@ -154,6 +156,20 @@ jobs:
       - name: Rename updater artifacts with arch suffix
         run: |
           BUNDLE_DIR="src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage"
+
+          # Tauri v2: AppImage 本体就是 updater 产物，签名文件为
+          # <app>.AppImage.sig。文件名可改，签名仍对应文件内容。
+          for f in "$BUNDLE_DIR"/*.AppImage; do
+            [ -f "$f" ] || continue
+            BASE=$(basename "$f" .AppImage | tr ' ' '.')
+            TARGET="$BUNDLE_DIR/${BASE}_x86_64.AppImage"
+            if [ "$f" != "$TARGET" ]; then
+              mv "$f" "$TARGET"
+              [ -f "$f.sig" ] && mv "$f.sig" "$TARGET.sig"
+            fi
+          done
+
+          # Tauri v1Compatible: updater archive + signature.
           for f in "$BUNDLE_DIR"/*.AppImage.tar.gz; do
             [ -f "$f" ] || continue
             BASE=$(basename "$f" .AppImage.tar.gz | tr ' ' '.')
@@ -168,14 +184,18 @@ jobs:
         run: |
           set -euo pipefail
           BUNDLE_DIR="src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage"
-          TAR_COUNT=$(find "$BUNDLE_DIR" -maxdepth 1 -name '*_x86_64.AppImage.tar.gz' ! -name '*.sig' | wc -l | tr -d ' ')
-          SIG_COUNT=$(find "$BUNDLE_DIR" -maxdepth 1 -name '*_x86_64.AppImage.tar.gz.sig' | wc -l | tr -d ' ')
-          if [ "$TAR_COUNT" -ne 1 ] || [ "$SIG_COUNT" -ne 1 ]; then
-            echo "::error::Expected exactly 1 updater archive + 1 .sig, got ${TAR_COUNT} archive(s) / ${SIG_COUNT} sig(s)"
+          V2_COUNT=$(find "$BUNDLE_DIR" -maxdepth 1 -name '*_x86_64.AppImage' ! -name '*.sig' | wc -l | tr -d ' ')
+          V2_SIG_COUNT=$(find "$BUNDLE_DIR" -maxdepth 1 -name '*_x86_64.AppImage.sig' | wc -l | tr -d ' ')
+          V1_COUNT=$(find "$BUNDLE_DIR" -maxdepth 1 -name '*_x86_64.AppImage.tar.gz' ! -name '*.sig' | wc -l | tr -d ' ')
+          V1_SIG_COUNT=$(find "$BUNDLE_DIR" -maxdepth 1 -name '*_x86_64.AppImage.tar.gz.sig' | wc -l | tr -d ' ')
+          V2_OK=$([ "$V2_COUNT" -eq 1 ] && [ "$V2_SIG_COUNT" -eq 1 ] && echo 1 || echo 0)
+          V1_OK=$([ "$V1_COUNT" -eq 1 ] && [ "$V1_SIG_COUNT" -eq 1 ] && echo 1 || echo 0)
+          if [ "$V2_OK" -ne 1 ] && [ "$V1_OK" -ne 1 ]; then
+            echo "::error::Expected Tauri v2 AppImage + .sig or v1Compatible tarball + .sig; got v2 ${V2_COUNT}/${V2_SIG_COUNT}, v1 ${V1_COUNT}/${V1_SIG_COUNT}"
             ls -la "$BUNDLE_DIR" || true
             exit 1
           fi
-          echo "✅ Updater archive + signature present"
+          echo "✅ Updater artifact + signature present"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -185,5 +205,6 @@ jobs:
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/rpm/*.rpm
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage
+            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage.sig
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage.tar.gz
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage.tar.gz.sig

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -272,11 +272,21 @@ jobs:
           DIR="artifacts/linux-x86_64"
           [[ -d "$DIR" ]] || fail "linux-x86_64: artifact directory missing: ${DIR}"
           if [[ -d "$DIR" ]]; then
-            TAR=$(find_exactly_one "$DIR" "*_x86_64.AppImage.tar.gz" "linux-x86_64 updater archive") || true
-            if [[ -n "${TAR:-}" ]]; then
+            if find "$DIR" -name "*_x86_64.AppImage.tar.gz" ! -name "*.sig" -print -quit | grep -q .; then
+              TAR=$(find_exactly_one "$DIR" "*_x86_64.AppImage.tar.gz" "linux-x86_64 updater archive") || true
               SIG=$(check_updater_sig "$TAR" "linux-x86_64") || true
               if [[ -n "${SIG:-}" ]]; then
                 add_platform "linux-x86_64" "$TAR" "$SIG"
+              fi
+            else
+              # Tauri v2 (createUpdaterArtifacts=true) signs the AppImage
+              # itself; v1Compatible uses the .AppImage.tar.gz archive.
+              APPIMAGE=$(find_exactly_one "$DIR" "*_x86_64.AppImage" "linux-x86_64 updater AppImage") || true
+              if [[ -n "${APPIMAGE:-}" ]]; then
+                SIG=$(check_updater_sig "$APPIMAGE" "linux-x86_64") || true
+                if [[ -n "${SIG:-}" ]]; then
+                  add_platform "linux-x86_64" "$APPIMAGE" "$SIG"
+                fi
               fi
             fi
             find_exactly_one "$DIR" "*.AppImage" "linux-x86_64 AppImage" > /dev/null || true
@@ -349,6 +359,7 @@ jobs:
           find artifacts -name "*.exe" -exec cp {} release-files/ \;
           find artifacts -name "*.exe.sig" -exec cp {} release-files/ \;
           find artifacts -name "*.AppImage" -exec cp {} release-files/ \;
+          find artifacts -name "*.AppImage.sig" -exec cp {} release-files/ \;
           find artifacts -name "*.AppImage.tar.gz" -exec cp {} release-files/ \;
           find artifacts -name "*.AppImage.tar.gz.sig" -exec cp {} release-files/ \;
           find artifacts -name "*.deb" -exec cp {} release-files/ \;


### PR DESCRIPTION
Android arm64 APK 已是单架构构建，但 hosted runner 仍在长时间 LLVM 优化阶段被回收。

- 保持 release profile 与 arm64-only APK
- opt-level 从 2 调整为 1
- codegen-units 从 32 调整为 128
- 不修改测试和业务代码