### PR TITLE
fix(design-system): 补齐未定义 token、暗色阴影、ErrorBoundary 文案

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -132,14 +132,16 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
                 </DsButton>
               </div>
               {this.state.componentStack && (
-                <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-5 text-muted-foreground">
+                <pre className="mt-2 max-h-40 overflow-auto overscroll-contain whitespace-pre-wrap break-words text-[11px] leading-5 text-muted-foreground">
                   {this.state.componentStack.trim()}
                 </pre>
               )}
             </div>
           )}
-          <DsButton variant="primary" size="sm" onClick={() => this.setState({ hasError: false })} className="text-xs !px-3 !py-1.5 bg-primary text-primary-foreground hover:opacity-90">
-            {i18n.t('common:error_boundary.refresh', 'Refresh Page')}
+          {/* 这个按钮只重挂子树，不重载页面——文案必须是「重试」。
+              真正的刷新在 TopLevelFallback（那里才用 error_boundary.refresh）。 */}
+          <DsButton variant="primary" size="md" onClick={this.resetError}>
+            {i18n.t('common:error_boundary.retry', 'Try again')}
           </DsButton>
         </div>
       );

--- a/src/components/ui/buttonPrimitiveContract.ts
+++ b/src/components/ui/buttonPrimitiveContract.ts
@@ -20,10 +20,10 @@ export type ButtonPrimitiveSize = 'sm' | 'md' | 'lg' | 'icon' | 'default';
 // ui-press-coarse：触屏（pointer:coarse）统一按压反馈（独立 scale 属性，
 // 不影响桌面鼠标 active 手感；定义见 src/styles/ui-motion.css 移动追加区）
 export const buttonBaseClassName =
-  'ui-press-coarse inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--button-radius)] border text-[13px] font-medium leading-none transition-[background-color,border-color,color] duration-150 ease-out outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 select-none motion-reduce:transition-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-inherit';
+  'ui-press-coarse inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--button-radius)] border text-ui font-medium leading-none transition-[background-color,border-color,color] duration-150 ease-out outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 select-none motion-reduce:transition-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-inherit';
 
 export const shellNavBaseClassName =
-  'ui-press-coarse inline-flex shrink-0 appearance-none items-center gap-2 whitespace-nowrap text-[13px] leading-none outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-inherit';
+  'ui-press-coarse inline-flex shrink-0 appearance-none items-center gap-2 whitespace-nowrap text-ui leading-none outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-inherit';
 
 export const buttonToneClassNames: Record<ButtonPrimitiveVariant, string> = {
   primary:
@@ -55,9 +55,9 @@ export const buttonToneClassNames: Record<ButtonPrimitiveVariant, string> = {
 };
 
 export const buttonSizeClassNames: Record<ButtonPrimitiveSize, string> = {
-  default: 'h-[var(--touch-target-size)] px-[var(--button-padding-x)] text-[13px] lg:h-[var(--button-height)]',
+  default: 'h-[var(--touch-target-size)] px-[var(--button-padding-x)] text-ui lg:h-[var(--button-height)]',
   sm: 'h-[var(--touch-target-size)] px-[var(--button-padding-x-sm)] text-xs lg:h-[var(--button-height-sm)]',
-  md: 'h-[var(--touch-target-size)] px-[var(--button-padding-x)] text-[13px] lg:h-[var(--button-height)]',
+  md: 'h-[var(--touch-target-size)] px-[var(--button-padding-x)] text-ui lg:h-[var(--button-height)]',
   lg: 'h-[var(--touch-target-size)] px-[var(--button-padding-x-lg)] text-sm lg:h-[var(--button-height-lg)]',
   icon:
     'h-[var(--touch-target-size)] w-[var(--touch-target-size)] rounded-[var(--button-radius)] p-0 lg:h-[var(--button-icon-size)] lg:w-[var(--button-icon-size)]',

--- a/src/features/learning-hub/icons/ResourceIcons.tsx
+++ b/src/features/learning-hub/icons/ResourceIcons.tsx
@@ -21,18 +21,36 @@ export interface ResourceIconProps {
 const defaultSize = 48;
 
 // Color Palette (Matte & Pastel)
-// Adjusted for v4: Slightly more vibrant for dark mode visibility, but still matte
+// 色值本体是 token（定义见 src/styles/theme-colors.css 的 --resource-icon-*）：
+// 原先写死的浅色 hex 在 .dark 下是一块块刺眼的亮斑，改走 token 后底色随卡片表面
+// 变沉、前景往 --foreground 提亮。fallback 保留亮色原值，token 层缺失时不至于失色。
+const tone = (hue: string, bg: string, fg: string, border: string) => ({
+  bg: `var(--resource-icon-${hue}-bg, ${bg})`,
+  fg: `var(--resource-icon-${hue}-fg, ${fg})`,
+  border: `var(--resource-icon-${hue}-border, ${border})`,
+});
+
 const palette = {
-  gray:   { bg: '#F1F0EF', fg: '#787774', border: '#E0E0E0' },
-  brown:  { bg: '#F4EEEE', fg: '#976D57', border: '#E8DCD5' },
-  orange: { bg: '#FBECDD', fg: '#CC782F', border: '#F5CCAA' },
-  yellow: { bg: '#FBF3DB', fg: '#CF9232', border: '#F9E2AF' },
-  green:  { bg: '#EDF3EC', fg: '#4F9779', border: '#C6E3C6' },
-  blue:   { bg: '#E7F3F8', fg: '#2B59C3', border: '#B8D6E8' },
-  purple: { bg: '#F6F3F9', fg: '#9A6DD7', border: '#D9CBE4' },
-  pink:   { bg: '#FBF2F5', fg: '#D65C9D', border: '#ECD0DE' },
-  red:    { bg: '#FDEBEC', fg: '#D44C47', border: '#FFD1CA' },
+  gray:   tone('gray',   '#F1F0EF', '#787774', '#E0E0E0'),
+  brown:  tone('brown',  '#F4EEEE', '#976D57', '#E8DCD5'),
+  orange: tone('orange', '#FBECDD', '#CC782F', '#F5CCAA'),
+  yellow: tone('yellow', '#FBF3DB', '#CF9232', '#F9E2AF'),
+  green:  tone('green',  '#EDF3EC', '#4F9779', '#C6E3C6'),
+  blue:   tone('blue',   '#E7F3F8', '#2B59C3', '#B8D6E8'),
+  purple: tone('purple', '#F6F3F9', '#9A6DD7', '#D9CBE4'),
+  pink:   tone('pink',   '#FBF2F5', '#D65C9D', '#ECD0DE'),
+  red:    tone('red',    '#FDEBEC', '#D44C47', '#FFD1CA'),
 };
+
+// 中性插画色：纸面、折角高光/暗角、文件夹三层色。同样在 .dark 下翻转。
+const paper = 'var(--resource-icon-paper, #FFFFFF)';
+const paperVeil = 'var(--resource-icon-paper-veil, rgba(255, 255, 255, 0.35))';
+const foldHighlight = 'var(--resource-icon-fold-highlight, rgba(255, 255, 255, 0.5))';
+const foldShade = 'var(--resource-icon-fold-shade, rgba(0, 0, 0, 0.05))';
+const folderBack = 'var(--resource-icon-folder-back, #E8B849)';
+const folderTab = 'var(--resource-icon-folder-tab, #D4A53A)';
+const folderFront = 'var(--resource-icon-folder-front, #F5C85C)';
+const folderHighlight = 'var(--resource-icon-folder-highlight, rgba(255, 255, 255, 0.4))';
 
 // ============================================================================
 // 基础组件：文档形状 (Flat Paper)
@@ -73,13 +91,11 @@ const DocBase: React.FC<{
       {/* 折角 - 纯色 */}
       <path
         d="M30 4V13C30 13.5523 30.4477 14 31 14H40"
-        fill="#FFFFFF"
-        fillOpacity="0.5"
+        fill={foldHighlight}
       />
       <path
         d="M30 4L40 14H31C30.4477 14 30 13.5523 30 13V4Z"
-        fill="black"
-        fillOpacity="0.05"
+        fill={foldShade}
       />
       
       {/* 内容区域 */}
@@ -203,7 +219,7 @@ export const ExamIcon: React.FC<ResourceIconProps> = React.memo(({
     <g style={{ transformOrigin: '8px 44px', transform: 'rotate(-8deg)' }}>
       <path
         d="M8 6C6.89543 6 6 6.89543 6 8V40C6 41.1046 6.89543 42 7 42H31C32.1046 42 33 41.1046 33 40V12L25 6H8Z"
-        fill="#FFFFFF"
+        fill={paper}
         stroke={palette.purple.fg}
         strokeWidth="1.5"
       />
@@ -295,7 +311,7 @@ export const TranslationIcon: React.FC<ResourceIconProps> = React.memo(({
       width="20"
       height="24"
       rx="3"
-      fill="#FFFFFF"
+      fill={paper}
       stroke={palette.blue.fg}
       strokeWidth="1.5"
     />
@@ -372,34 +388,33 @@ export const FolderIcon: React.FC<ResourceIconProps> = React.memo(({
     {/* 后层 - 文件夹背板 */}
     <path
       d="M6 10C6 8.89543 6.89543 8 8 8H18L21 11H40C41.1046 11 42 11.8954 42 13V39C42 40.1046 41.1046 41 40 41H8C6.89543 41 6 40.1046 6 39V10Z"
-      fill="#E8B849"
+      fill={folderBack}
     />
     
     {/* 标签页凸起 */}
     <path
       d="M6 10C6 8.89543 6.89543 8 8 8H17C17.5523 8 18 8.44772 18 9V11H6V10Z"
-      fill="#D4A53A"
+      fill={folderTab}
     />
 
     {/* 前盖 - 主体 */}
     <path
       d="M6 15C6 13.8954 6.89543 13 8 13H40C41.1046 13 42 13.8954 42 15V39C42 40.1046 41.1046 41 40 41H8C6.89543 41 6 40.1046 6 39V15Z"
-      fill="#F5C85C"
+      fill={folderFront}
     />
     
     {/* 顶部高光 - 增加质感 */}
     <path
       d="M7 15C7 14.4477 7.44772 14 8 14H40C40.5523 14 41 14.4477 41 15"
-      stroke="white"
+      stroke={folderHighlight}
       strokeWidth="1"
-      strokeOpacity="0.4"
       fill="none"
     />
     
     {/* 底部微暗 - 增加立体感 */}
     <path
       d="M6 37H42V39C42 40.1046 41.1046 41 40 41H8C6.89543 41 6 40.1046 6 39V37Z"
-      fill="#E8B849"
+      fill={folderBack}
       fillOpacity="0.5"
     />
   </svg>
@@ -681,7 +696,7 @@ export const RecentIcon: React.FC<ResourceIconProps> = React.memo(({ className, 
     <circle cx="12" cy="20.5" r="0.8" fill={symbolColor} fillOpacity="0.4"/>
     <circle cx="3.5" cy="12" r="0.8" fill={symbolColor} fillOpacity="0.4"/>
     {/* 时钟内圈 */}
-    <circle cx="12" cy="12" r="7" fill="white" fillOpacity="0.35" stroke={symbolColor} strokeWidth="0.8" strokeOpacity="0.25"/>
+    <circle cx="12" cy="12" r="7" fill={paperVeil} stroke={symbolColor} strokeWidth="0.8" strokeOpacity="0.25"/>
     {/* 时针 */}
     <path d="M12 12V8" stroke={symbolColor} strokeWidth="1.8" strokeLinecap="round"/>
     {/* 分针 */}

--- a/src/locales/en-US/common.json
+++ b/src/locales/en-US/common.json
@@ -3798,6 +3798,7 @@
     "title": "Application encountered a critical error",
     "description": "An unrecoverable error occurred. Please try refreshing the page. Contact support if the issue persists.",
     "refresh": "Refresh Page",
+    "retry": "Try again",
     "show_details": "Show Error Details",
     "hide_details": "Hide Details",
     "copy_error": "Copy Error Log",

--- a/src/locales/zh-CN/common.json
+++ b/src/locales/zh-CN/common.json
@@ -3741,6 +3741,7 @@
     "title": "应用遇到严重错误",
     "description": "应用发生了无法恢复的错误。请尝试刷新页面，如果问题持续请联系支持。",
     "refresh": "刷新页面",
+    "retry": "重试",
     "show_details": "查看错误详情",
     "hide_details": "隐藏详情",
     "copy_error": "复制错误日志",

--- a/src/styles/__tests__/themeColorTokens.definitions.test.ts
+++ b/src/styles/__tests__/themeColorTokens.definitions.test.ts
@@ -1,0 +1,135 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const srcRoot = resolve(process.cwd(), 'src');
+const themeColors = readFileSync(join(srcRoot, 'styles/theme-colors.css'), 'utf-8');
+const tailwindConfig = readFileSync(resolve(process.cwd(), 'tailwind.config.js'), 'utf-8');
+
+const collectFiles = (dir: string, out: string[] = []): string[] => {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) collectFiles(path, out);
+    else out.push(path);
+  }
+  return out;
+};
+
+const allSrcFiles = collectFiles(srcRoot);
+
+/** 每一个在 src 的样式层里被声明过的自定义属性（含 tsx/ts 里以 style 对象写死的）。 */
+const definedTokens = (() => {
+  const names = new Set<string>();
+  for (const file of allSrcFiles) {
+    if (file.endsWith('.css')) {
+      for (const match of readFileSync(file, 'utf-8').matchAll(/(--[a-zA-Z0-9-]+)\s*:/g)) {
+        names.add(match[1]);
+      }
+    } else if (/\.tsx?$/.test(file)) {
+      for (const match of readFileSync(file, 'utf-8').matchAll(/['"`](--[a-zA-Z0-9-]+)['"`]\s*:/g)) {
+        names.add(match[1]);
+      }
+    }
+  }
+  return names;
+})();
+
+const blockOf = (selector: string) => {
+  const start = themeColors.indexOf(`${selector} {`);
+  expect(start, `${selector} block should exist in theme-colors.css`).toBeGreaterThan(-1);
+  return themeColors.slice(start, themeColors.indexOf('\n}', start));
+};
+
+const lightRoot = blockOf(':where(:root)');
+const darkRoot = blockOf(':root.dark');
+
+const declarationOf = (block: string, token: string) =>
+  block.match(new RegExp(`${token}:([^;]+);`))?.[1]?.trim();
+
+/** hsl(var(--shadow-base) / 0.34) → 0.34 中最大的一个（复合阴影取最强的一层）。 */
+const maxShadowAlpha = (declaration: string | undefined) =>
+  Math.max(
+    ...[...(declaration ?? '').matchAll(/var\(--shadow-base\)\s*\/\s*([\d.]+)/g)].map((m) => Number(m[1])),
+    0,
+  );
+
+describe('theme color token definitions', () => {
+  it('defines the tokens that shipped as consumers-without-definitions', () => {
+    // 这些 var() 早于定义就被消费了：解析失败时属性直接丢弃，
+    // 表现为「面板没有背景」「选中态没有描边」而不是报错，很难被发现。
+    for (const token of [
+      '--surface-panel',
+      '--accent-primary',
+      '--button-secondary-surface',
+      '--brand-secondary',
+      '--brand-accent',
+    ]) {
+      expect(lightRoot, `${token} must be defined in the light token layer`).toContain(`${token}:`);
+    }
+  });
+
+  it('keeps --surface-panel an opaque panel surface next to --surface-panel-strong', () => {
+    const panel = declarationOf(lightRoot, '--surface-panel');
+    expect(panel).toBeTruthy();
+    expect(panel).not.toContain('transparent');
+    expect(lightRoot).toContain('--surface-panel-strong:');
+  });
+
+  it('exposes real colors for the tailwind brand.secondary / brand.accent mapping', () => {
+    // tailwind 直接吐 var(--brand-secondary)，不会再包 hsl()，所以必须是完整颜色值。
+    expect(tailwindConfig).toContain("secondary: 'var(--brand-secondary)'");
+    expect(tailwindConfig).toContain("accent: 'var(--brand-accent)'");
+    for (const token of ['--brand-secondary', '--brand-accent']) {
+      expect(declarationOf(lightRoot, token)).toMatch(/hsl\(|color-mix\(/);
+      expect(declarationOf(darkRoot, token), `${token} needs a dark value too`).toMatch(/hsl\(|color-mix\(/);
+    }
+  });
+
+  it('flips shell and content shadows so dark overlays keep depth', () => {
+    // 亮色档在 0.04–0.10；暗色档必须抬到 workbench 暗色区间（0.34–0.56）。
+    for (const token of [
+      '--shadow-shell-soft',
+      '--shadow-shell-panel',
+      '--shadow-shell-floating',
+      '--shadow-shell-pressed',
+      '--shadow-content-subtle',
+      '--shadow-content-soft',
+      '--shadow-content-elevated',
+    ]) {
+      const light = maxShadowAlpha(declarationOf(lightRoot, token));
+      const dark = maxShadowAlpha(declarationOf(darkRoot, token));
+      expect(dark, `${token} must be redefined for dark mode`).toBeGreaterThanOrEqual(0.3);
+      expect(dark, `${token} must be stronger in dark than in light`).toBeGreaterThan(light);
+    }
+  });
+
+  it('keeps the mobile sheet scrim and shadow readable in dark mode', () => {
+    // --shadow-base 换成浅色会把遮罩和底栏投影一起洗掉。
+    expect(declarationOf(darkRoot, '--shadow-base')).toBe('0 0% 0%');
+    expect(maxShadowAlpha(declarationOf(darkRoot, '--mobile-sheet-shadow'))).toBeGreaterThanOrEqual(0.4);
+    expect(maxShadowAlpha(declarationOf(darkRoot, '--mobile-sheet-scrim'))).toBeGreaterThanOrEqual(0.4);
+  });
+
+  it('gives resource icon illustrations a dark branch', () => {
+    for (const token of ['--resource-icon-bg-mix', '--resource-icon-ink-mix', '--resource-icon-paper']) {
+      expect(lightRoot).toContain(`${token}:`);
+      expect(darkRoot, `${token} needs a dark override`).toContain(`${token}:`);
+    }
+  });
+
+  it('leaves no undefined token behind in the recovery and system-status surfaces', () => {
+    const consumers = ['features/data-recovery', 'components/system-status'];
+    const missing: string[] = [];
+
+    for (const consumer of consumers) {
+      for (const file of collectFiles(join(srcRoot, consumer))) {
+        if (!/\.(tsx?|css)$/.test(file)) continue;
+        for (const match of readFileSync(file, 'utf-8').matchAll(/var\(\s*(--[a-zA-Z0-9-]+)/g)) {
+          if (!definedTokens.has(match[1])) missing.push(`${match[1]} (${file.slice(srcRoot.length + 1)})`);
+        }
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/styles/theme-colors.css
+++ b/src/styles/theme-colors.css
@@ -10,6 +10,10 @@
   --surface-overlay-strong: color-mix(in hsl, hsl(var(--card)) 65%, hsl(var(--background)) 35%);
   --surface-divider: color-mix(in hsl, hsl(var(--border)) 55%, transparent 45%);
   --surface-panel-muted: color-mix(in hsl, var(--surface-muted) 82%, var(--surface-elevated) 18%);
+  /* --surface-panel 是 panel family 的基准档（muted < panel < strong）。
+     必须是实底色：数据恢复面板（src/features/data-recovery/*）整片背景都挂在它上面，
+     一旦缺定义 bg-[color:var(--surface-panel)] 会解析失败、退化成透明。 */
+  --surface-panel: var(--surface-elevated);
   --surface-panel-strong: color-mix(in hsl, var(--surface-elevated) 92%, var(--surface-root) 8%);
 
   /* Desktop shell surfaces
@@ -130,6 +134,9 @@
   --button-prominent-active-bg: color-mix(in oklab, hsl(var(--primary)) 84%, hsl(var(--foreground)) 16%);
   --button-prominent-border: color-mix(in oklab, hsl(var(--primary)) 34%, hsl(var(--border)) 66%);
   --button-tonal-bg: color-mix(in oklab, hsl(var(--secondary)) 82%, hsl(var(--background)) 18%);
+  /* 次级按钮表面别名：tonal 就是本设计系统的"次级"档，
+     ComposerPlusMenu 等消费方按这个名字取色。 */
+  --button-secondary-surface: var(--button-tonal-bg);
   --button-tonal-hover-bg: color-mix(in oklab, hsl(var(--muted)) 78%, hsl(var(--background)) 22%);
   --button-tonal-active-bg: color-mix(in oklab, hsl(var(--accent)) 82%, hsl(var(--background)) 18%);
   --button-tonal-border: color-mix(in oklab, hsl(var(--border)) 78%, hsl(var(--foreground)) 6%);
@@ -231,7 +238,13 @@
   --text-muted: hsl(var(--muted-foreground));
   --text-inverse: hsl(var(--primary-foreground));
 
-  /* Brand palette + gradients */
+  /* Brand palette + gradients
+     注意 --brand-primary（定义在 shadcn-variables.css）是裸 HSL 分量，消费方必须自己包 hsl()；
+     下面的 --brand-secondary / --brand-accent 则是完整颜色值，因为 tailwind.config.js 的
+     colors.brand.* 直接吐 `var(--brand-secondary)`，不会再包一层函数。 */
+  --accent-primary: hsl(var(--primary));
+  --brand-secondary: hsl(var(--info));
+  --brand-accent: color-mix(in oklab, hsl(var(--primary)) 50%, hsl(var(--info)) 50%);
   --brand-gradient: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--info)) 100%);
   --brand-gradient-hover: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--info)) 80%, hsl(var(--primary)) 100%);
   --brand-primary-light: color-mix(in hsl, hsl(var(--primary)) 25%, hsl(var(--background)) 75%);
@@ -264,6 +277,64 @@
   --citation-source-memory: var(--warning);
   --citation-source-web-search: var(--success);
   --diagram-node-contrast-text: hsl(var(--destructive-foreground));
+
+  /* Learning-hub 资源图标插画色
+     ------------------------------------------------------------
+     消费方：src/features/learning-hub/icons/ResourceIcons.tsx
+     `-ink` 是与主题无关的色相锚点（原先直接写死在 tsx 里的浅色 hex）。
+     bg / border 与当前卡片表面混合，fg 在暗色下往 --foreground 提亮，
+     因此同一套 SVG 在 .dark 下不再是刺眼的浅色块。调档只需改下面三个
+     mix 比例，不必逐个 hue 重配。 */
+  --resource-icon-gray-ink: #787774;
+  --resource-icon-brown-ink: #976d57;
+  --resource-icon-orange-ink: #cc782f;
+  --resource-icon-yellow-ink: #cf9232;
+  --resource-icon-green-ink: #4f9779;
+  --resource-icon-blue-ink: #2b59c3;
+  --resource-icon-purple-ink: #9a6dd7;
+  --resource-icon-pink-ink: #d65c9d;
+  --resource-icon-red-ink: #d44c47;
+  --resource-icon-surface: hsl(var(--card));
+  --resource-icon-bg-mix: 9%;
+  --resource-icon-border-mix: 26%;
+  --resource-icon-ink-mix: 100%;
+  --resource-icon-ink-tint: hsl(var(--foreground));
+  /* 纸面/高光/暗角：原先是写死的 #FFFFFF 与 black/5% */
+  --resource-icon-paper: hsl(0 0% 100%);
+  --resource-icon-paper-veil: hsl(0 0% 100% / 0.35);
+  --resource-icon-fold-highlight: hsl(0 0% 100% / 0.5);
+  --resource-icon-fold-shade: hsl(0 0% 0% / 0.05);
+  --resource-icon-folder-back: #e8b849;
+  --resource-icon-folder-tab: #d4a53a;
+  --resource-icon-folder-front: #f5c85c;
+  --resource-icon-folder-highlight: hsl(0 0% 100% / 0.4);
+  --resource-icon-gray-bg: color-mix(in oklab, var(--resource-icon-gray-ink) var(--resource-icon-bg-mix), var(--resource-icon-surface));
+  --resource-icon-gray-fg: color-mix(in oklab, var(--resource-icon-gray-ink) var(--resource-icon-ink-mix), var(--resource-icon-ink-tint));
+  --resource-icon-gray-border: color-mix(in oklab, var(--resource-icon-gray-ink) var(--resource-icon-border-mix), var(--resource-icon-surface));
+  --resource-icon-brown-bg: color-mix(in oklab, var(--resource-icon-brown-ink) var(--resource-icon-bg-mix), var(--resource-icon-surface));
+  --resource-icon-brown-fg: color-mix(in oklab, var(--resource-icon-brown-ink) var(--resource-icon-ink-mix), var(--resource-icon-ink-tint));
+  --resource-icon-brown-border: color-mix(in oklab, var(--resource-icon-brown-ink) var(--resource-icon-border-mix), var(--resource-icon-surface));
+  --resource-icon-orange-bg: color-mix(in oklab, var(--resource-icon-orange-ink) var(--resource-icon-bg-mix), var(--resource-icon-surface));
+  --resource-icon-orange-fg: color-mix(in oklab, var(--resource-icon-orange-ink) var(--resource-icon-ink-mix), var(--resource-icon-ink-tint));
+  --resource-icon-orange-border: color-mix(in oklab, var(--resource-icon-orange-ink) var(--resource-icon-border-mix), var(--resource-icon-surface));
+  --resource-icon-yellow-bg: color-mix(in oklab, var(--resource-icon-yellow-ink) var(--resource-icon-bg-mix), var(--resource-icon-surface));
+  --resource-icon-yellow-fg: color-mix(in oklab, var(--resource-icon-yellow-ink) var(--resource-icon-ink-mix), var(--resource-icon-ink-tint));
+  --resource-icon-yellow-border: color-mix(in oklab, var(--resource-icon-yellow-ink) var(--resource-icon-border-mix), var(--resource-icon-surface));
+  --resource-icon-green-bg: color-mix(in oklab, var(--resource-icon-green-ink) var(--resource-icon-bg-mix), var(--resource-icon-surface));
+  --resource-icon-green-fg: color-mix(in oklab, var(--resource-icon-green-ink) var(--resource-icon-ink-mix), var(--resource-icon-ink-tint));
+  --resource-icon-green-border: color-mix(in oklab, var(--resource-icon-green-ink) var(--resource-icon-border-mix), var(--resource-icon-surface));
+  --resource-icon-blue-bg: color-mix(in oklab, var(--resource-icon-blue-ink) var(--resource-icon-bg-mix), var(--resource-icon-surface));
+  --resource-icon-blue-fg: color-mix(in oklab, var(--resource-icon-blue-ink) var(--resource-icon-ink-mix), var(--resource-icon-ink-tint));
+  --resource-icon-blue-border: color-mix(in oklab, var(--resource-icon-blue-ink) var(--resource-icon-border-mix), var(--resource-icon-surface));
+  --resource-icon-purple-bg: color-mix(in oklab, var(--resource-icon-purple-ink) var(--resource-icon-bg-mix), var(--resource-icon-surface));
+  --resource-icon-purple-fg: color-mix(in oklab, var(--resource-icon-purple-ink) var(--resource-icon-ink-mix), var(--resource-icon-ink-tint));
+  --resource-icon-purple-border: color-mix(in oklab, var(--resource-icon-purple-ink) var(--resource-icon-border-mix), var(--resource-icon-surface));
+  --resource-icon-pink-bg: color-mix(in oklab, var(--resource-icon-pink-ink) var(--resource-icon-bg-mix), var(--resource-icon-surface));
+  --resource-icon-pink-fg: color-mix(in oklab, var(--resource-icon-pink-ink) var(--resource-icon-ink-mix), var(--resource-icon-ink-tint));
+  --resource-icon-pink-border: color-mix(in oklab, var(--resource-icon-pink-ink) var(--resource-icon-border-mix), var(--resource-icon-surface));
+  --resource-icon-red-bg: color-mix(in oklab, var(--resource-icon-red-ink) var(--resource-icon-bg-mix), var(--resource-icon-surface));
+  --resource-icon-red-fg: color-mix(in oklab, var(--resource-icon-red-ink) var(--resource-icon-ink-mix), var(--resource-icon-ink-tint));
+  --resource-icon-red-border: color-mix(in oklab, var(--resource-icon-red-ink) var(--resource-icon-border-mix), var(--resource-icon-surface));
 }
 
 :root.dark {
@@ -319,12 +390,49 @@
   --chat-thinking-header-surface: color-mix(in hsl, var(--surface-root) 82%, hsl(var(--muted)) 18%);
   --chat-thinking-hover-surface: color-mix(in hsl, var(--surface-root) 76%, hsl(var(--muted)) 24%);
   --chat-thinking-border: color-mix(in hsl, hsl(var(--border)) 68%, transparent 32%);
+
+  /* 暗色阴影翻转
+     ------------------------------------------------------------
+     亮色档的 4%–10% 黑影落在 9% 灰底上等于不存在，浮层/面板/移动端底栏
+     全糊成一片，层次只能靠边框撑。色相仍保持纯黑：--mobile-sheet-scrim 和
+     --text-shadow-contrast-* 都从 --shadow-base 取色，换成浅色会把遮罩洗掉。
+     alpha 对齐 workbench 暗色档（workbench.tokens.css :root.dark 的
+     --wb-shadow-*，rgba 0.34–0.56）。 */
+  --shadow-base: 0 0% 0%;
+  --shadow-shell-soft: 0 12px 24px hsl(var(--shadow-base) / 0.34);
+  --shadow-shell-panel: 0 16px 32px hsl(var(--shadow-base) / 0.40);
+  --shadow-shell-floating: 0 18px 36px hsl(var(--shadow-base) / 0.52);
+  --shadow-shell-pressed: 0 8px 20px hsl(var(--shadow-base) / 0.38);
+  --shadow-content-subtle: 0 1px 3px hsl(var(--shadow-base) / 0.36);
+  --shadow-content-soft: 0 2px 8px hsl(var(--shadow-base) / 0.44);
+  --shadow-content-elevated: 0 6px 18px hsl(var(--shadow-base) / 0.48);
+  /* 移动端底部 sheet 的上投影：亮色 0.10 在暗色下完全看不见，
+     底栏会和页面内容连成一块。 */
+  --mobile-sheet-shadow: 0 -12px 34px hsl(var(--shadow-base) / 0.56);
   --mobile-sheet-scrim: hsl(var(--shadow-base) / 0.58);
+  /* brand.secondary / brand.accent 在暗底上要提亮，否则 tailwind 的
+     text-brand-secondary / bg-brand-accent 会掉进不可读区间。 */
+  --brand-secondary: color-mix(in oklab, hsl(var(--info)) 80%, hsl(var(--foreground)) 20%);
+  --brand-accent: color-mix(in oklab, var(--brand-secondary) 50%, hsl(var(--primary)) 50%);
   --citation-badge-bg-alpha: 0.15;
   --citation-badge-hover-alpha: 0.25;
   --scrollbar-thumb: color-mix(in oklab, hsl(var(--foreground)) 22%, transparent);
   --scrollbar-thumb-hover: color-mix(in oklab, hsl(var(--foreground)) 36%, transparent);
   --scrollbar-thumb-active: color-mix(in oklab, hsl(var(--foreground)) 50%, transparent);
+
+  /* 资源图标：底更沉、边更实、前景往 --foreground 提亮，
+     -bg / -fg / -border 的 color-mix 公式在亮色档已写好，这里只翻比例。 */
+  --resource-icon-bg-mix: 22%;
+  --resource-icon-border-mix: 40%;
+  --resource-icon-ink-mix: 64%;
+  --resource-icon-paper: color-mix(in oklab, hsl(var(--card)) 76%, hsl(var(--foreground)) 24%);
+  --resource-icon-paper-veil: hsl(0 0% 100% / 0.06);
+  --resource-icon-fold-highlight: hsl(0 0% 100% / 0.07);
+  --resource-icon-fold-shade: hsl(0 0% 0% / 0.28);
+  --resource-icon-folder-back: #a9791f;
+  --resource-icon-folder-tab: #8e6519;
+  --resource-icon-folder-front: #c7962f;
+  --resource-icon-folder-highlight: hsl(0 0% 100% / 0.14);
 }
 
 @media (prefers-reduced-transparency: reduce) {

--- a/tests/vitest/errorBoundaryCopy.test.tsx
+++ b/tests/vitest/errorBoundaryCopy.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -10,7 +12,12 @@ vi.mock('@/utils/clipboardUtils', () => ({
   copyTextToClipboard: vi.fn().mockResolvedValue(true),
 }));
 
-describe('ErrorBoundary copy action', () => {
+const errorBoundarySource = readFileSync(
+  resolve(process.cwd(), 'src/components/ErrorBoundary.tsx'),
+  'utf-8',
+);
+
+const silenceReactErrorLogs = () => {
   const originalConsoleError = console.error;
 
   beforeEach(() => {
@@ -21,6 +28,10 @@ describe('ErrorBoundary copy action', () => {
     console.error = originalConsoleError;
     vi.clearAllMocks();
   });
+};
+
+describe('ErrorBoundary copy action', () => {
+  silenceReactErrorLogs();
 
   it('lets chat-v2 fallback copy the error log', async () => {
     const Crashy = () => {
@@ -48,5 +59,77 @@ describe('ErrorBoundary copy action', () => {
     const copiedPayload = vi.mocked(copyTextToClipboard).mock.calls[0]?.[0] ?? '';
     expect(copiedPayload).toContain('sidebar crash');
     expect(copiedPayload).toContain('Timestamp:');
+  });
+});
+
+describe('ErrorBoundary retry action', () => {
+  silenceReactErrorLogs();
+
+  it('labels the inline action as a retry, not a page refresh', () => {
+    const Crashy = () => {
+      throw new Error('boom');
+    };
+
+    render(
+      <ErrorBoundary name="inline">
+        <Crashy />
+      </ErrorBoundary>
+    );
+
+    // 这个按钮只重挂子树，不会重载页面；写「刷新页面」是假承诺。
+    // 真刷新留在 TopLevelFallback（那里继续用 error_boundary.refresh）。
+    expect(
+      screen.getByRole('button', { name: i18n.t('common:error_boundary.retry') })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: i18n.t('common:error_boundary.refresh') })
+    ).not.toBeInTheDocument();
+  });
+
+  it('remounts the children when the failure was transient', () => {
+    let shouldThrow = true;
+    const Flaky = () => {
+      if (shouldThrow) throw new Error('transient crash');
+      return <p>recovered</p>;
+    };
+
+    render(
+      <ErrorBoundary name="inline">
+        <Flaky />
+      </ErrorBoundary>
+    );
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('common:error_boundary.retry') }));
+
+    expect(screen.getByText('recovered')).toBeInTheDocument();
+  });
+
+  it('routes the retry through the shared resetError instead of a partial setState', () => {
+    // 只 setState({ hasError: false }) 会把上一次的 error / componentStack / copied
+    // 留在 state 里，和 fallback 拿到的 reset 行为对不上。
+    expect(errorBoundarySource).toContain('onClick={this.resetError}');
+    expect(errorBoundarySource).not.toContain('setState({ hasError: false })');
+  });
+
+  it('keeps the retry hit area on the shared touch target size', () => {
+    const Crashy = () => {
+      throw new Error('boom');
+    };
+
+    render(
+      <ErrorBoundary name="inline">
+        <Crashy />
+      </ErrorBoundary>
+    );
+
+    const retry = screen.getByRole('button', { name: i18n.t('common:error_boundary.retry') });
+    expect(retry).toHaveClass('h-[var(--touch-target-size)]');
+    // 旧实现用 !px-3 !py-1.5 把热区压小，移动端会点不中。
+    expect(retry.className).not.toContain('!py-');
+  });
+
+  it('keeps the dev-only component stack scrollable instead of pushing the button off screen', () => {
+    expect(errorBoundarySource).toMatch(/<pre className="[^"]*max-h-40[^"]*overflow-auto/);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

故障/恢复面板消费了未定义的 `--surface-panel` / `--accent-primary`；暗色 `--shadow-base` 未翻转；ErrorBoundary 按钮写「刷新页面」实际只 reset state；按钮字号不吃 `--font-size-scale`。

### Changes
- 在 `theme-colors.css` 补齐缺失 token，暗色阴影可见
- 资源图标改走 theme token，不再写死浅色 hex
- ErrorBoundary 主按钮改为「重试」并调用 `resetError`
- 按钮配方改 `text-ui`

### How to test
- 打开数据恢复/功能不可用面板：亮暗色都有底色
- 暗色下浮层应有阴影层次
- 触发 ErrorBoundary：按钮文案是「重试」，点击重挂子树而不是假装刷新
- 调整设置字号：DsButton 标签跟着变

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

### 重叠说明
这 4 个 commit **已被** `cursor/practice-review-loop-fixes-1272` 包含。与 `cursor/design-system-tokens-dark-shadow-font-scale-ecb3` 也重叠（ecb3 另外有 eslint 禁 `text-[Npx]`、`mobileAccent` token 化）。建议：要练习闭环就合 practice 分支；只要设计系统且要 eslint/mobileAccent 就合 ecb3；本 PR 可作最小设计系统切片。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92ea5725-a196-4c8d-97b6-cf85cfe2ecb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92ea5725-a196-4c8d-97b6-cf85cfe2ecb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

