### PR TITLE
fix(ci): mark rebuilt Android release available

### DIFF
--- a/.github/workflows/rebuild-android.yml
+++ b/.github/workflows/rebuild-android.yml
@@ -212,7 +212,10 @@ jobs:
 
           if [ -f /tmp/current-latest.json ]; then
             APK_URL="${R2_BASE}/${APK_NAME}"
-            jq --arg apk "$APK_URL" '.apk_url = $apk' /tmp/current-latest.json > /tmp/updated-latest.json
+            jq --arg apk "$APK_URL" '
+              .apk_url = $apk
+              | .android = ((.android // {}) + {status: "available", url: $apk})
+            ' /tmp/current-latest.json > /tmp/updated-latest.json
 
             echo "Updated latest.json:"
             cat /tmp/updated-latest.json

--- a/.github/workflows/upload-r2.yml
+++ b/.github/workflows/upload-r2.yml
@@ -121,7 +121,11 @@ jobs:
             .platforms |= with_entries(
               .value.url = ($base + "/" + (.value.url | split("/") | last))
             )
-            | if $apk != "" then .apk_url = $apk else . end
+            | if $apk != "" then
+                .apk_url = $apk
+                | .android = ((.android // {}) + {status: "available", url: $apk})
+              else .
+              end
           ' release-assets/latest.json > r2-latest.json
 
           echo "Original:"


### PR DESCRIPTION
## Summary
- mark Android status available after a successful APK rebuild
- include the Android URL in the R2 latest manifest
- make manual R2 resync repair stale Android status when an APK exists

## Validation
- git diff --check passed
- actionlint parsed both workflows; it reported only pre-existing shellcheck findings
- no tests changed