### PR TITLE
fix(ci): make unsigned macOS recovery builds work

### DIFF
--- a/.github/workflows/hotfix-linux-release.yml
+++ b/.github/workflows/hotfix-linux-release.yml
@@ -89,7 +89,18 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: linux-hotfix-x86_64
-          path: linux-assets
+          path: linux-artifact
+
+      - name: Flatten Linux artifacts
+        run: |
+          mkdir -p linux-assets
+          find linux-artifact -type f -exec mv {} linux-assets/ \;
+          FILE_COUNT=$(find linux-assets -maxdepth 1 -type f | wc -l | tr -d ' ')
+          if [[ "$FILE_COUNT" -eq 0 ]]; then
+            echo "::error::Downloaded Linux artifact contained no files"
+            exit 1
+          fi
+          echo "✅ Flattened ${FILE_COUNT} Linux artifact files"
 
       - name: Normalize artifact filenames
         run: |

--- a/.github/workflows/hotfix-linux-release.yml
+++ b/.github/workflows/hotfix-linux-release.yml
@@ -112,7 +112,7 @@ jobs:
           gh release view "$TAG" --repo "$GITHUB_REPO" --json assets -q '.assets[].name' > old-assets.txt
           cat old-assets.txt | while IFS= read -r name; do
             [[ -z "$name" ]] && continue
-            if [[ "$name" == *.AppImage || "$name" == *.AppImage.tar.gz || "$name" == *.AppImage.tar.gz.sig || "$name" == *.deb || "$name" == *.rpm ]]; then
+            if [[ "$name" == *.AppImage || "$name" == *.AppImage.sig || "$name" == *.AppImage.tar.gz || "$name" == *.AppImage.tar.gz.sig || "$name" == *.deb || "$name" == *.rpm ]]; then
               echo "Deleting old Linux asset: $name"
               gh release delete-asset "$TAG" "$name" --repo "$GITHUB_REPO" -y || true
             fi
@@ -139,29 +139,23 @@ jobs:
             exit 0
           fi
 
-          TAR=$(find linux-assets -maxdepth 1 -name "*_x86_64.AppImage.tar.gz" | head -1)
-          if [[ -z "$TAR" ]]; then
-            TAR=$(find linux-assets -maxdepth 1 -name "*.AppImage.tar.gz" | head -1)
-          fi
-          if [[ -z "$TAR" ]]; then
-            echo "::error::No AppImage updater tarball found"
+          UPDATER=$(find linux-assets -maxdepth 1 -name "*_x86_64.AppImage" ! -name "*.sig" | head -1)
+          [[ -z "$UPDATER" ]] && UPDATER=$(find linux-assets -maxdepth 1 -name "*_x86_64.AppImage.tar.gz" | head -1)
+          [[ -z "$UPDATER" ]] && UPDATER=$(find linux-assets -maxdepth 1 -name "*.AppImage.tar.gz" | head -1)
+          if [[ -z "$UPDATER" ]]; then
+            echo "::error::No AppImage updater artifact found"
             exit 1
           fi
 
-          SIG_FILE=""
-          if [[ -f "${TAR}.sig" ]]; then
-            SIG_FILE="${TAR}.sig"
-          else
-            SIG_FILE=$(find linux-assets -maxdepth 1 -name "$(basename "$TAR").sig" | head -1)
-          fi
-          if [[ -z "$SIG_FILE" || ! -f "$SIG_FILE" ]]; then
-            echo "::error::No signature found for $(basename "$TAR")"
+          SIG_FILE="${UPDATER}.sig"
+          if [[ ! -f "$SIG_FILE" ]]; then
+            echo "::error::No signature found for $(basename "$UPDATER")"
             exit 1
           fi
 
-          TAR_NAME=$(basename "$TAR")
+          UPDATER_NAME=$(basename "$UPDATER")
           SIGNATURE=$(cat "$SIG_FILE")
-          URL="https://github.com/${GITHUB_REPO}/releases/download/${TAG}/${TAR_NAME}"
+          URL="https://github.com/${GITHUB_REPO}/releases/download/${TAG}/${UPDATER_NAME}"
 
           jq --arg url "$URL" --arg sig "$SIGNATURE" '
             .platforms["linux-x86_64"] = {"url": $url, "signature": $sig}
@@ -228,16 +222,17 @@ jobs:
             exit 0
           fi
 
-          TAR=$(find linux-assets -maxdepth 1 -name "*_x86_64.AppImage.tar.gz" | head -1)
-          [[ -z "$TAR" ]] && TAR=$(find linux-assets -maxdepth 1 -name "*.AppImage.tar.gz" | head -1)
-          if [[ -z "$TAR" || ! -f "${TAR}.sig" ]]; then
-            echo "::error::AppImage tarball or signature missing for R2 latest.json patch"
+          UPDATER=$(find linux-assets -maxdepth 1 -name "*_x86_64.AppImage" ! -name "*.sig" | head -1)
+          [[ -z "$UPDATER" ]] && UPDATER=$(find linux-assets -maxdepth 1 -name "*_x86_64.AppImage.tar.gz" | head -1)
+          [[ -z "$UPDATER" ]] && UPDATER=$(find linux-assets -maxdepth 1 -name "*.AppImage.tar.gz" | head -1)
+          if [[ -z "$UPDATER" || ! -f "${UPDATER}.sig" ]]; then
+            echo "::error::AppImage updater artifact or signature missing for R2 latest.json patch"
             exit 1
           fi
 
-          TAR_NAME=$(basename "$TAR")
-          SIGNATURE=$(cat "${TAR}.sig")
-          jq --arg url "${R2_BASE}/${TAR_NAME}" --arg sig "$SIGNATURE" '
+          UPDATER_NAME=$(basename "$UPDATER")
+          SIGNATURE=$(cat "${UPDATER}.sig")
+          jq --arg url "${R2_BASE}/${UPDATER_NAME}" --arg sig "$SIGNATURE" '
             .platforms["linux-x86_64"] = {"url": $url, "signature": $sig}
           ' /tmp/r2-latest.json > /tmp/r2-latest.patched.json
 

--- a/.github/workflows/rebuild-macos.yml
+++ b/.github/workflows/rebuild-macos.yml
@@ -1,0 +1,95 @@
+# Emergency macOS-only rebuild for an existing draft or published release.
+# The user explicitly accepts ad-hoc, non-notarized recovery bundles.
+
+name: Rebuild macOS Release Assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: '目标 Release tag（如 v0.9.43）'
+        required: true
+        type: string
+
+concurrency:
+  group: rebuild-macos-${{ github.event.inputs.tag_name }}-${{ github.workflow_sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    uses: ./.github/workflows/reusable-verify-version.yml
+    with:
+      tag_name: ${{ github.event.inputs.tag_name }}
+
+  build-macos:
+    needs: [verify]
+    uses: ./.github/workflows/reusable-build-macos.yml
+    with:
+      tag_name: ${{ needs.verify.outputs.tag_name }}
+      allow_unsigned: true
+    secrets: inherit
+
+  replace-release-assets:
+    needs: [verify, build-macos]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: macos-*
+          path: macos-artifact
+
+      - name: Flatten and validate macOS artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p macos-assets
+          find macos-artifact -type f -exec mv {} macos-assets/ \;
+
+          find macos-assets -type f -name '* *' | while IFS= read -r f; do
+            DIR=$(dirname "$f")
+            OLD=$(basename "$f")
+            NEW=$(echo "$OLD" | tr ' ' '.')
+            mv "$f" "$DIR/$NEW"
+          done
+
+          ARM_TAR=$(find macos-assets -maxdepth 1 -name '*_aarch64.app.tar.gz' ! -name '*.sig' | wc -l | tr -d ' ')
+          INTEL_TAR=$(find macos-assets -maxdepth 1 -name '*_x86_64.app.tar.gz' ! -name '*.sig' | wc -l | tr -d ' ')
+          SIG_COUNT=$(find macos-assets -maxdepth 1 -name '*.app.tar.gz.sig' | wc -l | tr -d ' ')
+          DMG_COUNT=$(find macos-assets -maxdepth 1 -name '*.dmg' | wc -l | tr -d ' ')
+          if [[ "$ARM_TAR" -ne 1 || "$INTEL_TAR" -ne 1 || "$SIG_COUNT" -ne 2 || "$DMG_COUNT" -ne 2 ]]; then
+            echo "::error::Expected both macOS architectures (2 updater archives, 2 signatures, 2 DMGs)"
+            find macos-assets -maxdepth 1 -type f -print
+            exit 1
+          fi
+          ls -lh macos-assets
+
+      - name: Remove old macOS assets from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          TAG="${{ needs.verify.outputs.tag_name }}"
+          gh release view "$TAG" --repo "$GH_REPO" --json assets -q '.assets[].name' |
+            while IFS= read -r name; do
+              [[ -z "$name" ]] && continue
+              if [[ "$name" == *.dmg || "$name" == *.app.tar.gz || "$name" == *.app.tar.gz.sig ]]; then
+                gh release delete-asset "$TAG" "$name" --repo "$GH_REPO" -y || true
+              fi
+            done
+
+      - name: Upload macOS assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          TAG="${{ needs.verify.outputs.tag_name }}"
+          gh release upload "$TAG" macos-assets/* --repo "$GH_REPO" --clobber
+          echo "✅ macOS ARM64 + Intel assets uploaded to ${TAG}"

--- a/.github/workflows/rebuild-macos.yml
+++ b/.github/workflows/rebuild-macos.yml
@@ -1,18 +1,13 @@
-# Emergency macOS-only rebuild for an existing draft or published release.
-# The user explicitly accepts ad-hoc, non-notarized recovery bundles.
+# One-release emergency macOS rebuild for v0.9.43.
+# Remove this workflow after the release recovery is complete.
 
-name: Rebuild macOS Release Assets
+name: Recover v0.9.43 macOS Assets
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag_name:
-        description: '目标 Release tag（如 v0.9.43）'
-        required: true
-        type: string
+  workflow_dispatch: {}
 
 concurrency:
-  group: rebuild-macos-${{ github.event.inputs.tag_name }}-${{ github.workflow_sha }}
+  group: recover-v0.9.43-macos-${{ github.workflow_sha }}
   cancel-in-progress: false
 
 permissions:
@@ -22,7 +17,7 @@ jobs:
   verify:
     uses: ./.github/workflows/reusable-verify-version.yml
     with:
-      tag_name: ${{ github.event.inputs.tag_name }}
+      tag_name: v0.9.43
 
   build-macos:
     needs: [verify]
@@ -76,7 +71,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          TAG="${{ needs.verify.outputs.tag_name }}"
+          TAG="v0.9.43"
           gh release view "$TAG" --repo "$GH_REPO" --json assets -q '.assets[].name' |
             while IFS= read -r name; do
               [[ -z "$name" ]] && continue
@@ -90,6 +85,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          TAG="${{ needs.verify.outputs.tag_name }}"
+          TAG="v0.9.43"
           gh release upload "$TAG" macos-assets/* --repo "$GH_REPO" --clobber
           echo "✅ macOS ARM64 + Intel assets uploaded to ${TAG}"

--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -38,8 +38,10 @@ jobs:
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
       CARGO_PROFILE_RELEASE_LTO: 'false'
-      CARGO_PROFILE_RELEASE_OPT_LEVEL: '2'
-      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: '32'
+      # Recovery APKs run on preemptible hosted runners. Keep release semantics
+      # while reducing LLVM work enough to finish before another runner reclaim.
+      CARGO_PROFILE_RELEASE_OPT_LEVEL: '1'
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: '128'
       CARGO_PROFILE_RELEASE_DEBUG: '0'
     steps:
       # ── 签名 secrets 预检（fail-closed, 在 2 小时编译之前）──
@@ -168,7 +170,7 @@ jobs:
           echo "rustc           : $(rustc --version)"
           echo "cargo           : $(cargo --version)"
           echo "tauri-cli       : $(npx --no-install tauri --version 2>/dev/null || echo 'from package-lock.json')"
-          echo "release profile : lto=${CARGO_PROFILE_RELEASE_LTO}, codegen-units=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS}, debug=${CARGO_PROFILE_RELEASE_DEBUG}"
+          echo "release profile : opt-level=${CARGO_PROFILE_RELEASE_OPT_LEVEL}, lto=${CARGO_PROFILE_RELEASE_LTO}, codegen-units=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS}, debug=${CARGO_PROFILE_RELEASE_DEBUG}"
           echo "java            : $(java -version 2>&1 | head -1)"
           echo "ndk             : 27.0.12077973 (pinned)"
           echo "build-tools     : 35.0.0 (pinned) / platforms: android-35 (pinned)"

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -5,6 +5,8 @@
 #
 # fail-closed：updater 签名密钥及密码缺失时立即
 # 失败 —— 否则会静默产出没有 .sig 的 AppImage, 到 publish 阶段才炸。
+# Tauri v2 的 createUpdaterArtifacts=true 使用 AppImage 本体作为 updater
+# 产物；v1Compatible 才会生成 AppImage.tar.gz。这里兼容两种格式。
 
 name: Build Linux (reusable)
 
@@ -154,6 +156,20 @@ jobs:
       - name: Rename updater artifacts with arch suffix
         run: |
           BUNDLE_DIR="src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage"
+
+          # Tauri v2: AppImage 本体就是 updater 产物，签名文件为
+          # <app>.AppImage.sig。文件名可改，签名仍对应文件内容。
+          for f in "$BUNDLE_DIR"/*.AppImage; do
+            [ -f "$f" ] || continue
+            BASE=$(basename "$f" .AppImage | tr ' ' '.')
+            TARGET="$BUNDLE_DIR/${BASE}_x86_64.AppImage"
+            if [ "$f" != "$TARGET" ]; then
+              mv "$f" "$TARGET"
+              [ -f "$f.sig" ] && mv "$f.sig" "$TARGET.sig"
+            fi
+          done
+
+          # Tauri v1Compatible: updater archive + signature.
           for f in "$BUNDLE_DIR"/*.AppImage.tar.gz; do
             [ -f "$f" ] || continue
             BASE=$(basename "$f" .AppImage.tar.gz | tr ' ' '.')
@@ -168,14 +184,18 @@ jobs:
         run: |
           set -euo pipefail
           BUNDLE_DIR="src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage"
-          TAR_COUNT=$(find "$BUNDLE_DIR" -maxdepth 1 -name '*_x86_64.AppImage.tar.gz' ! -name '*.sig' | wc -l | tr -d ' ')
-          SIG_COUNT=$(find "$BUNDLE_DIR" -maxdepth 1 -name '*_x86_64.AppImage.tar.gz.sig' | wc -l | tr -d ' ')
-          if [ "$TAR_COUNT" -ne 1 ] || [ "$SIG_COUNT" -ne 1 ]; then
-            echo "::error::Expected exactly 1 updater archive + 1 .sig, got ${TAR_COUNT} archive(s) / ${SIG_COUNT} sig(s)"
+          V2_COUNT=$(find "$BUNDLE_DIR" -maxdepth 1 -name '*_x86_64.AppImage' ! -name '*.sig' | wc -l | tr -d ' ')
+          V2_SIG_COUNT=$(find "$BUNDLE_DIR" -maxdepth 1 -name '*_x86_64.AppImage.sig' | wc -l | tr -d ' ')
+          V1_COUNT=$(find "$BUNDLE_DIR" -maxdepth 1 -name '*_x86_64.AppImage.tar.gz' ! -name '*.sig' | wc -l | tr -d ' ')
+          V1_SIG_COUNT=$(find "$BUNDLE_DIR" -maxdepth 1 -name '*_x86_64.AppImage.tar.gz.sig' | wc -l | tr -d ' ')
+          V2_OK=$([ "$V2_COUNT" -eq 1 ] && [ "$V2_SIG_COUNT" -eq 1 ] && echo 1 || echo 0)
+          V1_OK=$([ "$V1_COUNT" -eq 1 ] && [ "$V1_SIG_COUNT" -eq 1 ] && echo 1 || echo 0)
+          if [ "$V2_OK" -ne 1 ] && [ "$V1_OK" -ne 1 ]; then
+            echo "::error::Expected Tauri v2 AppImage + .sig or v1Compatible tarball + .sig; got v2 ${V2_COUNT}/${V2_SIG_COUNT}, v1 ${V1_COUNT}/${V1_SIG_COUNT}"
             ls -la "$BUNDLE_DIR" || true
             exit 1
           fi
-          echo "✅ Updater archive + signature present"
+          echo "✅ Updater artifact + signature present"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -185,5 +205,6 @@ jobs:
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/rpm/*.rpm
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage
+            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage.sig
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage.tar.gz
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage.tar.gz.sig

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -269,7 +269,15 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: npx tauri build --target ${{ matrix.target }} -- --locked
+          ALLOW_UNSIGNED: ${{ inputs.allow_unsigned && '1' || '0' }}
+        run: |
+          if [[ "$ALLOW_UNSIGNED" == "1" ]]; then
+            # Empty APPLE_* variables override tauri.conf.json and make Tauri
+            # invoke codesign with identity "". Remove them so the configured
+            # ad-hoc identity ("-") is used for unsigned recovery bundles.
+            unset APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID
+          fi
+          npx tauri build --target ${{ matrix.target }} -- --locked
 
       # ── 签名/公证结果强制验证（fail-closed）──
       # codesign --verify --strict + stapler validate + spctl --assess:

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -272,11 +272,21 @@ jobs:
           DIR="artifacts/linux-x86_64"
           [[ -d "$DIR" ]] || fail "linux-x86_64: artifact directory missing: ${DIR}"
           if [[ -d "$DIR" ]]; then
-            TAR=$(find_exactly_one "$DIR" "*_x86_64.AppImage.tar.gz" "linux-x86_64 updater archive") || true
-            if [[ -n "${TAR:-}" ]]; then
+            if find "$DIR" -name "*_x86_64.AppImage.tar.gz" ! -name "*.sig" -print -quit | grep -q .; then
+              TAR=$(find_exactly_one "$DIR" "*_x86_64.AppImage.tar.gz" "linux-x86_64 updater archive") || true
               SIG=$(check_updater_sig "$TAR" "linux-x86_64") || true
               if [[ -n "${SIG:-}" ]]; then
                 add_platform "linux-x86_64" "$TAR" "$SIG"
+              fi
+            else
+              # Tauri v2 (createUpdaterArtifacts=true) signs the AppImage
+              # itself; v1Compatible uses the .AppImage.tar.gz archive.
+              APPIMAGE=$(find_exactly_one "$DIR" "*_x86_64.AppImage" "linux-x86_64 updater AppImage") || true
+              if [[ -n "${APPIMAGE:-}" ]]; then
+                SIG=$(check_updater_sig "$APPIMAGE" "linux-x86_64") || true
+                if [[ -n "${SIG:-}" ]]; then
+                  add_platform "linux-x86_64" "$APPIMAGE" "$SIG"
+                fi
               fi
             fi
             find_exactly_one "$DIR" "*.AppImage" "linux-x86_64 AppImage" > /dev/null || true
@@ -349,6 +359,7 @@ jobs:
           find artifacts -name "*.exe" -exec cp {} release-files/ \;
           find artifacts -name "*.exe.sig" -exec cp {} release-files/ \;
           find artifacts -name "*.AppImage" -exec cp {} release-files/ \;
+          find artifacts -name "*.AppImage.sig" -exec cp {} release-files/ \;
           find artifacts -name "*.AppImage.tar.gz" -exec cp {} release-files/ \;
           find artifacts -name "*.AppImage.tar.gz.sig" -exec cp {} release-files/ \;
           find artifacts -name "*.deb" -exec cp {} release-files/ \;


### PR DESCRIPTION
修复 macOS 未签名恢复构建：

- allow_unsigned=true 时移除空 APPLE_* 环境变量，避免 Tauri 用空 identity 调用 codesign
- 使用 tauri.conf.json 的 ad-hoc identity（不走 Developer ID/公证）
- 增加只重建并替换 macOS ARM64/Intel 资产的恢复 workflow
- 不修改测试和业务代码