### PR TITLE
fix(workbench): 关窗拦截、快捷键可发现、沉浸可见出口

### DIFF
--- a/src/features/settings/components/WorkbenchSettingsSection.tsx
+++ b/src/features/settings/components/WorkbenchSettingsSection.tsx
@@ -27,6 +27,7 @@ import { APP_EVENTS, dispatchAppEvent } from '@/events';
 // 走 index 会把整条 chat store 链拖进 settings bundle（见 P10 进度文件遗留项）。
 import { workbenchBus } from '@/features/workbench/core/workbenchBus';
 import { setMaterialTier, type MaterialTierSetting } from '@/features/workbench/core/materialTier';
+import { listWorkbenchShortcuts } from '@/features/workbench/core/shortcuts';
 import { WALLPAPER_PRESETS, DEFAULT_WALLPAPER, type WallpaperConfig } from '@/features/workbench/components/WallpaperLayer';
 import {
   parseTitleBarDoubleClickAction,
@@ -57,6 +58,8 @@ export const WORKBENCH_SETTING_KEYS = {
    * 快照仍会后台保存；关闭时仅跳过启动 hydrate。
    */
   restoreSession: 'desktop.workbenchRestoreSession',
+  /** 桌面组件（日程小组件等）显隐；缺省显示，与桌面右键菜单同一 key */
+  desktopWidgets: 'desktop.workbenchDesktopWidgets',
   /** 菜单栏自动隐藏（StatusBar 自读；见 menuBarAutohideStore） */
   menuBarAutohide: 'desktop.workbenchMenuBarAutohide',
   /** 双击标题栏行为（WindowTitleBar 自读；见 titleBarBehaviorStore） */
@@ -186,6 +189,8 @@ export const WorkbenchSettingsSection: React.FC<WorkbenchSettingsSectionProps> =
   const [dockSize, setDockSize] = useState(DOCK_SIZE_DEFAULT);
   const [dockAutohide, setDockAutohide] = useState(false);
   const [restoreSession, setRestoreSession] = useState(false);
+  const [desktopWidgets, setDesktopWidgets] = useState(true);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [menuBarAutohide, setMenuBarAutohide] = useState(false);
   const [titleBarDoubleClick, setTitleBarDoubleClick] = useState<TitleBarDoubleClickAction>('zoom');
   const [devPanel, setDevPanel] = useState(false);
@@ -213,6 +218,7 @@ export const WorkbenchSettingsSection: React.FC<WorkbenchSettingsSectionProps> =
         dockSizeVal,
         autohideVal,
         restoreSessionVal,
+        desktopWidgetsVal,
         menuBarAutohideVal,
         titleBarDoubleClickVal,
         devPanelVal,
@@ -231,6 +237,7 @@ export const WorkbenchSettingsSection: React.FC<WorkbenchSettingsSectionProps> =
         read(WORKBENCH_SETTING_KEYS.dockSize),
         read(WORKBENCH_SETTING_KEYS.dockAutohide),
         read(WORKBENCH_SETTING_KEYS.restoreSession),
+        read(WORKBENCH_SETTING_KEYS.desktopWidgets),
         read(WORKBENCH_SETTING_KEYS.menuBarAutohide),
         read(WORKBENCH_SETTING_KEYS.titleBarDoubleClick),
         read(WORKBENCH_SETTING_KEYS.devPanel),
@@ -251,6 +258,8 @@ export const WorkbenchSettingsSection: React.FC<WorkbenchSettingsSectionProps> =
       setDockSize(parseDockSize(dockSizeVal));
       setDockAutohide(String(autohideVal ?? '') === 'true');
       setRestoreSession(String(restoreSessionVal ?? '') === 'true');
+      // 缺省（从未设置）= 显示，只有显式 'false' 才隐藏
+      setDesktopWidgets(String(desktopWidgetsVal ?? '') !== 'false');
       setMenuBarAutohide(String(menuBarAutohideVal ?? '') === 'true');
       setTitleBarDoubleClick(parseTitleBarDoubleClickAction(titleBarDoubleClickVal));
       setDevPanel(String(devPanelVal ?? '') === 'true');
@@ -381,6 +390,9 @@ export const WorkbenchSettingsSection: React.FC<WorkbenchSettingsSectionProps> =
     },
     [persist],
   );
+
+  // 键位展示随平台（macOS 为 ⌘ 基底符号），列表本身是静态定义
+  const workbenchShortcuts = React.useMemo(() => listWorkbenchShortcuts(), []);
 
   const presetOptions = WALLPAPER_PRESETS.map((preset) => ({
     value: preset.id,
@@ -675,6 +687,18 @@ export const WorkbenchSettingsSection: React.FC<WorkbenchSettingsSectionProps> =
       />
 
       <SwitchRow
+        title={t('workbench:settings.desktopWidgets.title')}
+        description={t('workbench:settings.desktopWidgets.desc')}
+        checked={desktopWidgets}
+        loading={!loaded}
+        onCheckedChange={(next) => {
+          if (!loaded) return;
+          setDesktopWidgets(next);
+          void persist(WORKBENCH_SETTING_KEYS.desktopWidgets, String(next), next);
+        }}
+      />
+
+      <SwitchRow
         title={t('workbench:settings.menubarAutohide.title')}
         description={t('workbench:settings.menubarAutohide.desc')}
         checked={menuBarAutohide}
@@ -707,6 +731,54 @@ export const WorkbenchSettingsSection: React.FC<WorkbenchSettingsSectionProps> =
             { value: 'none', label: t('workbench:settings.titleBarDoubleClick.none') },
           ]}
         />
+      </SettingRow>
+
+      {/* 快捷键清单：速查表（`?` / 桌面右键菜单 / 品牌菜单）之外的第三条可发现路径 */}
+      <SettingRow
+        title={t('workbench:settings.shortcuts.title')}
+        description={t('workbench:settings.shortcuts.desc')}
+      >
+        <div className="w-full min-w-0 lg:max-w-[560px]">
+          <button
+            type="button"
+            aria-expanded={shortcutsOpen}
+            aria-controls="workbench-shortcuts-list"
+            onClick={() => setShortcutsOpen((prev) => !prev)}
+            className="flex items-center gap-1.5 py-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            <span
+              aria-hidden="true"
+              className={`inline-block transition-transform ${shortcutsOpen ? 'rotate-90' : ''}`}
+            >
+              ▸
+            </span>
+            {shortcutsOpen
+              ? t('workbench:settings.shortcuts.hide')
+              : t('workbench:settings.shortcuts.show', { count: workbenchShortcuts.length })}
+          </button>
+          {shortcutsOpen && (
+            <ul
+              id="workbench-shortcuts-list"
+              data-testid="workbench-shortcuts-list"
+              className="mt-1 divide-y divide-border/40 rounded-md border border-border/40"
+            >
+              {workbenchShortcuts.map((shortcut) => (
+                <li
+                  key={shortcut.id}
+                  data-shortcut-id={shortcut.id}
+                  className="flex items-center justify-between gap-3 px-2.5 py-1.5"
+                >
+                  <span className="min-w-0 break-words text-xs text-foreground/85">
+                    {t(shortcut.descriptionKey, shortcut.defaultDescription)}
+                  </span>
+                  <kbd className="shrink-0 rounded border border-border/60 bg-muted/40 px-1.5 py-0.5 text-[11px] tabular-nums text-muted-foreground">
+                    {shortcut.keys}
+                  </kbd>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </SettingRow>
 
       <SwitchRow

--- a/src/features/workbench/components/DesktopContextMenu.css
+++ b/src/features/workbench/components/DesktopContextMenu.css
@@ -181,6 +181,20 @@
   background: var(--wb-glass-border);
 }
 
+/* 触控/笔指针：菜单行放大到 44px 命中高度（Apple HIG 最小可点区），
+   顶栏菜单（StatusBarMenu）与桌面右键菜单共用 .wb-desk-menu-item 契约 */
+@media (pointer: coarse) {
+  .wb-desk-menu-item {
+    min-height: 44px;
+    padding: 10px 12px;
+    font-size: 14px;
+  }
+
+  .wb-desk-menu-sep {
+    margin: 6px 8px;
+  }
+}
+
 /* ==== 子菜单 ============================================================= */
 
 .wb-desk-menu-subwrap {

--- a/src/features/workbench/components/DesktopContextMenu.tsx
+++ b/src/features/workbench/components/DesktopContextMenu.tsx
@@ -18,16 +18,19 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
 import {
+  CalendarBlank,
   CaretRight,
   ChatCircleDots,
   Check,
   CirclesFour,
+  Compass,
   Desktop,
   Drop,
   FolderOpen,
   GearSix,
   GridFour,
   Image,
+  Keyboard,
   SquaresFour,
   Stack,
 } from '@phosphor-icons/react';
@@ -46,6 +49,7 @@ import { toggleShowDesktop as toggleShowDesktopShared } from '../hooks/showDeskt
 import { WALLPAPER_PRESETS, type WallpaperConfig } from './WallpaperLayer';
 import { OPEN_WALLPAPER_MANAGER_EVENT } from './WallpaperManagerDialog';
 import { openAppsPanel } from './appsPanelStore';
+import { EMPTY_DESKTOP_REPLAY_TOUR_EVENT } from './EmptyDesktop';
 import './DesktopContextMenu.css';
 
 // ---------------------------------------------------------------------------
@@ -54,6 +58,8 @@ import './DesktopContextMenu.css';
 
 const WALLPAPER_SETTING_KEY = 'desktop.workbenchWallpaper';
 const MATERIAL_TIER_SETTING_KEY = 'desktop.workbenchMaterialTier';
+/** 桌面组件（日程小组件等）显隐；缺省 = 显示，只有显式 'false' 才隐藏 */
+export const DESKTOP_WIDGETS_SETTING_KEY = 'desktop.workbenchDesktopWidgets';
 /** 桌面右键子菜单展示的壁纸预设数量（完整清单进壁纸管理面板） */
 const MENU_WALLPAPER_PRESET_COUNT = 5;
 
@@ -397,6 +403,7 @@ const DesktopContextMenuComponent: React.FC<DesktopContextMenuProps> = ({
   const [openSub, setOpenSub] = useState<SubMenuId | null>(null);
   const [submenuPosition, setSubmenuPosition] = useState<SubmenuPosition | null>(null);
   const [tierSetting, setTierSetting] = useState<MaterialTierSetting>('auto');
+  const [widgetsVisible, setWidgetsVisible] = useState(true);
   const open = anchor !== null;
   useLiquidGlassLens(panelRef, open);
   useLiquidGlassLens(subPanelRef, open && openSub !== null);
@@ -488,7 +495,7 @@ const DesktopContextMenuComponent: React.FC<DesktopContextMenuProps> = ({
     };
   }, [open, onClose]);
 
-  // 打开时回读材质档设置（仅菜单展示 radio 选中态用）
+  // 打开时回读材质档 / 桌面组件设置（仅菜单展示选中态用）
   useEffect(() => {
     if (!open) return undefined;
     let cancelled = false;
@@ -496,6 +503,10 @@ const DesktopContextMenuComponent: React.FC<DesktopContextMenuProps> = ({
       if (cancelled) return;
       const v = String(raw ?? '');
       setTierSetting(v === 'full' || v === 'reduced' || v === 'minimal' ? v : 'auto');
+    });
+    void readWorkbenchSetting(DESKTOP_WIDGETS_SETTING_KEY).then((raw) => {
+      if (cancelled) return;
+      setWidgetsVisible(String(raw ?? '') !== 'false');
     });
     return () => {
       cancelled = true;
@@ -574,6 +585,28 @@ const DesktopContextMenuComponent: React.FC<DesktopContextMenuProps> = ({
     onClose();
     try {
       window.dispatchEvent(new CustomEvent(OPEN_WALLPAPER_MANAGER_EVENT));
+    } catch {
+      // noop
+    }
+  }, [onClose]);
+
+  /** 桌面组件显隐：走既有 desktop.* 设置通道，WorkbenchDesktop 经热更新事件收敛 */
+  const toggleDesktopWidgets = useCallback(() => {
+    const next = !widgetsVisible;
+    setWidgetsVisible(next);
+    void persistWorkbenchSetting(DESKTOP_WIDGETS_SETTING_KEY, String(next), next);
+    onClose();
+  }, [onClose, widgetsVisible]);
+
+  const openCheatsheet = useCallback(() => {
+    onClose();
+    useWorkbenchOverlay.getState().openCheatsheet({ sticky: true });
+  }, [onClose]);
+
+  const replayTour = useCallback(() => {
+    onClose();
+    try {
+      window.dispatchEvent(new CustomEvent(EMPTY_DESKTOP_REPLAY_TOUR_EVENT));
     } catch {
       // noop
     }
@@ -777,8 +810,32 @@ const DesktopContextMenuComponent: React.FC<DesktopContextMenuProps> = ({
           />
         </div>
 
+        <ActionItem
+          icon={<CalendarBlank size={15} weight="duotone" />}
+          label={t('workbench:desktopMenu.showWidgets')}
+          checked={widgetsVisible}
+          testId="wb-desk-menu-widgets"
+          onClick={toggleDesktopWidgets}
+          onPointerEnter={() => setOpenSub(null)}
+        />
+
         <div className="wb-desk-menu-sep" role="separator" />
 
+        <ActionItem
+          icon={<Keyboard size={15} weight="duotone" />}
+          label={t('workbench:desktopMenu.shortcuts')}
+          shortcut={shortcutHintFor('cheatsheet')}
+          testId="wb-desk-menu-shortcuts"
+          onClick={openCheatsheet}
+          onPointerEnter={() => setOpenSub(null)}
+        />
+        <ActionItem
+          icon={<Compass size={15} weight="duotone" />}
+          label={t('workbench:desktopMenu.replayTour')}
+          testId="wb-desk-menu-replay-tour"
+          onClick={replayTour}
+          onPointerEnter={() => setOpenSub(null)}
+        />
         <ActionItem
           icon={<GearSix size={15} weight="duotone" />}
           label={t('workbench:desktopMenu.settings')}

--- a/src/features/workbench/components/EmptyDesktop.css
+++ b/src/features/workbench/components/EmptyDesktop.css
@@ -36,7 +36,7 @@
 .wb-empty-cta-block {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: stretch;
   gap: 10px;
   width: 100%;
   margin-top: 8px;
@@ -72,6 +72,18 @@
 
 .wb-empty-cta:active {
   transform: translateY(0);
+}
+
+/* 次级 CTA（恢复上次桌面）：同尺寸不同权重，主 CTA 仍是视觉重心 */
+.wb-empty-cta-secondary {
+  border-color: color-mix(in hsl, hsl(var(--border)) 80%, transparent 20%);
+  background: color-mix(in hsl, hsl(var(--card)) 40%, transparent 60%);
+  font-weight: 500;
+}
+
+.wb-empty-cta-secondary:hover {
+  background: color-mix(in hsl, hsl(var(--card)) 62%, transparent 38%);
+  border-color: color-mix(in hsl, hsl(var(--border)) 100%, transparent 0%);
 }
 
 .wb-empty-cta:focus-visible {
@@ -286,5 +298,47 @@
 
   .wb-empty-card-pro .wb-empty-hint {
     font-size: 11px;
+  }
+}
+
+/* ==== 窄工作区（移动 / 分屏）：单列铺开，不再给日程组件让出 404px ====
+   原先 `max-width: calc(100% - 404px)` 会在窄屏把整张卡压到 180px 下限，
+   tour 文案与三个按钮全部挤成不可用的窄条。这里改为单列 + 允许纵向滚动。 */
+@media (width <= 720px) {
+  .wb-empty-card.wb-empty-card-pro {
+    top: 12px;
+    left: 12px;
+    right: 12px;
+    width: auto;
+    max-width: none;
+    max-height: calc(100% - 24px);
+    overflow-y: auto;
+    /* 卡片自身成为滚动容器时必须能接收指针，否则窄屏根本滚不动 */
+    pointer-events: auto;
+    overscroll-behavior: contain;
+    padding: 16px 16px 14px;
+  }
+
+  .wb-empty-card-pro .wb-empty-hint {
+    font-size: 12px;
+  }
+
+  .wb-empty-tour-actions {
+    gap: 8px;
+  }
+}
+
+/* 触控：CTA 与 tour 按钮给足 44px 命中高度 */
+@media (pointer: coarse) {
+  .wb-empty-cta {
+    min-height: 44px;
+    padding: 10px 16px;
+    font-size: 14px;
+  }
+
+  .wb-empty-tour-btn {
+    min-height: 44px;
+    padding: 8px 14px;
+    font-size: 13px;
   }
 }

--- a/src/features/workbench/components/EmptyDesktop.tsx
+++ b/src/features/workbench/components/EmptyDesktop.tsx
@@ -2,16 +2,22 @@
  * 空桌面引导（A4：4 步首启 tour）
  * ---------------------------------------------------------------------------
  * 桌面上没有任何窗口时展示的轻量引导：
- * - 单主 CTA（打开资源库）；
+ * - 主 CTA（打开资源库）**始终在**——tour 关掉的只是 tour，空桌面不该变成
+ *   一块什么都点不到的壁纸；
  * - 4 步 tour：Dock 应用 → ⌘K/Ctrl+K 搜索 → 状态栏 → Agent 控制；
- * - 「跳过」仅本会话隐藏；「不再显示」/「完成」写入 localStorage 永久消隐；
+ *   「跳过」仅本会话隐藏，「不再显示」/「完成」写入 localStorage 永久消隐，
+ *   两者都只作用于 tour 区块；
+ * - 桌面右键菜单的「重新查看引导」经 EMPTY_DESKTOP_REPLAY_TOUR_EVENT 复活 tour；
+ * - 可选的「恢复上次桌面」次级 CTA：由 WorkbenchDesktop 在探测到可用快照时
+ *   下发（不翻转「启动时恢复上次桌面」这个设置的默认值）；
  * - 整层 pointer-events: none，仅 CTA / tour 控件恢复指针，
  *   不拦截桌面右键 / 双击手势。
  */
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   AppWindow,
+  ClockCounterClockwise,
   FolderOpen,
   Keyboard,
   Pulse,
@@ -25,6 +31,9 @@ import './EmptyDesktop.css';
 
 /** 首次使用 onboarding 的记忆位（本地 UI 偏好，不进设置后端/快照） */
 export const EMPTY_DESKTOP_ONBOARDING_KEY = 'workbench.emptyDesktop.onboardingDismissed';
+
+/** 「重新查看引导」入口（桌面右键菜单）派发的事件 */
+export const EMPTY_DESKTOP_REPLAY_TOUR_EVENT = 'workbench:empty-desktop-replay-tour';
 
 const TOUR_STEP_IDS = ['dock', 'search', 'statusBar', 'agent'] as const;
 export type EmptyDesktopTourStepId = (typeof TOUR_STEP_IDS)[number];
@@ -44,27 +53,50 @@ function readOnboardingDismissed(): boolean {
   }
 }
 
-function persistOnboardingDismissed(): void {
+function persistOnboardingDismissed(dismissed: boolean): void {
   try {
-    localStorage.setItem(EMPTY_DESKTOP_ONBOARDING_KEY, '1');
+    if (dismissed) localStorage.setItem(EMPTY_DESKTOP_ONBOARDING_KEY, '1');
+    else localStorage.removeItem(EMPTY_DESKTOP_ONBOARDING_KEY);
   } catch {
-    /* 存储不可用时仅本次会话隐藏 */
+    /* 存储不可用时仅本次会话生效 */
   }
 }
 
-export const EmptyDesktop: React.FC = React.memo(() => {
+export interface EmptyDesktopProps {
+  /** 存在可恢复的上次桌面快照时显示次级 CTA（默认 false，不做破坏性默认翻转） */
+  restoreAvailable?: boolean;
+  /** 「恢复上次桌面」点击回调（由总装提供 hydrate 实现） */
+  onRestoreSession?: () => void;
+}
+
+export const EmptyDesktop: React.FC<EmptyDesktopProps> = React.memo(({
+  restoreAvailable = false,
+  onRestoreSession,
+}) => {
   const { t } = useTranslation();
-  const [onboardingDismissed, setOnboardingDismissed] = useState(readOnboardingDismissed);
+  const [tourDismissed, setTourDismissed] = useState(readOnboardingDismissed);
   const [sessionSkipped, setSessionSkipped] = useState(false);
   const [stepIndex, setStepIndex] = useState(0);
 
   const dismissForever = useCallback(() => {
-    setOnboardingDismissed(true);
-    persistOnboardingDismissed();
+    setTourDismissed(true);
+    persistOnboardingDismissed(true);
   }, []);
 
   const skipSession = useCallback(() => {
     setSessionSkipped(true);
+  }, []);
+
+  // 「重新查看引导」：清掉两个消隐标记并回到第一步
+  useEffect(() => {
+    const onReplay = () => {
+      persistOnboardingDismissed(false);
+      setTourDismissed(false);
+      setSessionSkipped(false);
+      setStepIndex(0);
+    };
+    window.addEventListener(EMPTY_DESKTOP_REPLAY_TOUR_EVENT, onReplay);
+    return () => window.removeEventListener(EMPTY_DESKTOP_REPLAY_TOUR_EVENT, onReplay);
   }, []);
 
   const goNext = useCallback(() => {
@@ -85,8 +117,7 @@ export const EmptyDesktop: React.FC = React.memo(() => {
     launch('files');
   }, [launch]);
 
-  if (onboardingDismissed || sessionSkipped) return null;
-
+  const tourVisible = !tourDismissed && !sessionSkipped;
   const stepId = TOUR_STEP_IDS[stepIndex] ?? TOUR_STEP_IDS[0];
   const isLast = stepIndex >= TOUR_STEP_IDS.length - 1;
   const searchShortcut = isMacOS() ? '⌘K' : 'Ctrl+K';
@@ -114,85 +145,98 @@ export const EmptyDesktop: React.FC = React.memo(() => {
             <FolderOpen size={18} weight="duotone" aria-hidden="true" />
             {t('workbench:emptyDesktop.actionFiles')}
           </button>
+          {restoreAvailable && onRestoreSession ? (
+            <button
+              type="button"
+              className="wb-empty-cta wb-empty-cta-secondary"
+              data-testid="wb-empty-restore-session"
+              onClick={onRestoreSession}
+            >
+              <ClockCounterClockwise size={18} weight="duotone" aria-hidden="true" />
+              {t('workbench:emptyDesktop.actionRestoreSession')}
+            </button>
+          ) : null}
         </div>
 
-        <div
-          className="wb-empty-tour wb-empty-rise wb-empty-rise-5"
-          role="region"
-          aria-label={t('workbench:emptyDesktop.tourTitle')}
-          data-testid="wb-empty-tour"
-          data-tour-step={stepId}
-        >
-          <div className="wb-empty-tour-head">
-            <span className="wb-empty-tour-icon" aria-hidden="true">
-              {TOUR_ICONS[stepId]}
-            </span>
-            <span className="wb-empty-tour-title">
-              {t('workbench:emptyDesktop.tourTitle')}
-            </span>
-            <span className="wb-empty-tour-progress" data-testid="wb-empty-tour-progress">
-              {t('workbench:emptyDesktop.tourStep', {
-                current: stepIndex + 1,
-                total: TOUR_STEP_IDS.length,
-              })}
-            </span>
-          </div>
+        {tourVisible ? (
+          <div
+            className="wb-empty-tour wb-empty-rise wb-empty-rise-5"
+            role="region"
+            aria-label={t('workbench:emptyDesktop.tourTitle')}
+            data-testid="wb-empty-tour"
+            data-tour-step={stepId}
+          >
+            <div className="wb-empty-tour-head">
+              <span className="wb-empty-tour-icon" aria-hidden="true">
+                {TOUR_ICONS[stepId]}
+              </span>
+              <span className="wb-empty-tour-title">
+                {t('workbench:emptyDesktop.tourTitle')}
+              </span>
+              <span className="wb-empty-tour-progress" data-testid="wb-empty-tour-progress">
+                {t('workbench:emptyDesktop.tourStep', {
+                  current: stepIndex + 1,
+                  total: TOUR_STEP_IDS.length,
+                })}
+              </span>
+            </div>
 
-          <div className="wb-empty-tour-body">
-            <h3 className="wb-empty-tour-step-title">
-              {t(`workbench:emptyDesktop.tourSteps.${stepId}.title`)}
-            </h3>
-            <p className="wb-empty-tour-step-desc">
-              {stepId === 'search'
-                ? t('workbench:emptyDesktop.tourSteps.search.body', { shortcut: searchShortcut })
-                : t(`workbench:emptyDesktop.tourSteps.${stepId}.body`)}
-            </p>
-            {stepId === 'search' ? (
-              <p className="wb-empty-tour-shortcut" data-testid="wb-empty-tour-shortcut">
-                <kbd className="wb-empty-kbd">{searchShortcut}</kbd>
+            <div className="wb-empty-tour-body">
+              <h3 className="wb-empty-tour-step-title">
+                {t(`workbench:emptyDesktop.tourSteps.${stepId}.title`)}
+              </h3>
+              <p className="wb-empty-tour-step-desc">
+                {stepId === 'search'
+                  ? t('workbench:emptyDesktop.tourSteps.search.body', { shortcut: searchShortcut })
+                  : t(`workbench:emptyDesktop.tourSteps.${stepId}.body`)}
               </p>
-            ) : null}
-          </div>
+              {stepId === 'search' ? (
+                <p className="wb-empty-tour-shortcut" data-testid="wb-empty-tour-shortcut">
+                  <kbd className="wb-empty-kbd">{searchShortcut}</kbd>
+                </p>
+              ) : null}
+            </div>
 
-          <div className="wb-empty-tour-dots" aria-hidden="true">
-            {TOUR_STEP_IDS.map((id, index) => (
-              <span
-                key={id}
-                className="wb-empty-tour-dot"
-                data-active={index === stepIndex ? 'true' : undefined}
-              />
-            ))}
-          </div>
+            <div className="wb-empty-tour-dots" aria-hidden="true">
+              {TOUR_STEP_IDS.map((id, index) => (
+                <span
+                  key={id}
+                  className="wb-empty-tour-dot"
+                  data-active={index === stepIndex ? 'true' : undefined}
+                />
+              ))}
+            </div>
 
-          <div className="wb-empty-tour-actions">
-            <button
-              type="button"
-              className="wb-empty-tour-btn wb-empty-tour-btn-ghost"
-              data-testid="wb-empty-tour-skip"
-              onClick={skipSession}
-            >
-              {t('workbench:emptyDesktop.tourSkip')}
-            </button>
-            <button
-              type="button"
-              className="wb-empty-tour-btn wb-empty-tour-btn-ghost"
-              data-testid="wb-empty-tour-dont-show"
-              onClick={dismissForever}
-            >
-              {t('workbench:emptyDesktop.tourDontShow')}
-            </button>
-            <button
-              type="button"
-              className="wb-empty-tour-btn wb-empty-tour-btn-primary"
-              data-testid="wb-empty-tour-next"
-              onClick={goNext}
-            >
-              {isLast
-                ? t('workbench:emptyDesktop.tourDone')
-                : t('workbench:emptyDesktop.tourNext')}
-            </button>
+            <div className="wb-empty-tour-actions">
+              <button
+                type="button"
+                className="wb-empty-tour-btn wb-empty-tour-btn-ghost"
+                data-testid="wb-empty-tour-skip"
+                onClick={skipSession}
+              >
+                {t('workbench:emptyDesktop.tourSkip')}
+              </button>
+              <button
+                type="button"
+                className="wb-empty-tour-btn wb-empty-tour-btn-ghost"
+                data-testid="wb-empty-tour-dont-show"
+                onClick={dismissForever}
+              >
+                {t('workbench:emptyDesktop.tourDontShow')}
+              </button>
+              <button
+                type="button"
+                className="wb-empty-tour-btn wb-empty-tour-btn-primary"
+                data-testid="wb-empty-tour-next"
+                onClick={goNext}
+              >
+                {isLast
+                  ? t('workbench:emptyDesktop.tourDone')
+                  : t('workbench:emptyDesktop.tourNext')}
+              </button>
+            </div>
           </div>
-        </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/features/workbench/components/ExposeOverlay.tsx
+++ b/src/features/workbench/components/ExposeOverlay.tsx
@@ -178,6 +178,26 @@ function clearOrphanedExposeTransforms() {
     .forEach((el) => el.removeAttribute('data-expose-dimmed'));
 }
 
+/**
+ * 俯瞰期间把真实窗口层整体设为 inert + aria-hidden：
+ * 缩略窗只是「被 transform 缩小的真实 DOM」，读屏会把背后每个窗口的完整内容
+ * 都念一遍；命中层（role=dialog）才是本会话唯一的可交互 / 可朗读界面。
+ * 直接操作 DOM（与本组件的 transform 注入同一路数），避免 WorkbenchDesktop
+ * 因俯瞰开合而整树重渲染。
+ */
+function setWindowLayerInert(inert: boolean): void {
+  if (typeof document === 'undefined') return;
+  document.querySelectorAll<HTMLElement>('[data-wb-window-layer]').forEach((layer) => {
+    if (inert) {
+      layer.setAttribute('inert', '');
+      layer.setAttribute('aria-hidden', 'true');
+    } else {
+      layer.removeAttribute('inert');
+      layer.removeAttribute('aria-hidden');
+    }
+  });
+}
+
 function parseCssDurationMs(raw: string): number | null {
   const v = raw.trim();
   if (!v) return null;
@@ -462,6 +482,7 @@ const ExposeOverlayComponent: React.FC = () => {
       exitTimerRef.current = null;
     }
     setRendered(true);
+    setWindowLayerInert(true);
 
     // App Exposé（P2）：exposeAppTypeId 非 null 时只俯瞰该应用的窗口。
     // 最小化窗口两种模式统一排除：macOS App Exposé 会显示最小化窗口，
@@ -595,6 +616,9 @@ const ExposeOverlayComponent: React.FC = () => {
     if (exposeOpen || !rendered) return;
     setPhase('closing');
     setHoveredId(null);
+    // 退场即解除窗口层 inert：飞回途中窗口就该重新可聚焦（handlePick 随后
+    // 会把焦点落回目标窗壳），不能等退场计时器
+    setWindowLayerInert(false);
     // 退出即开始把非目标应用窗口淡回（transition 由 CSS 提供）
     clearDimmed();
     restoreAll(true);
@@ -627,6 +651,7 @@ const ExposeOverlayComponent: React.FC = () => {
     restoreAll(false);
     for (const id of [...restoreTimersRef.current.keys()]) finishPendingRestore(id);
     clearDimmed();
+    setWindowLayerInert(false);
     clearOrphanedExposeTransforms();
     releaseHeavyPause();
     if (dissolveTimerRef.current) clearTimeout(dissolveTimerRef.current);

--- a/src/features/workbench/components/ImmersiveHint.css
+++ b/src/features/workbench/components/ImmersiveHint.css
@@ -1,0 +1,100 @@
+/**
+ * ImmersiveHint 专属样式（全部 wb-immersive- 前缀，不重定义契约类）
+ * ---------------------------------------------------------------------------
+ * - 顶缘胶囊提示：玻璃底 + 弱边，压在沉浸窗口之上（--wb-z-hud）；
+ * - 淡出后 pointer-events:none，绝不挡住窗口顶部内容；
+ * - 动画仅 transform / opacity；reduced-motion 与 minimal 材质档下时长归零。
+ */
+
+.wb-immersive-hint {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  z-index: var(--wb-z-hud, 9800);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: min(92vw, 560px);
+  padding: 7px 8px 7px 14px;
+  border: 1px solid var(--wb-glass-border);
+  border-radius: 999px;
+  background-color: var(--wb-glass-bg-strong);
+  -webkit-backdrop-filter: var(--wb-glass-blur-strong, var(--wb-glass-blur));
+  backdrop-filter: var(--wb-glass-blur-strong, var(--wb-glass-blur));
+  box-shadow: var(--wb-glass-edge), var(--wb-dock-shadow);
+  color: var(--text-primary, hsl(var(--foreground)));
+  font-size: 12.5px;
+  line-height: 1.3;
+  white-space: nowrap;
+  transition:
+    opacity var(--wb-motion-gentle, 320ms) var(--wb-ease-out, ease-out),
+    transform var(--wb-motion-gentle, 320ms) var(--wb-ease-out, ease-out);
+}
+
+.wb-immersive-hint[data-visible='true'] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  pointer-events: auto;
+}
+
+.wb-immersive-hint[data-visible='false'] {
+  opacity: 0;
+  transform: translate(-50%, -12px);
+  pointer-events: none;
+}
+
+.wb-immersive-hint-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.wb-immersive-hint-exit {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: none;
+  min-height: 28px;
+  padding: 4px 12px;
+  border: 1px solid color-mix(in hsl, hsl(var(--primary)) 42%, hsl(var(--border)) 58%);
+  border-radius: 999px;
+  background: color-mix(in hsl, hsl(var(--primary)) 16%, transparent 84%);
+  color: inherit;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.wb-immersive-hint-exit:hover {
+  background: color-mix(in hsl, hsl(var(--primary)) 26%, transparent 74%);
+}
+
+.wb-immersive-hint-exit:focus-visible {
+  outline: 2px solid hsl(var(--primary) / 70%);
+  outline-offset: 1px;
+}
+
+/* 触控：退出按钮给足 44px 命中高度，提示条整体加大 */
+@media (pointer: coarse) {
+  .wb-immersive-hint {
+    padding: 8px 8px 8px 16px;
+    font-size: 14px;
+    white-space: normal;
+  }
+
+  .wb-immersive-hint-exit {
+    min-height: 44px;
+    padding: 8px 16px;
+    font-size: 14px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wb-immersive-hint {
+    transition-duration: 0ms;
+  }
+}
+
+:root[data-wb-material='minimal'] .wb-immersive-hint {
+  transition-duration: 0ms;
+}

--- a/src/features/workbench/components/ImmersiveHint.tsx
+++ b/src/features/workbench/components/ImmersiveHint.tsx
@@ -1,0 +1,94 @@
+/**
+ * ImmersiveHint — 沉浸模式（绿灯）进入时的可见退出指引
+ * ---------------------------------------------------------------------------
+ * 沉浸模式会把菜单栏与 Dock 一起收起，此时「怎么退出」只剩 Esc 这条隐性知识，
+ * 触屏设备上甚至无键盘可按。本组件在进入沉浸时于顶缘弹出一条提示条：
+ * - 文案给出 Esc（细指针）/ 顶栏绿灯（触控）两条退出路径；
+ * - 提示条自带「退出沉浸」按钮，读屏与触屏用户不依赖键盘也能退出；
+ * - HINT_VISIBLE_MS 后自动淡出（不长期占顶），指针回到顶缘（菜单栏 reveal
+ *   热区）时重新出现，与 StatusBar 的 autohide 心智一致。
+ *
+ * 只读 core/immersiveMode 的沉浸窗口 id，不改沉浸状态机本身。
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ArrowsIn } from '@phosphor-icons/react';
+import { exitImmersive, useImmersiveWindowId } from '../core/immersiveMode';
+import './ImmersiveHint.css';
+
+/** 提示条自动淡出时间（ms） */
+export const IMMERSIVE_HINT_VISIBLE_MS = 4200;
+
+/** 顶缘 reveal 热区高度（与 StatusBar autohide 热区同量级） */
+const TOP_REVEAL_ZONE_PX = 6;
+
+function isCoarsePointer(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  try {
+    return window.matchMedia('(pointer: coarse)').matches;
+  } catch {
+    return false;
+  }
+}
+
+const ImmersiveHintComponent: React.FC = () => {
+  const { t } = useTranslation('workbench');
+  const immersiveWindowId = useImmersiveWindowId();
+  const [visible, setVisible] = useState(false);
+  const [coarse, setCoarse] = useState(false);
+
+  useEffect(() => {
+    if (!immersiveWindowId) {
+      setVisible(false);
+      return undefined;
+    }
+    setCoarse(isCoarsePointer());
+    setVisible(true);
+    const timer = window.setTimeout(() => setVisible(false), IMMERSIVE_HINT_VISIBLE_MS);
+    return () => window.clearTimeout(timer);
+  }, [immersiveWindowId]);
+
+  // 淡出后仍可召回：指针贴顶缘（菜单栏 reveal 热区）时重新显示
+  useEffect(() => {
+    if (!immersiveWindowId) return undefined;
+    const onPointerMove = (e: PointerEvent) => {
+      if (e.clientY <= TOP_REVEAL_ZONE_PX) setVisible(true);
+    };
+    window.addEventListener('pointermove', onPointerMove, { passive: true });
+    return () => window.removeEventListener('pointermove', onPointerMove);
+  }, [immersiveWindowId]);
+
+  const onExit = useCallback(() => {
+    exitImmersive();
+  }, []);
+
+  if (!immersiveWindowId) return null;
+
+  return (
+    <div
+      className="wb-immersive-hint"
+      data-testid="wb-immersive-hint"
+      data-visible={visible ? 'true' : 'false'}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="wb-immersive-hint-text">
+        {coarse ? t('immersive.hintTouch') : t('immersive.hint')}
+      </span>
+      <button
+        type="button"
+        className="wb-immersive-hint-exit"
+        data-testid="wb-immersive-hint-exit"
+        onClick={onExit}
+      >
+        <ArrowsIn size={13} weight="bold" aria-hidden="true" />
+        {t('immersive.exit')}
+      </button>
+    </div>
+  );
+};
+
+export const ImmersiveHint = React.memo(ImmersiveHintComponent);
+ImmersiveHint.displayName = 'ImmersiveHint';
+
+export default ImmersiveHint;

--- a/src/features/workbench/components/StatusBarAppMenus.tsx
+++ b/src/features/workbench/components/StatusBarAppMenus.tsx
@@ -26,6 +26,10 @@ import { useWindowStore } from '../core/windowStore';
 import { getSortedWindows } from '../core/windowListCache';
 import { workbenchBus } from '../core/workbenchBus';
 import { useWorkbenchOverlay } from '../core/shortcuts';
+import {
+  requestCloseAnimated,
+  requestCloseAppWindowsAnimated,
+} from '../hooks/useWindowLifecycleAnim';
 import { openAppsPanel } from './appsPanelStore';
 import { ActionItem } from './DesktopContextMenu';
 import { StatusBarMenu } from './StatusBarMenu';
@@ -154,12 +158,11 @@ export const StatusBarAppMenus: React.FC<StatusBarAppMenusProps> = ({ onOpenChan
       : focusedTypeId
     : t('menubar.appName');
 
+  // 关窗一律走 requestCloseAnimated：canClose（未保存确认）+ 退场动画统一，
+  // 菜单栏不得绕过 guard 直接 store.closeWindow
   const closeAllOfApp = () => {
-    if (!focusedTypeId) return;
-    const store = useWindowStore.getState();
-    for (const win of Object.values(store.windows)) {
-      if (win.typeId === focusedTypeId) store.closeWindow(win.id);
-    }
+    if (!focusedWindowId) return;
+    void requestCloseAppWindowsAnimated(focusedWindowId);
   };
 
   return (
@@ -213,7 +216,7 @@ export const StatusBarAppMenus: React.FC<StatusBarAppMenusProps> = ({ onOpenChan
               label={t('dock.closeWindow')}
               testId="wb-menubar-app-close-window"
               onClick={runAndClose(() => {
-                if (focusedWindowId) useWindowStore.getState().closeWindow(focusedWindowId);
+                if (focusedWindowId) void requestCloseAnimated(focusedWindowId);
               })}
             />
             <ActionItem

--- a/src/features/workbench/components/StatusBarBrandMenu.tsx
+++ b/src/features/workbench/components/StatusBarBrandMenu.tsx
@@ -6,8 +6,13 @@
  */
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { GearSix, SignOut, SquaresFour } from '@phosphor-icons/react';
+import { GearSix, Keyboard, SignOut, SquaresFour } from '@phosphor-icons/react';
 import { workbenchBus } from '../core/workbenchBus';
+import {
+  WORKBENCH_SHORTCUT_DEFINITIONS,
+  formatShortcutBinding,
+  useWorkbenchOverlay,
+} from '../core/shortcuts';
 import { openAppsPanel } from './appsPanelStore';
 import { ActionItem } from './DesktopContextMenu';
 import { StatusBarMenu } from './StatusBarMenu';
@@ -18,6 +23,12 @@ export interface StatusBarBrandMenuProps {
   /** 品牌钮（定位锚 + 焦点归还目标） */
   anchorRef: React.RefObject<HTMLButtonElement | null>;
   onClose: () => void;
+}
+
+/** 速查表键位提示（平台相关，渲染时求值而非模块初始化时） */
+function cheatsheetShortcutHint(): string | undefined {
+  const def = WORKBENCH_SHORTCUT_DEFINITIONS.find((d) => d.id === 'cheatsheet');
+  return def ? formatShortcutBinding(def.binding) : undefined;
 }
 
 export const StatusBarBrandMenu: React.FC<StatusBarBrandMenuProps> = ({
@@ -47,6 +58,16 @@ export const StatusBarBrandMenu: React.FC<StatusBarBrandMenuProps> = ({
         label={t('workbench:appsPanel.title')}
         testId="wb-menubar-brand-apps"
         onClick={runAndClose(() => openAppsPanel())}
+      />
+      {/* 速查表的常驻可发现入口（`?` 快捷键之外的第二条路径） */}
+      <ActionItem
+        icon={<Keyboard size={15} weight="duotone" />}
+        label={t('workbench:desktopMenu.shortcuts')}
+        shortcut={cheatsheetShortcutHint()}
+        testId="wb-menubar-brand-shortcuts"
+        onClick={runAndClose(() =>
+          useWorkbenchOverlay.getState().openCheatsheet({ sticky: true }),
+        )}
       />
       <ActionItem
         icon={<GearSix size={15} weight="duotone" />}

--- a/src/features/workbench/components/WorkbenchDesktop.tsx
+++ b/src/features/workbench/components/WorkbenchDesktop.tsx
@@ -46,7 +46,7 @@ import {
 import { RESOURCE_APP_TYPE_IDS } from '../apps/content/typeMap';
 import { NOTES_APP_TYPE_ID } from '../apps/notes/register';
 import { normalizeSingletonAppWindows } from '../core/snapshotWindowPolicy';
-import type { SnapZone, WorkbenchWindow } from '../core/types';
+import type { SnapZone, WorkbenchSnapshotV1, WorkbenchWindow } from '../core/types';
 import { setActiveSnapZone } from '../core/snapZoneStore';
 import { WallpaperLayer, DEFAULT_WALLPAPER, type WallpaperConfig } from './WallpaperLayer';
 import { DesktopContextMenu, useDesktopGestures } from './DesktopContextMenu';
@@ -54,6 +54,7 @@ import { WallpaperManagerDialog, OPEN_WALLPAPER_MANAGER_EVENT } from './Wallpape
 import { useWallpaperCoveragePause } from '../hooks/useWallpaperCoveragePause';
 import { EmptyDesktop } from './EmptyDesktop';
 import { DesktopAgendaWidget } from './DesktopAgendaWidget';
+import { ImmersiveHint } from './ImmersiveHint';
 import { DesktopShortcutsLayer } from './DesktopShortcuts';
 import { WindowShell } from './WindowShell';
 import { SnapPreview } from './SnapPreview';
@@ -95,6 +96,8 @@ const SETTING_KEYS = {
   dockSize: 'desktop.workbenchDockSize',
   dockAutohide: 'desktop.workbenchDockAutohide',
   restoreSession: 'desktop.workbenchRestoreSession',
+  /** 桌面组件（日程小组件）显隐；缺省显示，桌面右键菜单与设置页共用该 key */
+  desktopWidgets: 'desktop.workbenchDesktopWidgets',
   devPanel: 'desktop.workbenchDevPanel',
 } as const;
 
@@ -272,7 +275,13 @@ export const WorkbenchDesktop: React.FC = () => {
   const [tileMargins, setTileMargins] = useState<TileMarginsSetting>(DEFAULT_TILE_MARGINS);
   const [dockSize, setDockSize] = useState(DOCK_SIZE_DEFAULT);
   const [dockAutohide, setDockAutohide] = useState(false);
+  const [desktopWidgets, setDesktopWidgets] = useState(true);
   const [devPanel, setDevPanel] = useState(false);
+  /**
+   * 「恢复上次桌面」次级 CTA 的可用性：仅在关闭自动恢复、且启动时确有快照的
+   * 冷启动首屏提供。不翻转 restoreSession 默认值（老用户不会突然被恢复一屏窗口）。
+   */
+  const [restorableSnapshot, setRestorableSnapshot] = useState<WorkbenchSnapshotV1 | null>(null);
   // 壁纸管理面板：入口方（桌面右键菜单 / 设置页）派发事件，这里统一打开
   const [wallpaperManagerOpen, setWallpaperManagerOpen] = useState(false);
 
@@ -301,6 +310,7 @@ export const WorkbenchDesktop: React.FC = () => {
         marginsVal,
         dockSizeVal,
         autohideVal,
+        desktopWidgetsVal,
         devPanelVal,
       ] = await Promise.all([
         readSetting(SETTING_KEYS.materialTier),
@@ -308,6 +318,7 @@ export const WorkbenchDesktop: React.FC = () => {
         readSetting(SETTING_KEYS.tileMargins),
         readSetting(SETTING_KEYS.dockSize),
         readSetting(SETTING_KEYS.dockAutohide),
+        readSetting(SETTING_KEYS.desktopWidgets),
         readSetting(SETTING_KEYS.devPanel),
       ]);
       if (cancelled) return;
@@ -321,6 +332,8 @@ export const WorkbenchDesktop: React.FC = () => {
       setTileMargins(parseJson<TileMarginsSetting>(marginsVal, DEFAULT_TILE_MARGINS));
       setDockSize(parseDockSize(dockSizeVal));
       setDockAutohide(String(autohideVal ?? '') === 'true');
+      // 桌面组件缺省显示（保持现状），只有显式 'false' 才隐藏
+      setDesktopWidgets(String(desktopWidgetsVal ?? '') !== 'false');
       // 无启动参数时强制关闭 HUD；带参时默认开（可用设置关掉）
       if (isWorkbenchDiagnosticsRequested()) {
         setDevPanel(devPanelVal == null || String(devPanelVal) === '' || String(devPanelVal) === 'true');
@@ -345,6 +358,9 @@ export const WorkbenchDesktop: React.FC = () => {
           break;
         case SETTING_KEYS.dockSize:
           setDockSize(parseDockSize(value));
+          break;
+        case SETTING_KEYS.desktopWidgets:
+          setDesktopWidgets(value !== false);
           break;
         case SETTING_KEYS.devPanel:
           setDevPanel(isWorkbenchDiagnosticsRequested() && value === true);
@@ -448,6 +464,14 @@ export const WorkbenchDesktop: React.FC = () => {
       setHydrated(true);
       // 快照恢复完成后补投运行中的长活实例（番茄钟等）
       resyncProjections();
+
+      // 未开启自动恢复时探测一次快照：有内容就在空桌面上给一个显式的
+      // 「恢复上次桌面」入口（首屏之后再读，不拖慢冷启动）
+      if (!shouldRestoreSession) {
+        const snapshot = await loadSnapshot();
+        if (disposed) return;
+        if (snapshot && snapshot.windows.length > 0) setRestorableSnapshot(snapshot);
+      }
     })();
 
     return () => {
@@ -461,6 +485,21 @@ export const WorkbenchDesktop: React.FC = () => {
       stopScheduler();
     };
   }, []);
+
+  /** 空桌面 CTA：把探测到的快照按与自动恢复完全相同的链路 hydrate 一次 */
+  const restoreLastSession = useCallback(() => {
+    const snapshot = restorableSnapshot;
+    if (!snapshot) return;
+    setRestorableSnapshot(null);
+    void (async () => {
+      const windows = await pruneSnapshotWindows(snapshot.windows);
+      useWindowStore.getState().hydrate(windows, snapshot.tilingRatios, {
+        preserveExisting: true,
+      });
+      if (snapshot.dockPinned.length > 0) setDockPinned(snapshot.dockPinned);
+      resyncProjections();
+    })();
+  }, [restorableSnapshot]);
 
   // ---- 快捷键（俯瞰 / 切换器 / 平铺全集 / 速查表）----
   useWorkbenchShortcuts({ enabled: true });
@@ -529,6 +568,10 @@ export const WorkbenchDesktop: React.FC = () => {
       // overflow-clip（非 hidden）：结构容器不可成为滚动容器，否则 WebKit 的
       // reveal-selection/caret 会在拖选文本时把整个桌面（窗口+Dock）滚出去
       className="absolute inset-0 overflow-clip"
+      // isolation:isolate：桌面内部的 --wb-z-* 刻度（Dock 9000 / 菜单栏 9050 /
+      // overlay 9500+）全部关进本根节点的 stacking context，不再与应用全局的
+      // Dialog / Toast（body 层 portal）比大小——层序表本身不动。
+      style={{ isolation: 'isolate' }}
     >
       {/* 壁纸挂在根节点（延伸到菜单栏背后），玻璃顶条才有真实背景可采样 */}
       <div className="wb-wallpaper-frame" aria-hidden="true">
@@ -549,10 +592,16 @@ export const WorkbenchDesktop: React.FC = () => {
         onKeyDown={gestures.onDesktopKeyDown}
         onDoubleClick={gestures.onDesktopDoubleClick}
       >
-        {hydrated && <DesktopAgendaWidget />}
+        {/* 桌面组件可关：关掉后窄工作区不再被 340px 日程组件挤占 */}
+        {hydrated && desktopWidgets && <DesktopAgendaWidget />}
         {/* 桌面快捷方式图标层：与资源库「桌面」视图共用 desktopStore，双向同步 */}
         {hydrated && <DesktopShortcutsLayer />}
-        {hydrated && orderedWindows.length === 0 && <EmptyDesktop />}
+        {hydrated && orderedWindows.length === 0 && (
+          <EmptyDesktop
+            restoreAvailable={restorableSnapshot !== null}
+            onRestoreSession={restoreLastSession}
+          />
+        )}
 
         {/* 窗口层：自成 stacking context（COORDINATION 裁决），内部 zIndex 与 overlay 定值互不干扰。
             层本身指针穿透（空桌面引导可点），窗口壳 / 中缝各自恢复 pointer-events */}
@@ -604,6 +653,9 @@ export const WorkbenchDesktop: React.FC = () => {
 
         <WorkbenchEventBridge />
       </div>
+
+      {/* 沉浸模式（绿灯）退出指引：菜单栏与 Dock 都收起时唯一的可见出口 */}
+      <ImmersiveHint />
 
       {/* SnapPreview 使用工作区测得的物理偏移，固定层也不会碰到顶栏。 */}
       <SnapPreview margin={tileMargin} desktopOffset={desktopOffset} />

--- a/src/features/workbench/components/__tests__/StatusBar.test.tsx
+++ b/src/features/workbench/components/__tests__/StatusBar.test.tsx
@@ -598,16 +598,20 @@ describe('StatusBar 聚焦应用菜单', () => {
     fireEvent.click(await screen.findByTestId('wb-menubar-app-new-window'));
     expect(launchSpy).toHaveBeenCalledWith({ typeId: 'todo', reason: 'api' });
 
-    // 关闭窗口 → 只关焦点窗
+    // 关闭窗口 → 只关焦点窗（走 requestCloseAnimated：先标 closing，动画收尾后才落库）
     fireEvent.click(appMenuBtn);
     fireEvent.click(await screen.findByTestId('wb-menubar-app-close-window'));
-    expect(useWindowStore.getState().windows[winB]).toBeUndefined();
+    await waitFor(() => {
+      expect(useWindowStore.getState().windows[winB]).toBeUndefined();
+    });
     expect(useWindowStore.getState().windows[winA]).toBeTruthy();
 
     // 全部关闭 → 同应用全关
     fireEvent.click(appMenuBtn);
     fireEvent.click(await screen.findByTestId('wb-menubar-app-close-all'));
-    expect(Object.keys(useWindowStore.getState().windows)).toHaveLength(0);
+    await waitFor(() => {
+      expect(Object.keys(useWindowStore.getState().windows)).toHaveLength(0);
+    });
     // 焦点窗清空后回落默认名
     await waitFor(() => {
       expect(appMenuBtn.textContent).toBe('学习桌面');

--- a/src/features/workbench/core/__tests__/shortcuts.test.ts
+++ b/src/features/workbench/core/__tests__/shortcuts.test.ts
@@ -73,8 +73,8 @@ describe('matchWorkbenchShortcut — 非 macOS（历史行为不变）', () => {
       matchWorkbenchShortcut(keydown({ key: '?', shiftKey: true, code: 'Slash' }))?.id,
     ).toBe('cheatsheet');
     expect(matchWorkbenchShortcut(keydown({ key: '?', code: 'Slash' }))?.id).toBe('cheatsheet');
-    // 布局兜底：e.key 为 '/' 但物理键是 Slash
-    expect(matchWorkbenchShortcut(keydown({ key: '/', code: 'Slash' }))?.id).toBe('cheatsheet');
+    // 单独一个 `/` 不再命中：Slash code 兜底已移除（误触修复）
+    expect(matchWorkbenchShortcut(keydown({ key: '/', code: 'Slash' }))).toBeNull();
   });
 
   it('Ctrl+Alt+Shift+E → expose-app（不带 Shift 仍是 expose）', () => {
@@ -149,7 +149,9 @@ describe('matchWorkbenchShortcut — macOS（⌘ 基底映射）', () => {
     expect(
       matchWorkbenchShortcut(keydown({ key: '?', shiftKey: true, code: 'Slash' }))?.id,
     ).toBe('cheatsheet');
-    expect(matchWorkbenchShortcut(keydown({ key: '/', code: 'Slash' }))?.id).toBe('cheatsheet');
+    expect(matchWorkbenchShortcut(keydown({ key: '?', code: 'Slash' }))?.id).toBe('cheatsheet');
+    // `/` 单键不再误触速查表
+    expect(matchWorkbenchShortcut(keydown({ key: '/', code: 'Slash' }))).toBeNull();
   });
 
   it('code 优先匹配策略保持：⌥ 产生替代字符时按 code 命中', () => {

--- a/src/features/workbench/core/immersiveMode.ts
+++ b/src/features/workbench/core/immersiveMode.ts
@@ -137,6 +137,15 @@ export function useWindowImmersive(windowId: string): boolean {
   return useImmersiveStore((s) => s.windowId === windowId);
 }
 
+/**
+ * React hook：当前沉浸窗口 id（无则 null）。
+ * 供壳层的沉浸退出提示（ImmersiveHint）订阅——Esc 是隐性知识，
+ * 进入沉浸必须给一条可见的退出指引。
+ */
+export function useImmersiveWindowId(): string | null {
+  return useImmersiveStore((s) => s.windowId);
+}
+
 /** 仅供单元测试：清空沉浸状态与监听 */
 export function resetImmersiveModeForTests(): void {
   clearImmersiveState();

--- a/src/features/workbench/core/shortcuts.ts
+++ b/src/features/workbench/core/shortcuts.ts
@@ -511,10 +511,10 @@ export function matchWorkbenchShortcut(e: KeyboardEvent): WorkbenchShortcutDefin
     if (b.code) {
       if (e.code === b.code) return def;
     } else if (b.key) {
+      // 只按 e.key 匹配：曾有的「Slash code 兜底」会让单独一个 `/` 弹出速查表
+      // （搜索框外的 `/` 是常见误触），速查表的可发现性改由桌面右键菜单 /
+      // 品牌菜单 / 设置页的入口保证。
       if (e.key === b.key) return def;
-      // `?` 类 shiftAgnostic 绑定的布局兜底：部分键盘布局未按 Shift 时
-      // e.key 为 '/'（物理 Slash 键），按 code 也算命中，速查表不失联
-      if (b.shiftAgnostic && b.key === '?' && e.code === 'Slash') return def;
     }
   }
   return null;

--- a/src/locales/en-US/workbench.json
+++ b/src/locales/en-US/workbench.json
@@ -368,6 +368,7 @@
     "hint": "Open apps from the Dock below to get started — windows can be freely arranged, tiled and compared side by side.",
     "actionsLabel": "Quick start",
     "actionFiles": "Open Files",
+    "actionRestoreSession": "Restore last desktop",
     "actionFilesDesc": "Browse notes, textbooks, and all resources",
     "actionApps": "All apps",
     "actionFlashcards": "Flashcards",
@@ -438,7 +439,15 @@
     "materialTier": "Visual material",
     "showDesktop": "Show desktop",
     "restoreWindows": "Restore windows",
+    "showWidgets": "Show desktop widgets",
+    "shortcuts": "Keyboard shortcuts",
+    "replayTour": "Replay quick tour",
     "settings": "Desktop settings…"
+  },
+  "immersive": {
+    "hint": "Immersive mode — press Esc to exit",
+    "hintTouch": "Immersive mode — tap Exit, or the green button in the window title bar",
+    "exit": "Exit immersive"
   },
   "cheatsheet": {
     "title": "Keyboard shortcuts",
@@ -621,8 +630,18 @@
       "desc": "Hides the Dock when not in use. Move the pointer to the bottom edge to reveal it."
     },
     "restoreSession": {
-      "title": "Restore last desktop on launch",
-      "desc": "On next launch, restore previously open windows and layout. Off by default for faster cold starts; desktop state is still saved so you can turn this on later."
+      "title": "Automatically restore last desktop on launch",
+      "desc": "When on, every launch reopens all of your previous windows. Off by default for faster cold starts — desktop state is still saved, and the empty desktop offers a one-off \"Restore last desktop\" button."
+    },
+    "desktopWidgets": {
+      "title": "Show desktop widgets",
+      "desc": "Show the calendar and today's agenda widget on the desktop. Turning it off frees horizontal space on narrow windows and small screens (also toggleable from the desktop context menu)."
+    },
+    "shortcuts": {
+      "title": "Keyboard shortcuts",
+      "desc": "Window management shortcuts for the Study Desktop. On the desktop, press ? or use the desktop context menu to open the cheatsheet anytime.",
+      "show": "Show all {{count}}",
+      "hide": "Hide list"
     },
     "menubarAutohide": {
       "title": "Automatically Hide Menu Bar",

--- a/src/locales/zh-CN/workbench.json
+++ b/src/locales/zh-CN/workbench.json
@@ -368,6 +368,7 @@
     "hint": "从下方 Dock 打开应用开始工作——窗口可以自由摆放、平铺与并排对比。",
     "actionsLabel": "快速开始",
     "actionFiles": "打开资源库",
+    "actionRestoreSession": "恢复上次桌面",
     "actionFilesDesc": "浏览笔记、教材与全部资源",
     "actionApps": "全部应用",
     "actionFlashcards": "闪卡",
@@ -438,7 +439,15 @@
     "materialTier": "视觉材质",
     "showDesktop": "显示桌面",
     "restoreWindows": "恢复窗口",
+    "showWidgets": "显示桌面组件",
+    "shortcuts": "键盘快捷键",
+    "replayTour": "重新查看引导",
     "settings": "桌面设置…"
+  },
+  "immersive": {
+    "hint": "已进入沉浸模式，按 Esc 退出",
+    "hintTouch": "已进入沉浸模式，点「退出沉浸」或窗口标题栏绿灯退出",
+    "exit": "退出沉浸"
   },
   "cheatsheet": {
     "title": "键盘快捷键",
@@ -621,8 +630,18 @@
       "desc": "不使用时 Dock 自动收起，指针移到屏幕底部时滑出。"
     },
     "restoreSession": {
-      "title": "启动时恢复上次桌面",
-      "desc": "下次启动学习桌面时恢复上次打开的窗口与布局。默认关闭以加快冷启动；关闭时仍会保存桌面状态，便于日后开启。"
+      "title": "启动时自动恢复上次桌面",
+      "desc": "开启后每次启动都会自动重开上次的全部窗口。默认关闭以加快冷启动——关闭时桌面状态照常保存，空桌面上的「恢复上次桌面」按钮可按需恢复一次。"
+    },
+    "desktopWidgets": {
+      "title": "显示桌面组件",
+      "desc": "在桌面上显示日历与今日日程组件。关闭后窄窗口/小屏幕可用宽度更大（桌面右键菜单也可切换）。"
+    },
+    "shortcuts": {
+      "title": "键盘快捷键",
+      "desc": "学习桌面的窗口管理快捷键清单；桌面上按 ? 或从桌面右键菜单也可随时打开速查表。",
+      "show": "查看全部 {{count}} 项",
+      "hide": "收起列表"
     },
     "menubarAutohide": {
       "title": "自动隐藏菜单栏",

--- a/tests/vitest/workbench/workbench-shell-ux.test.tsx
+++ b/tests/vitest/workbench/workbench-shell-ux.test.tsx
@@ -1,0 +1,355 @@
+/**
+ * Workbench 壳层交互修复回归测试
+ *
+ * 覆盖本轮修复的可观察契约：
+ * 1) 菜单栏关窗走 requestCloseAnimated（canClose guard 生效，不再绕过 store）
+ * 2) 单独按 `/` 不再命中速查表；`?` / Shift+/ 照常命中
+ * 3) 桌面右键菜单 / 品牌菜单可打开速查表
+ * 4) 空态与 tour 解耦：跳过 tour 后主 CTA 仍在；「重新查看引导」可复活
+ * 5) 桌面组件（日程小组件）可关；WorkbenchDesktop 根节点 isolation
+ * 6) 沉浸模式提供可见退出提示与退出按钮
+ * 7) 俯瞰打开时窗口层 inert + aria-hidden
+ * 8) 空桌面「恢复上次桌面」CTA（仅在有快照且未开自动恢复时出现）
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup, act, fireEvent, within } from '@testing-library/react';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async () => null),
+}));
+vi.mock('@/features/chat/core/session/createSessionWithDefaults', () => ({
+  createSessionWithDefaults: vi.fn(async () => ({ id: 'sess_test' })),
+}));
+vi.mock('@/features/workbench/components/WallpaperManagerDialog', () => ({
+  OPEN_WALLPAPER_MANAGER_EVENT: 'workbench:open-wallpaper-manager',
+  WallpaperManagerDialog: () => null,
+}));
+
+import { WorkbenchDesktop } from '@/features/workbench/components/WorkbenchDesktop';
+import { StatusBar } from '@/features/workbench/components/StatusBar';
+import { ImmersiveHint } from '@/features/workbench/components/ImmersiveHint';
+import { EmptyDesktop, EMPTY_DESKTOP_ONBOARDING_KEY } from '@/features/workbench/components/EmptyDesktop';
+import { setDockPinned } from '@/features/workbench/components/Dock';
+import { appRegistry } from '@/features/workbench/core/appRegistry';
+import { workbenchBus } from '@/features/workbench/core/workbenchBus';
+import { useWindowStore, resetWindowStoreForTests } from '@/features/workbench/core/windowStore';
+import {
+  matchWorkbenchShortcut,
+  useWorkbenchOverlay,
+} from '@/features/workbench/core/shortcuts';
+import {
+  enterImmersive,
+  resetImmersiveModeForTests,
+} from '@/features/workbench/core/immersiveMode';
+
+const TEST_TYPE_ID = 'shell-ux-smoke';
+const GUARDED_TYPE_ID = 'shell-ux-guarded';
+
+/** canClose 返回值由测试逐例改写；默认放行 */
+let guardAllows = true;
+const guardCalls: string[] = [];
+
+function ensureTestApps(): void {
+  if (!appRegistry.get(TEST_TYPE_ID)) {
+    appRegistry.register({
+      typeId: TEST_TYPE_ID,
+      nameKey: 'workbench:apps.files',
+      icon: null,
+      instanceMode: 'multi',
+      memoryWeight: 1,
+      defaultFrame: { w: 400, h: 300 },
+      minSize: { w: 200, h: 150 },
+      render: React.lazy(async () => ({ default: () => <div data-testid="shell-ux-app" /> })),
+    });
+  }
+  if (!appRegistry.get(GUARDED_TYPE_ID)) {
+    appRegistry.register({
+      typeId: GUARDED_TYPE_ID,
+      nameKey: 'workbench:apps.files',
+      icon: null,
+      instanceMode: 'multi',
+      memoryWeight: 1,
+      defaultFrame: { w: 400, h: 300 },
+      minSize: { w: 200, h: 150 },
+      canClose: (instanceKey?: string) => {
+        guardCalls.push(instanceKey ?? '');
+        return guardAllows;
+      },
+      render: React.lazy(async () => ({ default: () => <div data-testid="shell-ux-guarded-app" /> })),
+    });
+  }
+}
+
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent('keydown', init);
+}
+
+function getDesktopRoot(): HTMLElement {
+  const el = document.querySelector<HTMLElement>('[data-wb-desktop]');
+  if (!el) throw new Error('desktop root not mounted');
+  return el;
+}
+
+async function mountDesktop(): Promise<HTMLElement> {
+  render(<WorkbenchDesktop />);
+  await waitFor(() => {
+    expect(document.querySelector('.wb-empty-desktop')).toBeTruthy();
+  });
+  return getDesktopRoot();
+}
+
+function openDesktopMenu(root: HTMLElement): HTMLElement {
+  fireEvent.contextMenu(root, { clientX: 120, clientY: 140 });
+  const menu = document.querySelector<HTMLElement>('[data-wb-desk-menu]');
+  if (!menu) throw new Error('desktop context menu did not open');
+  return menu;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  guardAllows = true;
+  guardCalls.length = 0;
+  resetWindowStoreForTests();
+  resetImmersiveModeForTests();
+  useWorkbenchOverlay.getState().closeCheatsheet();
+  setDockPinned([]);
+  workbenchBus.setEnabled(true);
+  ensureTestApps();
+});
+
+afterEach(() => {
+  cleanup();
+  workbenchBus.setEnabled(false);
+  resetImmersiveModeForTests();
+});
+
+// ---------------------------------------------------------------------------
+// 1) 菜单栏关窗统一走 requestCloseAnimated
+// ---------------------------------------------------------------------------
+
+describe('菜单栏关窗走 close guard', () => {
+  it('「关闭窗口」被 canClose 拒绝时窗口留下；放行时才移除', async () => {
+    render(<StatusBar />);
+    let winId = '';
+    act(() => {
+      winId = useWindowStore.getState().openWindow({
+        typeId: GUARDED_TYPE_ID,
+        instanceKey: 'guarded-1',
+      });
+    });
+
+    guardAllows = false;
+    fireEvent.click(screen.getByTestId('wb-menubar-appmenu'));
+    fireEvent.click(await screen.findByTestId('wb-menubar-app-close-window'));
+    await waitFor(() => {
+      expect(guardCalls).toContain('guarded-1');
+    });
+    // guard 拒绝 → 既不进 closing 相位也不落库删除
+    expect(useWindowStore.getState().windows[winId]).toBeTruthy();
+    expect(useWindowStore.getState().transientPhases?.[winId]).not.toBe('closing');
+
+    guardAllows = true;
+    fireEvent.click(screen.getByTestId('wb-menubar-appmenu'));
+    fireEvent.click(await screen.findByTestId('wb-menubar-app-close-window'));
+    await waitFor(() => {
+      expect(useWindowStore.getState().windows[winId]).toBeUndefined();
+    });
+  });
+
+  it('「全部关闭」逐窗过 guard：被拒的窗口全部留在桌面上', async () => {
+    render(<StatusBar />);
+    act(() => {
+      useWindowStore.getState().openWindow({ typeId: GUARDED_TYPE_ID, instanceKey: 'g-a' });
+      useWindowStore.getState().openWindow({ typeId: GUARDED_TYPE_ID, instanceKey: 'g-b' });
+    });
+
+    guardAllows = false;
+    fireEvent.click(screen.getByTestId('wb-menubar-appmenu'));
+    fireEvent.click(await screen.findByTestId('wb-menubar-app-close-all'));
+
+    await waitFor(() => {
+      expect(guardCalls.sort()).toEqual(['g-a', 'g-b']);
+    });
+    expect(Object.keys(useWindowStore.getState().windows)).toHaveLength(2);
+
+    guardAllows = true;
+    fireEvent.click(screen.getByTestId('wb-menubar-appmenu'));
+    fireEvent.click(await screen.findByTestId('wb-menubar-app-close-all'));
+    await waitFor(() => {
+      expect(Object.keys(useWindowStore.getState().windows)).toHaveLength(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2/3) 速查表：`/` 不再误触 + 菜单入口
+// ---------------------------------------------------------------------------
+
+describe('速查表可发现性', () => {
+  it('单独 `/` 不命中任何快捷键；`?` 与 Shift+/ 仍命中速查表', () => {
+    expect(matchWorkbenchShortcut(keydown({ key: '/', code: 'Slash' }))).toBeNull();
+    expect(matchWorkbenchShortcut(keydown({ key: '/', code: 'Slash', shiftKey: true }))).toBeNull();
+    expect(matchWorkbenchShortcut(keydown({ key: '?', code: 'Slash' }))?.id).toBe('cheatsheet');
+    expect(
+      matchWorkbenchShortcut(keydown({ key: '?', code: 'Slash', shiftKey: true }))?.id,
+    ).toBe('cheatsheet');
+  });
+
+  it('桌面右键菜单「键盘快捷键」打开速查表', async () => {
+    const root = await mountDesktop();
+    const menu = openDesktopMenu(root);
+    fireEvent.click(within(menu).getByTestId('wb-desk-menu-shortcuts'));
+
+    expect(useWorkbenchOverlay.getState().cheatsheetOpen).toBe(true);
+    await waitFor(() => {
+      expect(document.querySelector('[data-wb-desk-menu]')).toBeNull();
+    });
+  });
+
+  it('品牌菜单「键盘快捷键」打开速查表', async () => {
+    render(<StatusBar />);
+    fireEvent.click(screen.getByTestId('wb-menubar-brand'));
+    fireEvent.click(await screen.findByTestId('wb-menubar-brand-shortcuts'));
+    expect(useWorkbenchOverlay.getState().cheatsheetOpen).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4) 空态与引导解耦
+// ---------------------------------------------------------------------------
+
+describe('空桌面与引导解耦', () => {
+  it('跳过 tour 后主 CTA 仍在；「重新查看引导」可复活 tour', () => {
+    render(<EmptyDesktop />);
+    expect(screen.getByTestId('wb-empty-tour')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('wb-empty-tour-skip'));
+    expect(screen.queryByTestId('wb-empty-tour')).toBeNull();
+    // 主 CTA 不随 tour 一起消失
+    expect(screen.getByText('打开资源库')).toBeTruthy();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('workbench:empty-desktop-replay-tour'));
+    });
+    expect(screen.getByTestId('wb-empty-tour')).toBeTruthy();
+  });
+
+  it('「不再显示」永久消隐 tour，主 CTA 与卡片仍渲染；重播清掉持久标记', () => {
+    render(<EmptyDesktop />);
+    fireEvent.click(screen.getByTestId('wb-empty-tour-dont-show'));
+
+    expect(localStorage.getItem(EMPTY_DESKTOP_ONBOARDING_KEY)).toBe('1');
+    expect(screen.queryByTestId('wb-empty-tour')).toBeNull();
+    expect(screen.getByText('打开资源库')).toBeTruthy();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('workbench:empty-desktop-replay-tour'));
+    });
+    expect(localStorage.getItem(EMPTY_DESKTOP_ONBOARDING_KEY)).toBeNull();
+    expect(screen.getByTestId('wb-empty-tour')).toBeTruthy();
+  });
+
+  it('「恢复上次桌面」次级 CTA 仅在有快照时出现', () => {
+    const onRestore = vi.fn();
+    const { rerender } = render(<EmptyDesktop />);
+    expect(screen.queryByTestId('wb-empty-restore-session')).toBeNull();
+
+    rerender(<EmptyDesktop restoreAvailable onRestoreSession={onRestore} />);
+    fireEvent.click(screen.getByTestId('wb-empty-restore-session'));
+    expect(onRestore).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5/6) 根节点 isolation + 桌面组件可关
+// ---------------------------------------------------------------------------
+
+describe('桌面根节点与桌面组件', () => {
+  it('根节点自成 stacking context（isolation: isolate）', async () => {
+    await mountDesktop();
+    const rootEl = document.querySelector<HTMLElement>('[data-wb-workbench-root]');
+    expect(rootEl).toBeTruthy();
+    expect(rootEl!.style.isolation).toBe('isolate');
+  });
+
+  it('桌面右键菜单可关掉桌面组件，并写入 desktop.* 设置通道', async () => {
+    const root = await mountDesktop();
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="wb-agenda-widget"]')).toBeTruthy();
+    });
+
+    const menu = openDesktopMenu(root);
+    const toggle = within(menu).getByTestId('wb-desk-menu-widgets');
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="wb-agenda-widget"]')).toBeNull();
+    });
+    expect(localStorage.getItem('desktop.workbenchDesktopWidgets')).toBe('false');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7) 沉浸模式可见退出
+// ---------------------------------------------------------------------------
+
+describe('沉浸模式退出提示', () => {
+  it('非沉浸时不渲染；进入沉浸后给出提示与退出按钮，点击即退出', async () => {
+    let winId = '';
+    act(() => {
+      winId = useWindowStore.getState().openWindow({ typeId: TEST_TYPE_ID });
+    });
+
+    render(<ImmersiveHint />);
+    expect(screen.queryByTestId('wb-immersive-hint')).toBeNull();
+
+    act(() => {
+      enterImmersive(winId);
+    });
+
+    const hint = await screen.findByTestId('wb-immersive-hint');
+    expect(hint.getAttribute('data-visible')).toBe('true');
+    expect(hint.getAttribute('role')).toBe('status');
+    expect(hint.textContent).toContain('Esc');
+
+    fireEvent.click(screen.getByTestId('wb-immersive-hint-exit'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('wb-immersive-hint')).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8) 俯瞰打开时窗口层 inert
+// ---------------------------------------------------------------------------
+
+describe('俯瞰期间窗口层 inert', () => {
+  it('Exposé 打开 → 窗口层 inert + aria-hidden；关闭后复原', async () => {
+    await mountDesktop();
+    act(() => {
+      workbenchBus.launch({ typeId: TEST_TYPE_ID, instanceKey: 'expose-1', reason: 'api' });
+    });
+
+    const layer = document.querySelector<HTMLElement>('[data-wb-window-layer]');
+    expect(layer).toBeTruthy();
+    expect(layer!.hasAttribute('inert')).toBe(false);
+
+    act(() => {
+      useWorkbenchOverlay.getState().openExpose();
+    });
+    await waitFor(() => {
+      expect(layer!.hasAttribute('inert')).toBe(true);
+    });
+    expect(layer!.getAttribute('aria-hidden')).toBe('true');
+
+    act(() => {
+      useWorkbenchOverlay.getState().closeExpose();
+    });
+    await waitFor(() => {
+      expect(layer!.hasAttribute('inert')).toBe(false);
+    });
+    expect(layer!.hasAttribute('aria-hidden')).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

修复 Workbench 壳层交互：顶栏关窗绕过未保存拦截、快捷键速查表不可发现、`/` 误触打开速查表、沉浸模式没有可见出口、空态跳过 tour 后主 CTA 消失。

### Changes
- 菜单栏关窗统一走 `requestCloseAnimated` / `requestCloseAppWindowsAnimated`，不再直接 `store.closeWindow`
- 删除 `?` 绑定的 Slash code 兜底：单独按 `/` 不再弹出速查表
- 速查表入口：桌面右键、品牌菜单、设置页 `listWorkbenchShortcuts()` 清单
- `ImmersiveHint`：沉浸模式可见退出指引与按钮（触屏另给顶栏提示）
- EmptyDesktop 与 tour 解耦，主 CTA 常在；桌面组件可关，避免窄屏被日程挤占
- Exposé 期间窗口层 `inert` / `aria-hidden`
- 窄屏/触控：空态与菜单命中高度 ≥ 44px

### How to test
- 未保存窗口：菜单「窗口 ▸ 关闭」应被拦截（与 ⌘W 一致）
- 按 `/` 不应打开速查表；`?` 或菜单入口应打开
- 进入沉浸后应能看见退出控件，Esc 仍可用
- 空桌面点「跳过」后主 CTA 仍在
- 窄屏关闭日程小组件后桌面不再被占满

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

### 重叠说明
与 `cursor/design-system-tokens-dark-shadow-font-scale-ecb3` 无文件重叠。壳层修复以本分支为准。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92ea5725-a196-4c8d-97b6-cf85cfe2ecb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92ea5725-a196-4c8d-97b6-cf85cfe2ecb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

