### PR TITLE
fix(ui): 补齐缺失 token、暗色阴影、字号缩放与命令面板 a11y

### DIFF
--- a/eslint-rules/no-arbitrary-font-size.js
+++ b/eslint-rules/no-arbitrary-font-size.js
@@ -1,0 +1,63 @@
+/**
+ * ESLint 自定义规则：禁止 Tailwind 硬编码字号（text-[13px] 等）
+ *
+ * 背景：设置 → 外观 → 界面字号写的是 `--font-size-scale`
+ * （src/config/fontConfig.ts → applyFontSizeToDocument），所有字号 token
+ * （--font-size-2xs / xs / sm / base / md / lg / ui / --m-text-caption）都是
+ * `calc(Npx * var(--font-size-scale))`。而 `text-[13px]` 是编译期常量，
+ * 完全不参与缩放——用户把字号调到 130% 时，按钮标签仍是 13px，
+ * 这正是"字号缩放没闭环"的根因。
+ *
+ * 允许的写法：
+ *   - token 类：text-ui / text-sm / text-2xs / text-caption ...
+ *   - 显式走 token 的任意值：text-[length:var(--font-size-ui)]
+ *
+ * @example
+ * // ❌ 错误
+ * <span className="text-[13px]" />
+ * // ✅ 正确
+ * <span className="text-ui" />
+ */
+
+/** 匹配 text-[13px] / md:text-[0.8rem] / data-[state=open]:text-[2em]，
+ *  放过 text-[length:var(--font-size-ui)] 这类 token 引用 */
+const ARBITRARY_FONT_SIZE = /(?<![a-zA-Z0-9])text-\[(?:length:)?\d*\.?\d+(?:px|rem|em|pt)\]/;
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: '禁止 text-[Npx] 硬编码字号，必须使用参与 --font-size-scale 的字号 token 类',
+      recommended: true,
+    },
+    messages: {
+      noArbitraryFontSize:
+        '❌ 禁止硬编码字号 "{{value}}"。它不参与设置里的界面字号缩放（--font-size-scale）。'
+        + '请改用字号 token 类（text-2xs/xs/sm/base/md/lg/ui/caption，见 tailwind.config.js fontSize），'
+        + '确需任意值时写 text-[length:var(--font-size-*)]。',
+    },
+    schema: [],
+  },
+  create(context) {
+    const report = (node, value) => {
+      const match = value.match(ARBITRARY_FONT_SIZE);
+      if (!match) return;
+      context.report({
+        node,
+        messageId: 'noArbitraryFontSize',
+        data: { value: match[0].trim() },
+      });
+    };
+
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string') report(node, node.value);
+      },
+      TemplateElement(node) {
+        const raw = node.value?.cooked ?? node.value?.raw ?? '';
+        if (raw) report(node, raw);
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import tseslint from 'typescript-eslint';
 import boundaries from 'eslint-plugin-boundaries';
 import reactHooks from 'eslint-plugin-react-hooks';
 import noNativeButton from './eslint-rules/no-native-button.js';
+import noArbitraryFontSize from './eslint-rules/no-arbitrary-font-size.js';
 
 export default tseslint.config(
   // 基础 JS 推荐配置
@@ -22,7 +23,8 @@ export default tseslint.config(
     plugins: {
       'ds-components': {
         rules: {
-          'no-native-button': noNativeButton
+          'no-native-button': noNativeButton,
+          'no-arbitrary-font-size': noArbitraryFontSize
         }
       },
       'react-hooks': reactHooks
@@ -105,6 +107,11 @@ export default tseslint.config(
       // 6. 禁止使用原生 <button> 元素 - 必须使用 DsButton（设为 warn 便于逐步修复）
       'ds-components/no-native-button': 'warn',
 
+      // 6.1 禁止 text-[Npx] 硬编码字号（不参与 --font-size-scale 缩放）。
+      // 全仓约 950 处历史欠账，先 warn；共享 UI 基元目录（src/components/ui/**）
+      // 已清零，在下方单独升为 error，防止按钮/对话框配方再退化。
+      'ds-components/no-arbitrary-font-size': 'warn',
+
       // 禁用与 TypeScript 不兼容的规则（TypeScript 已处理）
       'no-undef': 'off',
       'no-unused-vars': 'off',
@@ -134,6 +141,15 @@ export default tseslint.config(
     rules: {
       'no-restricted-imports': 'off',
       'ds-components/no-native-button': 'off'
+    }
+  },
+
+  // 共享 UI 基元（按钮/对话框/侧边栏配方）：字号必须走 token 类，
+  // 这里是字号缩放闭环的上游，退化一次就会扩散到全部消费方。
+  {
+    files: ['src/components/ui/**/*.{ts,tsx}'],
+    rules: {
+      'ds-components/no-arbitrary-font-size': 'error'
     }
   },
 

--- a/src/command-palette/CommandPalette.tsx
+++ b/src/command-palette/CommandPalette.tsx
@@ -6,6 +6,7 @@
 import React, {
   useState,
   useEffect,
+  useId,
   useRef,
   useCallback,
   useMemo,
@@ -56,6 +57,21 @@ import './styles/command-palette.css';
 
 /** 资源命令 id 前缀（不进入命令注册表，仅在面板内即时构造） */
 const RESOURCE_COMMAND_PREFIX = '__resource.';
+
+/**
+ * 面板内可聚焦控件选择器。
+ *
+ * 用于 Tab 焦点环：面板是 aria-modal 对话框，焦点不能逃到背景页，
+ * 但必须能在面板内部的搜索框 / 模式按钮 / 收藏按钮 / 关闭按钮之间流转。
+ */
+const PALETTE_FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
 
 /** DSTU 资源类型 → 图标 */
 const RESOURCE_TYPE_ICONS: Partial<Record<DstuNodeType, Icon>> = {
@@ -125,6 +141,12 @@ export function CommandPalette() {
     sessionSearchOnly,
   } = useCommandPalette();
   
+  // combobox / listbox / option 之间用稳定 id 关联（aria-controls、aria-activedescendant）
+  const baseId = useId();
+  const listboxId = `${baseId}-listbox`;
+  const optionId = useCallback((index: number) => `${baseId}-option-${index}`, [baseId]);
+  const groupLabelId = useCallback((category: string) => `${baseId}-group-${category}`, [baseId]);
+
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [viewMode, setViewMode] = useState<ViewMode>('search');
@@ -254,6 +276,18 @@ export function CommandPalette() {
     }
   }, [isOpen, sessionSearchOnly]);
 
+  // 关闭后把焦点还给打开面板的那个元素，避免焦点掉回 body（读屏丢失上下文）
+  useEffect(() => {
+    if (!isOpen) return;
+    const previouslyFocused = document.activeElement;
+    const restoreTarget = previouslyFocused instanceof HTMLElement ? previouslyFocused : null;
+    return () => {
+      if (restoreTarget && document.contains(restoreTarget)) {
+        restoreTarget.focus();
+      }
+    };
+  }, [isOpen]);
+
   // Android 系统返回键 = 关闭面板（自绘 dialog 无 data-state，协调器 Radix 兜底覆盖不到）
   const closeRef = useRef(close);
   closeRef.current = close;
@@ -333,8 +367,64 @@ export function CommandPalette() {
     isKeyboardNavRef.current = false;
   }, [selectedIndex]);
   
+  /**
+   * Tab：只把焦点圈在面板内，不再一刀切吞掉。
+   *
+   * 旧实现对 Tab 无条件 preventDefault，面板内的收藏 / 模式切换 / 关闭按钮
+   * 对键盘和读屏用户完全不可达。现在只在到达焦点环两端时接管并回绕，
+   * 中间的 Tab 交给浏览器默认行为，正常走到下一个控件。
+   */
+  const handleTabKey = useCallback((e: React.KeyboardEvent) => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const focusables = Array.from(
+      container.querySelectorAll<HTMLElement>(PALETTE_FOCUSABLE_SELECTOR),
+    ).filter((el) => el.getAttribute('aria-hidden') !== 'true');
+
+    if (focusables.length === 0) {
+      e.preventDefault();
+      return;
+    }
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+    const isInside = active instanceof HTMLElement && container.contains(active);
+
+    if (e.shiftKey) {
+      if (!isInside || active === first) {
+        e.preventDefault();
+        last.focus();
+      }
+      return;
+    }
+
+    if (!isInside || active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }, []);
+
   // 键盘事件处理
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // Escape / Tab 与焦点所在控件无关，始终由面板处理
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+      return;
+    }
+    if (e.key === 'Tab') {
+      handleTabKey(e);
+      return;
+    }
+
+    // 焦点已经进入面板内的按钮时，Enter/Space 属于该按钮，
+    // 不能再被「执行当前高亮命令」抢走
+    const target = e.target as HTMLElement | null;
+    const isOnInnerControl = target !== inputRef.current && !!target?.closest('button');
+    if (isOnInnerControl && e.key === 'Enter') return;
+
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault();
@@ -367,18 +457,8 @@ export function CommandPalette() {
           }
         }
         break;
-        
-      case 'Escape':
-        e.preventDefault();
-        close();
-        break;
-        
-      case 'Tab':
-        // 阻止 Tab 离开面板
-        e.preventDefault();
-        break;
     }
-  }, [flatCommands, selectedIndex, handleExecuteCommand, close, deps, t]);
+  }, [flatCommands, selectedIndex, handleExecuteCommand, close, deps, t, handleTabKey]);
   
   // 点击遮罩关闭
   const handleBackdropClick = useCallback((e: React.MouseEvent) => {
@@ -396,6 +476,11 @@ export function CommandPalette() {
   
   // 计算当前命令在扁平列表中的索引
   let currentFlatIndex = 0;
+
+  const hasResults = flatCommands.length > 0;
+  const activeOptionId = hasResults && flatCommands[selectedIndex]
+    ? optionId(selectedIndex)
+    : undefined;
   
   return (
     <div 
@@ -414,6 +499,7 @@ export function CommandPalette() {
         <div className="command-palette-search">
           {isSmallScreen && (
             <button
+              type="button"
               className="command-palette-back-btn"
               onClick={close}
               aria-label={t('common:back')}
@@ -441,11 +527,19 @@ export function CommandPalette() {
               aria-label={sessionSearchOnly
                 ? t('command_palette:session_search_placeholder', 'Search sessions...')
                 : t('command_palette:search_placeholder')}
+              // 读屏契约：搜索框是 combobox，结果列表是它控制的 listbox，
+              // 高亮项通过 aria-activedescendant 播报（焦点始终留在输入框）
+              role="combobox"
+              aria-autocomplete="list"
+              aria-controls={listboxId}
+              aria-expanded={hasResults}
+              aria-activedescendant={activeOptionId}
             />
           </div>
           {/* 模式切换按钮 */}
           {!sessionSearchOnly ? <div className="command-palette-mode-buttons">
             <button
+              type="button"
               className={cn(
                 'command-palette-mode-btn',
                 viewMode === 'recent' && 'command-palette-mode-btn-active'
@@ -455,10 +549,13 @@ export function CommandPalette() {
                 setSelectedIndex(0);
               }}
               title={t('command_palette:mode_recent')}
+              aria-label={t('command_palette:mode_recent')}
+              aria-pressed={viewMode === 'recent'}
             >
               <Clock size={16} />
             </button>
             <button
+              type="button"
               className={cn(
                 'command-palette-mode-btn',
                 viewMode === 'favorites' && 'command-palette-mode-btn-active'
@@ -468,12 +565,15 @@ export function CommandPalette() {
                 setSelectedIndex(0);
               }}
               title={t('command_palette:mode_favorites')}
+              aria-label={t('command_palette:mode_favorites')}
+              aria-pressed={viewMode === 'favorites'}
             >
               <Star size={16} />
             </button>
           </div> : null}
           {!isSmallScreen && (
             <button
+              type="button"
               className="command-palette-close-btn"
               onClick={close}
               aria-label={t('common:close')}
@@ -488,7 +588,11 @@ export function CommandPalette() {
           className="command-palette-scroll-area"
           viewportRef={listRef}
           viewportClassName="command-palette-list"
-          viewportProps={{ role: 'listbox' }}
+          viewportProps={{
+            role: 'listbox',
+            id: listboxId,
+            'aria-label': t('command_palette:results_label', 'Command results'),
+          } as React.HTMLAttributes<HTMLDivElement>}
           hideTrackWhenIdle={true}
           trackOffsetTop={4}
           trackOffsetBottom={4}
@@ -523,8 +627,13 @@ export function CommandPalette() {
               }
 
               return (
-                <div key={category} className="command-palette-group">
-                  <div className="command-palette-group-label">
+                <div
+                  key={category}
+                  className="command-palette-group"
+                  role="group"
+                  aria-labelledby={groupLabelId(category)}
+                >
+                  <div className="command-palette-group-label" id={groupLabelId(category)}>
                     {categoryLabel}
                   </div>
                   {commands.map((command) => {
@@ -537,6 +646,7 @@ export function CommandPalette() {
                     return (
                       <div
                         key={command.id}
+                        id={optionId(flatIndex)}
                         data-index={flatIndex}
                         className={cn(
                           'command-palette-item',
@@ -563,6 +673,7 @@ export function CommandPalette() {
                         {/* 收藏按钮（资源直达项为动态结果，不支持收藏） */}
                         {!isResource && (
                           <button
+                            type="button"
                             className={cn(
                               'command-palette-item-favorite',
                               commandFavorites.isFavorite(command.id) && 'command-palette-item-favorite-active'
@@ -572,6 +683,11 @@ export function CommandPalette() {
                               ? t('command_palette:unfavorite')
                               : t('command_palette:favorite')
                             }
+                            // 图标按钮：读屏可访问名 = 收藏/取消收藏 + 命令名
+                            aria-label={`${commandFavorites.isFavorite(command.id)
+                              ? t('command_palette:unfavorite')
+                              : t('command_palette:favorite')} — ${command.name}`}
+                            aria-pressed={commandFavorites.isFavorite(command.id)}
                           >
                             {commandFavorites.isFavorite(command.id) ? (
                               <Star size={14} className="fill-current" />

--- a/src/command-palette/styles/command-palette.css
+++ b/src/command-palette/styles/command-palette.css
@@ -278,8 +278,15 @@
 }
 
 .command-palette-item:hover .command-palette-item-favorite,
-.command-palette-item-selected .command-palette-item-favorite {
+.command-palette-item-selected .command-palette-item-favorite,
+/* Tab 可以走到收藏按钮：聚焦时必须显形，否则是「不可见但可聚焦」的键盘陷阱 */
+.command-palette-item-favorite:focus-visible {
   opacity: 1;
+}
+
+.command-palette-item-favorite:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 1px;
 }
 
 .command-palette-item-favorite:hover {
@@ -456,6 +463,20 @@
   .command-palette-item-description {
     max-width: 100%;
   }
+
+  /* ★ 移动视口触控规范（不依赖 pointer: coarse——390px 宽的桌面窗口/模拟器
+     同样是「移动形态」，此时指针仍是 fine，但布局已是全屏子屏）：
+     结果行与顶栏按钮都要满足 ≥44px 触控目标。 */
+  .command-palette-item {
+    min-height: 44px;
+  }
+
+  /* 收藏按钮在触屏/窄屏没有 hover 可依赖，常显 + 放大触控区 */
+  .command-palette-item-favorite {
+    opacity: 1;
+    width: 40px;
+    height: 40px;
+  }
 }
 
 @keyframes command-palette-page-in {
@@ -503,6 +524,16 @@
   .command-palette-mode-btn {
     border-radius: 9999px;
     color: hsl(var(--shell-navigation-muted, var(--muted-foreground)));
+  }
+
+  /* 顶栏触控目标 ≥44px：与 (pointer: coarse) 分支互补，
+     覆盖「窄视口 + fine 指针」（桌面窄窗、设备模拟器）这一档。
+     关闭/返回入口在 390px 宽下必须点得到。 */
+  .command-palette-back-btn,
+  .command-palette-close-btn,
+  .command-palette-mode-btn {
+    width: 44px;
+    height: 44px;
   }
 
   .command-palette-mode-btn-active,

--- a/src/components/style-lab/TokenInspectorTab.tsx
+++ b/src/components/style-lab/TokenInspectorTab.tsx
@@ -15,8 +15,10 @@ const TOKEN_GROUPS: TokenGroup[] = [
       { name: 'surface-elevated', var: '--surface-elevated', type: 'color' },
       { name: 'surface-muted', var: '--surface-muted', type: 'color' },
       { name: 'surface-overlay', var: '--surface-overlay', type: 'color' },
+      { name: 'surface-panel', var: '--surface-panel', type: 'color' },
       { name: 'surface-panel-muted', var: '--surface-panel-muted', type: 'color' },
       { name: 'surface-panel-strong', var: '--surface-panel-strong', type: 'color' },
+      { name: 'accent-primary', var: '--accent-primary', type: 'color' },
     ],
   },
   {
@@ -83,6 +85,7 @@ const TOKEN_GROUPS: TokenGroup[] = [
     title: 'Button Tonal / Outline / Plain',
     tokens: [
       { name: 'button-tonal-bg', var: '--button-tonal-bg', type: 'color' },
+      { name: 'button-secondary-surface', var: '--button-secondary-surface', type: 'color' },
       { name: 'button-tonal-hover-bg', var: '--button-tonal-hover-bg', type: 'color' },
       { name: 'button-tonal-border', var: '--button-tonal-border', type: 'color' },
       { name: 'button-outline-bg', var: '--button-outline-bg', type: 'color' },

--- a/src/components/ui/DsDialog.tsx
+++ b/src/components/ui/DsDialog.tsx
@@ -284,7 +284,7 @@ export function DsDialogTitle({ className, children, ...props }: React.HTMLAttri
 
 export function DsDialogDescription({ className, children, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
   return (
-    <p className={cn('text-[13px] text-muted-foreground leading-relaxed', className)} {...props}>
+    <p className={cn('text-ui font-normal text-muted-foreground leading-relaxed', className)} {...props}>
       {children}
     </p>
   );
@@ -463,7 +463,7 @@ export function DsAlertDialog({
             <div className="flex-1 min-w-0 space-y-1.5">
               <h3 className="text-base font-semibold leading-tight text-foreground">{title}</h3>
               {description && (
-                <p className="text-[13px] text-muted-foreground leading-relaxed">{description}</p>
+                <p className="text-ui font-normal text-muted-foreground leading-relaxed">{description}</p>
               )}
             </div>
           </div>

--- a/src/components/ui/SnappySlider.tsx
+++ b/src/components/ui/SnappySlider.tsx
@@ -325,7 +325,7 @@ export const SnappySlider = React.forwardRef<HTMLDivElement, SnappySliderProps>(
           >
             {showBubble && (
               <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-0.5 whitespace-nowrap">
-                <span className={cn('text-[10px] font-medium text-muted-foreground', isOutOfBounds && 'opacity-75')}>
+                <span className={cn('text-2xs font-medium text-muted-foreground', isOutOfBounds && 'opacity-75')}>
                   {displayedBubbleValue}
                 </span>
               </div>

--- a/src/components/ui/buttonPrimitiveContract.ts
+++ b/src/components/ui/buttonPrimitiveContract.ts
@@ -21,8 +21,8 @@ export type ButtonPrimitiveSize = 'sm' | 'md' | 'lg' | 'icon' | 'default';
 // 不影响桌面鼠标 active 手感；定义见 src/styles/ui-motion.css 移动追加区）
 //
 // 字号一律走 token 类（text-ui / text-xs / text-sm → --font-size-* ，内含
-// --font-size-scale），不再写 text-[13px]：设置里的"界面字号"缩放对硬编码
-// px 无效，按钮标签会成为唯一不跟随缩放的一层。高度仍是
+// --font-size-scale），不写 Tailwind 任意值字号：设置里的「界面字号」缩放
+// 对硬编码 px 无效，按钮标签会成为唯一不跟随缩放的一层。高度仍是
 // --touch-target-size（移动 44px）/ --button-height（桌面 32px）等固定
 // 几何 token，字号放大不会把触控目标压小。
 // 新增违规由 eslint 规则 ds-components/no-arbitrary-font-size 拦截。

--- a/src/components/ui/buttonPrimitiveContract.ts
+++ b/src/components/ui/buttonPrimitiveContract.ts
@@ -19,11 +19,18 @@ export type ButtonPrimitiveSize = 'sm' | 'md' | 'lg' | 'icon' | 'default';
 
 // ui-press-coarse：触屏（pointer:coarse）统一按压反馈（独立 scale 属性，
 // 不影响桌面鼠标 active 手感；定义见 src/styles/ui-motion.css 移动追加区）
+//
+// 字号一律走 token 类（text-ui / text-xs / text-sm → --font-size-* ，内含
+// --font-size-scale），不再写 text-[13px]：设置里的"界面字号"缩放对硬编码
+// px 无效，按钮标签会成为唯一不跟随缩放的一层。高度仍是
+// --touch-target-size（移动 44px）/ --button-height（桌面 32px）等固定
+// 几何 token，字号放大不会把触控目标压小。
+// 新增违规由 eslint 规则 ds-components/no-arbitrary-font-size 拦截。
 export const buttonBaseClassName =
-  'ui-press-coarse inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--button-radius)] border text-[13px] font-medium leading-none transition-[background-color,border-color,color] duration-150 ease-out outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 select-none motion-reduce:transition-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-inherit';
+  'ui-press-coarse inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--button-radius)] border text-ui font-medium leading-none transition-[background-color,border-color,color] duration-150 ease-out outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 select-none motion-reduce:transition-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-inherit';
 
 export const shellNavBaseClassName =
-  'ui-press-coarse inline-flex shrink-0 appearance-none items-center gap-2 whitespace-nowrap text-[13px] leading-none outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-inherit';
+  'ui-press-coarse inline-flex shrink-0 appearance-none items-center gap-2 whitespace-nowrap text-ui font-normal leading-none outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-inherit';
 
 export const buttonToneClassNames: Record<ButtonPrimitiveVariant, string> = {
   primary:
@@ -55,9 +62,9 @@ export const buttonToneClassNames: Record<ButtonPrimitiveVariant, string> = {
 };
 
 export const buttonSizeClassNames: Record<ButtonPrimitiveSize, string> = {
-  default: 'h-[var(--touch-target-size)] px-[var(--button-padding-x)] text-[13px] lg:h-[var(--button-height)]',
+  default: 'h-[var(--touch-target-size)] px-[var(--button-padding-x)] text-ui lg:h-[var(--button-height)]',
   sm: 'h-[var(--touch-target-size)] px-[var(--button-padding-x-sm)] text-xs lg:h-[var(--button-height-sm)]',
-  md: 'h-[var(--touch-target-size)] px-[var(--button-padding-x)] text-[13px] lg:h-[var(--button-height)]',
+  md: 'h-[var(--touch-target-size)] px-[var(--button-padding-x)] text-ui lg:h-[var(--button-height)]',
   lg: 'h-[var(--touch-target-size)] px-[var(--button-padding-x-lg)] text-sm lg:h-[var(--button-height-lg)]',
   icon:
     'h-[var(--touch-target-size)] w-[var(--touch-target-size)] rounded-[var(--button-radius)] p-0 lg:h-[var(--button-icon-size)] lg:w-[var(--button-icon-size)]',

--- a/src/components/ui/shad/CollapsibleModelSelector.tsx
+++ b/src/components/ui/shad/CollapsibleModelSelector.tsx
@@ -140,7 +140,7 @@ export function CollapsibleModelSelector({
                   <span>{t('model_selector.total_model_count', { count: totalCount })}</span>
                   {cacheTimeText && (
                     <span className="flex items-center gap-1">
-                      {isFromCache && <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted">{t('model_selector.cached')}</span>}
+                      {isFromCache && <span className="text-2xs px-1.5 py-0.5 rounded bg-muted">{t('model_selector.cached')}</span>}
                       {cacheTimeText}
                     </span>
                   )}

--- a/src/components/ui/shad/Tooltip.tsx
+++ b/src/components/ui/shad/Tooltip.tsx
@@ -194,7 +194,7 @@ interface TooltipContentProps extends React.HTMLAttributes<HTMLDivElement> {
 // 基础样式 - 最小化，让用户传递的类可以完全覆盖
 // ui-tooltip-in：ui-motion 入场（fade + scale 0.97 + 朝最终位置 2px 漂移，方向随 data-side）
 const getBaseClasses = () => {
-  return 'rounded-md px-2 py-1.5 text-[13px] shadow-none border border-border/40 bg-[var(--tooltip-surface)] text-[var(--tooltip-foreground)] font-medium leading-none ui-tooltip-in';
+  return 'rounded-md px-2 py-1.5 text-ui shadow-none border border-border/40 bg-[var(--tooltip-surface)] text-[var(--tooltip-foreground)] font-medium leading-none ui-tooltip-in';
 };
 
 export const TooltipContent: React.FC<TooltipContentProps>

--- a/src/components/ui/unified-sidebar/UnifiedSidebar.tsx
+++ b/src/components/ui/unified-sidebar/UnifiedSidebar.tsx
@@ -51,7 +51,7 @@ const SIDEBAR_STYLES = {
     header: { height: '40px', padding: 'px-2', gap: 'gap-0.5' },
     search: { iconSize: 'w-3.5 h-3.5', inputPadding: 'pl-8 pr-3 py-1.5 text-sm' },
     button: { padding: 'p-1.5', iconSize: 'w-4 h-4' },
-    item: { padding: 'gap-2.5 px-2 py-2 mx-1', iconSize: 'w-4 h-4', textSize: 'text-[13px]', indicator: 'w-[3px] h-4' },
+    item: { padding: 'gap-2.5 px-2 py-2 mx-1', iconSize: 'w-4 h-4', textSize: 'text-ui', indicator: 'w-[3px] h-4' },
     content: { viewportPadding: 'py-1', spacing: 'space-y-0.5' },
     footer: { padding: 'p-3' },
     actions: { gap: 'gap-0.5', opacity: 'opacity-0 group-hover:opacity-100', btnPadding: 'p-1', iconSize: 'w-3 h-3' },
@@ -80,7 +80,7 @@ const SIDEBAR_STYLES = {
     header: { height: 'var(--touch-target-size)', padding: 'px-2 py-1.5', gap: 'gap-0.5' },
     search: { iconSize: 'w-4 h-4', inputPadding: 'pl-9 pr-3 py-2 text-base' },
     button: { padding: 'p-2', iconSize: 'w-5 h-5' },
-    item: { padding: 'gap-3 px-3 py-2.5 mx-1 min-h-[44px]', iconSize: 'w-5 h-5', textSize: 'text-[15px]', indicator: 'w-[3px] h-5' },
+    item: { padding: 'gap-3 px-3 py-2.5 mx-1 min-h-[44px]', iconSize: 'w-5 h-5', textSize: 'text-md', indicator: 'w-[3px] h-5' },
     content: { viewportPadding: 'py-1', spacing: 'space-y-0.5' },
     footer: { padding: 'p-3' },
     actions: { gap: 'gap-1', opacity: 'opacity-100', btnPadding: 'p-2', iconSize: 'w-4 h-4' },
@@ -626,7 +626,7 @@ export const UnifiedSidebarItem: React.FC<UnifiedSidebarItemProps> = ({
               {badge && (
                 <span className={cn(
                   'px-1.5 py-0.5 rounded bg-accent text-accent-foreground font-medium flex-shrink-0',
-                  isMobileMode && !isMobileSlidingMode ? 'text-xs' : 'text-[10px]'
+                  isMobileMode && !isMobileSlidingMode ? 'text-xs' : 'text-2xs'
                 )}>
                   {badge}
                 </span>
@@ -650,10 +650,7 @@ export const UnifiedSidebarItem: React.FC<UnifiedSidebarItemProps> = ({
               </p>
             )}
             {stats && (
-              <div className={cn(
-                'flex items-center gap-2 mt-0.5 text-muted-foreground',
-                isMobileMode && !isMobileSlidingMode ? 'text-xs' : 'text-[11px]'
-              )}>
+              <div className="flex items-center gap-2 mt-0.5 text-xs text-muted-foreground">
                 {stats}
               </div>
             )}

--- a/src/components/ui/unified-sidebar/UnifiedSidebarSection.tsx
+++ b/src/components/ui/unified-sidebar/UnifiedSidebarSection.tsx
@@ -89,7 +89,7 @@ export const UnifiedSidebarSection: React.FC<UnifiedSidebarSectionProps> = ({
         >
           <div className="flex items-center gap-2">
             {Icon && <Icon className="w-4 h-4 text-foreground/90" />}
-            <span className={cn('font-normal text-foreground/90', isMobileMode ? 'text-sm' : 'text-[13px]')}>
+            <span className={cn('font-normal text-foreground/90', isMobileMode ? 'text-sm' : 'text-ui')}>
               {title}
             </span>
             {count !== undefined && (
@@ -136,12 +136,7 @@ export const UnifiedSidebarSection: React.FC<UnifiedSidebarSectionProps> = ({
       >
         <div className="flex items-center gap-2">
           {Icon && <Icon className="w-3 h-3 text-muted-foreground/60" />}
-          <span
-            className={cn(
-              'font-normal text-muted-foreground/60',
-              isMobileMode ? 'text-xs' : 'text-[11px]'
-            )}
-          >
+          <span className="text-xs font-normal text-muted-foreground/60">
             {title}
           </span>
           {count !== undefined && (

--- a/src/features/chat/pages/ChatV2Page.tsx
+++ b/src/features/chat/pages/ChatV2Page.tsx
@@ -25,7 +25,7 @@ import { unifiedConfirm } from '@/utils/unifiedDialogs';
 // Learning Hub 学习资源侧边栏
 import { LearningHubSidebar } from '@/features/learning-hub';
 import type { ResourceListItem, ResourceType } from '@/features/learning-hub/types';
-import { useFinderStore } from '@/features/learning-hub/stores/finderStore';
+import { useHostFinderStore, FINDER_HOST_IDS } from '@/features/learning-hub/stores/finderStore';
 import { useNotesOptional } from '@/features/notes/NotesContext';
 import { lazy, Suspense } from 'react';
 
@@ -210,8 +210,10 @@ export const ChatV2Page: React.FC<ChatV2PageProps> = ({
   // 移动端：分组已关联资源 ID 集合（用于右面板高亮显示）
   const [groupPinnedIds, setGroupPinnedIds] = useState<Set<string>>(new Set());
   // 📱 移动端资源库面包屑导航（用于应用顶栏）
-  const finderCurrentPath = useFinderStore(state => state.currentPath);
-  const finderJumpToBreadcrumb = useFinderStore(state => state.jumpToBreadcrumb);
+  // ★ LH-HOST Step2：读画布自己的 finder 桶，别再拿学习中心那一桶的落点
+  const useCanvasFinder = useHostFinderStore(FINDER_HOST_IDS.canvas);
+  const finderCurrentPath = useCanvasFinder(state => state.currentPath);
+  const finderJumpToBreadcrumb = useCanvasFinder(state => state.jumpToBreadcrumb);
   const finderBreadcrumbs = finderCurrentPath.breadcrumbs;
   const [isLoading, setIsLoading] = useState(false);
   // 🔧 防闪烁：首次加载会话列表期间为 true，避免短暂显示全空状态

--- a/src/features/learning-hub/LearningHubNavigationContext.tsx
+++ b/src/features/learning-hub/LearningHubNavigationContext.tsx
@@ -9,7 +9,7 @@
 import React, { createContext, useContext, useState, useCallback, useMemo, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { RealPathBreadcrumbItem } from './types/navigation';
-import { useFinderStore } from './stores/finderStore';
+import { useHostFinderStore, FINDER_HOST_IDS } from './stores/finderStore';
 
 // ============================================================================
 // 📱 全局导航 Ref（解决 App.tsx 无法访问 Context 的问题）
@@ -85,6 +85,10 @@ const LearningHubNavigationContext = createContext<LearningHubNavigationContextV
 
 export const LearningHubNavigationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isInLearningHub, setIsInLearningHub] = useState(false);
+
+  // ★ LH-HOST Step2：本 Provider 服务的是学习中心页顶栏，绑定 `page` 桶。
+  // workbench Files 窗（默认桶）与画布（canvas 桶）各自有自己的导航栈。
+  const useFinderStore = useHostFinderStore(FINDER_HOST_IDS.page);
 
   // ★ 性能：只订阅导航相关字段（items/selectedIds/searchQuery 等高频变化字段
   // 与本 Provider 无关，全量订阅会让 Provider 随文件列表加载/多选频繁重渲染）

--- a/src/features/learning-hub/LearningHubPage.tsx
+++ b/src/features/learning-hub/LearningHubPage.tsx
@@ -57,7 +57,7 @@ import { usePageMount } from '@/debug-panel/hooks/usePageLifecycle';
 import { debugLog } from '@/debug-panel/debugMasterSwitch';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useViewVisibility } from '@/hooks/useViewVisibility';
-import { useFinderStore } from './stores/finderStore';
+import { useHostFinderStore, FINDER_HOST_IDS } from './stores/finderStore';
 import { DstuAppLauncher } from './components/DstuAppLauncher';
 import { type OpenTab, type SplitViewState, MAX_TABS, createTab } from './types/tabs';
 import { TabBar } from './components/TabBar';
@@ -487,14 +487,17 @@ export const LearningHubPage: React.FC = () => {
 
   // ★ 使用 finderStore 获取实际的文件夹导航状态（而非 NavigationContext）
   // finderStore 是实际控制文件列表显示的状态，NavigationContext 只是同步层
-  const finderCurrentPath = useFinderStore(state => state.currentPath);
-  const finderGoUp = useFinderStore(state => state.goUp);
-  const finderJumpToBreadcrumb = useFinderStore(state => state.jumpToBreadcrumb);
-  const finderRefresh = useFinderStore(state => state.refresh);
-  const finderQuickAccessNavigate = useFinderStore(state => state.quickAccessNavigate);
-  const finderEnterFolder = useFinderStore(state => state.enterFolder);
-  const finderSearchQuery = useFinderStore(state => state.searchQuery);
-  const finderSetSearchQuery = useFinderStore(state => state.setSearchQuery);
+  // ★ LH-HOST Step2：本页两个 LearningHubSidebar 宿主是 page / page-mobile，
+  // 同属 `page` 桶；顶栏读的必须是同一桶，否则窄宽屏切换会读到别的宿主。
+  const useFinder = useHostFinderStore(FINDER_HOST_IDS.page);
+  const finderCurrentPath = useFinder(state => state.currentPath);
+  const finderGoUp = useFinder(state => state.goUp);
+  const finderJumpToBreadcrumb = useFinder(state => state.jumpToBreadcrumb);
+  const finderRefresh = useFinder(state => state.refresh);
+  const finderQuickAccessNavigate = useFinder(state => state.quickAccessNavigate);
+  const finderEnterFolder = useFinder(state => state.enterFolder);
+  const finderSearchQuery = useFinder(state => state.searchQuery);
+  const finderSetSearchQuery = useFinder(state => state.setSearchQuery);
   const finderBreadcrumbs = finderCurrentPath.breadcrumbs;
   const finderViewCapabilities = getViewCapabilities(finderCurrentPath.viewKind);
 

--- a/src/features/learning-hub/LearningHubSidebar.tsx
+++ b/src/features/learning-hub/LearningHubSidebar.tsx
@@ -83,7 +83,7 @@ const MemoryView = lazy(() => import('./views/MemoryView'));
 // ★ 2026-01-31: 懒加载桌面视图
 import { DesktopView, type CreateResourceType } from './components/finder';
 import type { DesktopRootConfig } from './stores/desktopStore';
-import { useFinderStore, type FinderPath, type QuickAccessType } from './stores/finderStore';
+import { useHostFinderStore, type FinderPath, type QuickAccessType } from './stores/finderStore';
 import { useRecentStore } from './stores/recentStore';
 import { useLearningHubNavigationSafe } from './LearningHubNavigationContext';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
@@ -139,12 +139,6 @@ const CANVAS_FALLBACK_PATH = {
   folderId: null as string | null,
   typeFilter: null as null,
 };
-const createCanvasFinderPath = (): FinderPath => ({
-  viewKind: 'folder',
-  breadcrumbs: [],
-  folderId: null,
-  typeFilter: null,
-});
 const PENDING_FOLDER_ID_PREFIX = '__pending_new_folder__';
 
 type SoftDeleteTarget = { id: string; type: string; name: string };
@@ -174,7 +168,7 @@ export function LearningHubSidebar({
   toolbarPortalTarget,
   toolbarPortalMode = 'window',
   highlightedIds,
-  hostId: _hostId,
+  hostId,
   sessionActive,
   commandsEnabled,
   onMultiSelectModeChange,
@@ -189,6 +183,9 @@ export function LearningHubSidebar({
 
   // ========== 页面生命周期监控 ==========
   usePageMount('learning-hub-sidebar', 'LearningHubSidebar');
+
+  // ★ LH-HOST Step2：按 hostId 取对应的 finder 桶；未登记 hostId 落默认桶（旧行为）
+  const useHostFinder = useHostFinderStore(hostId);
 
   // Store state
   const {
@@ -223,11 +220,12 @@ export function LearningHubSidebar({
     navigateTo: storeNavigateTo,
     quickAccessNavigate: storeQuickAccessNavigate,
     queryItemsForPath,
-  } = useFinderStore();
+  } = useHostFinder();
 
-  const [canvasPath, setCanvasPath] = useState<FinderPath>(createCanvasFinderPath);
-  const [canvasHistory, setCanvasHistory] = useState<FinderPath[]>(() => [createCanvasFinderPath()]);
-  const [canvasHistoryIndex, setCanvasHistoryIndex] = useState(0);
+  // ★ LH-HOST Step2：canvas 宿主的「导航位置」不再是组件本地 state，而是
+  // hostId 桶内的 store。外部顶栏（ChatV2Page 移动端面包屑）因此能读到画布
+  // 自己的落点，不再串到学习中心那一桶。
+  // 列表 / 选中 / 搜索仍留在本地：canvas 走本地活名过滤而非后端搜索。
   const [canvasItems, setCanvasItems] = useState<DstuNode[]>([]);
   const [canvasIsLoading, setCanvasIsLoading] = useState(false);
   const [canvasError, setCanvasError] = useState<string | null>(null);
@@ -236,10 +234,10 @@ export function LearningHubSidebar({
   const [canvasSearchQuery, setCanvasSearchQuery] = useState('');
   const canvasRequestIdRef = useRef(0);
 
-  // Canvas uses an isolated file-browser state: never reuse the global path/items/search.
-  const currentPath = mode === 'canvas' ? canvasPath : storeCurrentPath;
-  const history = mode === 'canvas' ? canvasHistory : storeHistory;
-  const historyIndex = mode === 'canvas' ? canvasHistoryIndex : storeHistoryIndex;
+  // 导航位置统一由宿主桶 store 承载（canvas 与 fullscreen 桶不同，天然隔离）。
+  const currentPath = storeCurrentPath;
+  const history = storeHistory;
+  const historyIndex = storeHistoryIndex;
   const items = mode === 'canvas' ? canvasItems : storeItems;
   const isLoading = mode === 'canvas' ? canvasIsLoading : storeIsLoading;
   const error = mode === 'canvas' ? canvasError : storeError;
@@ -366,7 +364,7 @@ export function LearningHubSidebar({
     inlineEdit,
     startInlineEdit,
     cancelInlineEdit,
-  } = useFinderStore();
+  } = useHostFinder();
   
   // Container ref for keyboard shortcuts scope
   const containerRef = useRef<HTMLDivElement>(null);
@@ -389,89 +387,50 @@ export function LearningHubSidebar({
     };
   }, []);
 
-  const navigateCanvasTo = useCallback((path: FinderPath) => {
-    setCanvasHistory((previous) => {
-      const next = [...previous.slice(0, canvasHistoryIndex + 1), path];
-      setCanvasHistoryIndex(next.length - 1);
-      return next;
-    });
-    setCanvasPath(path);
+  // canvas 的列表/选中/搜索仍是本地态，导航后需要跟着清一次
+  const resetCanvasLocalSelection = useCallback(() => {
     setCanvasSelectedIds(new Set());
     setCanvasLastSelectedId(null);
+  }, []);
+  const resetCanvasLocalState = useCallback(() => {
+    resetCanvasLocalSelection();
     setCanvasSearchQuery('');
-  }, [canvasHistoryIndex]);
+  }, [resetCanvasLocalSelection]);
 
-  const enterCanvasFolder = useCallback(async (folderId: string, _folderName?: string, _folderPath?: string) => {
-    const breadcrumbsResult = await folderApi.getBreadcrumbs(folderId);
-    const breadcrumbs = breadcrumbsResult.ok
-      ? breadcrumbsResult.value.map((crumb, index, all) => ({
-          id: crumb.id,
-          name: crumb.name,
-          dstuPath: `/${all.slice(0, index + 1).map((item) => item.name).join('/')}`,
-        }))
-      : [];
-    navigateCanvasTo({
-      viewKind: 'folder',
-      folderId,
-      breadcrumbs,
-      typeFilter: null,
-    });
-  }, [navigateCanvasTo]);
+  const navigateCanvasTo = useCallback((path: FinderPath) => {
+    storeNavigateTo(path);
+    resetCanvasLocalState();
+  }, [storeNavigateTo, resetCanvasLocalState]);
+
+  const enterCanvasFolder = useCallback(async (folderId: string, folderName?: string, folderPath?: string) => {
+    await storeEnterFolder(folderId, folderName, folderPath);
+    resetCanvasLocalState();
+  }, [storeEnterFolder, resetCanvasLocalState]);
 
   const goCanvasBack = useCallback(() => {
-    if (canvasHistoryIndex <= 0) return;
-    const index = canvasHistoryIndex - 1;
-    setCanvasHistoryIndex(index);
-    setCanvasPath(canvasHistory[index]);
-    setCanvasSelectedIds(new Set());
-    setCanvasLastSelectedId(null);
-  }, [canvasHistory, canvasHistoryIndex]);
+    storeGoBack();
+    resetCanvasLocalSelection();
+  }, [storeGoBack, resetCanvasLocalSelection]);
 
   const goCanvasForward = useCallback(() => {
-    if (canvasHistoryIndex >= canvasHistory.length - 1) return;
-    const index = canvasHistoryIndex + 1;
-    setCanvasHistoryIndex(index);
-    setCanvasPath(canvasHistory[index]);
-    setCanvasSelectedIds(new Set());
-    setCanvasLastSelectedId(null);
-  }, [canvasHistory, canvasHistoryIndex]);
+    storeGoForward();
+    resetCanvasLocalSelection();
+  }, [storeGoForward, resetCanvasLocalSelection]);
 
   const jumpCanvasToBreadcrumb = useCallback((index: number) => {
-    if (index === -1) {
-      navigateCanvasTo(createCanvasFinderPath());
-      return;
-    }
-    if (index < 0 || index >= canvasPath.breadcrumbs.length - 1) return;
-    const breadcrumbs = canvasPath.breadcrumbs.slice(0, index + 1);
-    navigateCanvasTo({
-      viewKind: 'folder',
-      folderId: breadcrumbs[index].id,
-      breadcrumbs,
-      typeFilter: null,
-    });
-  }, [canvasPath, navigateCanvasTo]);
+    storeJumpToBreadcrumb(index);
+    resetCanvasLocalState();
+  }, [storeJumpToBreadcrumb, resetCanvasLocalState]);
 
   const navigateCanvasQuickAccess = useCallback((type: QuickAccessType) => {
-    const target = getQuickAccessTarget(type);
-    navigateCanvasTo({
-      viewKind: target.viewKind,
-      breadcrumbs: [],
-      folderId: null,
-      typeFilter: target.typeFilter,
-    });
-  }, [navigateCanvasTo]);
+    storeQuickAccessNavigate(type);
+    resetCanvasLocalState();
+  }, [storeQuickAccessNavigate, resetCanvasLocalState]);
 
   const goCanvasUp = useCallback(() => {
-    if (canvasPath.breadcrumbs.length === 0) return;
-    const breadcrumbs = canvasPath.breadcrumbs.slice(0, -1);
-    const parent = breadcrumbs[breadcrumbs.length - 1] ?? null;
-    navigateCanvasTo({
-      viewKind: 'folder',
-      breadcrumbs,
-      folderId: parent ? parent.id : null,
-      typeFilter: null,
-    });
-  }, [canvasPath.breadcrumbs, navigateCanvasTo]);
+    storeGoUp();
+    resetCanvasLocalState();
+  }, [storeGoUp, resetCanvasLocalState]);
 
   const goBack = mode === 'canvas' ? goCanvasBack : storeGoBack;
   const goForward = mode === 'canvas' ? goCanvasForward : storeGoForward;
@@ -527,7 +486,7 @@ export function LearningHubSidebar({
   const refreshCanvas = useCallback(async () => {
     if (!isMountedRef.current) return;
     const requestId = ++canvasRequestIdRef.current;
-    const pathSnapshot = canvasPath;
+    const pathSnapshot = currentPath;
     const querySnapshot = canvasSearchQuery.trim();
     setCanvasIsLoading(true);
     setCanvasError(null);
@@ -552,12 +511,12 @@ export function LearningHubSidebar({
       setCanvasError(result.error.message);
     }
     setCanvasIsLoading(false);
-  }, [canvasLastSelectedId, canvasPath, canvasSearchQuery, queryItemsForPath]);
+  }, [canvasLastSelectedId, currentPath, canvasSearchQuery, queryItemsForPath]);
 
   useEffect(() => {
     if (mode !== 'canvas' || sessionActive === false) return;
     void refreshCanvas();
-  }, [mode, canvasPath, canvasSearchQuery, refreshCanvas, sessionActive]);
+  }, [mode, currentPath, canvasSearchQuery, refreshCanvas, sessionActive]);
 
   // ★ 2025-12-31: 移除组件挂载时的 reset() 调用
   // 原因: finderStore 使用 persist 中间件保存导航状态到 localStorage
@@ -614,7 +573,7 @@ export function LearningHubSidebar({
             'learning-hub-sidebar',
             'LearningHubSidebar',
             'data_ready',
-            `${useFinderStore.getState().items.length} items`,
+            `${useHostFinder.getState().items.length} items`,
             { duration: Date.now() - start }
           );
         }
@@ -629,7 +588,7 @@ export function LearningHubSidebar({
     return () => {
       isCancelled = true;
     };
-  }, [mode, sessionActive, currentPathDisplay, currentPath.viewKind, currentPath.folderId, currentPath.typeFilter, debouncedSearchQuery, searchQuery, finderRefresh]);
+  }, [mode, sessionActive, currentPathDisplay, currentPath.viewKind, currentPath.folderId, currentPath.typeFilter, debouncedSearchQuery, searchQuery, finderRefresh, useHostFinder]);
 
   // Handle open item
   const handleOpen = (item: DstuNode) => {
@@ -726,7 +685,7 @@ export function LearningHubSidebar({
           // R2-04：内联重命名进行中延迟 silent refresh（非永久跳过），避免丢 agent 变更
           const trySilentRefresh = () => {
             // canvas 宿主有独立列表；勿被全局 fullscreen 的 inlineEdit 卡住刷新
-            if (mode !== 'canvas' && useFinderStore.getState().inlineEdit.editingId) {
+            if (mode !== 'canvas' && useHostFinder.getState().inlineEdit.editingId) {
               watchDebounceRef.current = setTimeout(() => {
                 watchDebounceRef.current = null;
                 trySilentRefresh();
@@ -747,7 +706,7 @@ export function LearningHubSidebar({
         watchDebounceRef.current = null;
       }
     };
-  }, [sessionActive, currentPath.viewKind, handleSilentRefresh, mode]);
+  }, [sessionActive, currentPath.viewKind, handleSilentRefresh, mode, useHostFinder]);
 
   const ensureCreatableView = useCallback(() => {
     if (canCreateInCurrentView) {
@@ -1966,16 +1925,16 @@ export function LearningHubSidebar({
       pendingFolderDraftRef.current = null;
       setPendingFolderDraft(null);
     }
-    if (useFinderStore.getState().inlineEdit.editingId === itemId) {
+    if (useHostFinder.getState().inlineEdit.editingId === itemId) {
       cancelInlineEdit();
     }
-  }, [cancelInlineEdit]);
+  }, [cancelInlineEdit, useHostFinder]);
 
   useEffect(() => {
     if (!pendingFolderDraft) return;
     setPendingFolderDraft(null);
     pendingFolderDraftRef.current = null;
-    if (isPendingFolderId(useFinderStore.getState().inlineEdit.editingId)) {
+    if (isPendingFolderId(useHostFinder.getState().inlineEdit.editingId)) {
       cancelInlineEdit();
     }
     // 路径变化后草稿不应跟随到另一个文件夹。

--- a/src/features/learning-hub/stores/__tests__/finderStoreHostBuckets.test.ts
+++ b/src/features/learning-hub/stores/__tests__/finderStoreHostBuckets.test.ts
@@ -1,0 +1,157 @@
+/**
+ * LH-HOST Step2：finderStore 按 hostId 分桶的契约测试。
+ *
+ * 锁定三件事：
+ * 1. 同一逻辑宿主（page / page-mobile，canvas / canvas-mobile）共用一个桶
+ * 2. 不同宿主桶之间导航位置 / 选中 / viewMode 互不影响
+ * 3. 默认桶仍是历史 `useFinderStore`，persist key 不变（刷新后不串台）
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/dstu/api', () => ({
+  dstu: {
+    list: vi.fn(async () => ({ ok: true, value: [] })),
+    get: vi.fn(async () => ({ ok: false, error: { message: 'not found' } })),
+    search: vi.fn(async () => ({ ok: true, value: [] })),
+    searchInFolder: vi.fn(async () => ({ ok: true, value: [] })),
+    listDeleted: vi.fn(async () => ({ ok: true, value: [] })),
+  },
+}));
+
+vi.mock('@/dstu', () => ({
+  folderApi: {
+    getBreadcrumbs: vi.fn(async (folderId: string) => ({
+      ok: true,
+      value: [{ id: folderId, name: folderId }],
+    })),
+  },
+  trashApi: { listTrash: vi.fn(async () => ({ ok: true, value: [] })) },
+}));
+
+import {
+  DEFAULT_FINDER_BUCKET,
+  FINDER_HOST_IDS,
+  createFinderPath,
+  getFinderStoreForHost,
+  resolveFinderBucketId,
+  useFinderStore,
+} from '../finderStore';
+
+const pathAt = (folderId: string) =>
+  createFinderPath({ folderId, breadcrumbs: [{ id: folderId, name: folderId, dstuPath: `/${folderId}` }] });
+
+describe('resolveFinderBucketId', () => {
+  it('maps every declared hostId to a bucket', () => {
+    expect(resolveFinderBucketId(FINDER_HOST_IDS.files)).toBe(DEFAULT_FINDER_BUCKET);
+    expect(resolveFinderBucketId(FINDER_HOST_IDS.page)).toBe('page');
+    expect(resolveFinderBucketId(FINDER_HOST_IDS.pageMobile)).toBe('page');
+    expect(resolveFinderBucketId(FINDER_HOST_IDS.canvas)).toBe('canvas');
+    expect(resolveFinderBucketId(FINDER_HOST_IDS.canvasMobile)).toBe('canvas');
+    expect(resolveFinderBucketId(FINDER_HOST_IDS.groupPicker)).toBe('group-picker');
+  });
+
+  it('falls back to the default bucket for missing / unknown hosts', () => {
+    expect(resolveFinderBucketId(undefined)).toBe(DEFAULT_FINDER_BUCKET);
+    expect(resolveFinderBucketId(null)).toBe(DEFAULT_FINDER_BUCKET);
+    expect(resolveFinderBucketId('some-future-host')).toBe(DEFAULT_FINDER_BUCKET);
+  });
+});
+
+describe('finder store host buckets', () => {
+  beforeEach(() => {
+    getFinderStoreForHost(FINDER_HOST_IDS.page).getState().reset();
+    getFinderStoreForHost(FINDER_HOST_IDS.canvas).getState().reset();
+    getFinderStoreForHost(FINDER_HOST_IDS.groupPicker).getState().reset();
+    useFinderStore.getState().reset();
+  });
+
+  it('shares one store between page and page-mobile', () => {
+    expect(getFinderStoreForHost(FINDER_HOST_IDS.page))
+      .toBe(getFinderStoreForHost(FINDER_HOST_IDS.pageMobile));
+  });
+
+  it('shares one store between canvas and canvas-mobile', () => {
+    expect(getFinderStoreForHost(FINDER_HOST_IDS.canvas))
+      .toBe(getFinderStoreForHost(FINDER_HOST_IDS.canvasMobile));
+  });
+
+  it('keeps the default bucket pointing at the legacy global store', () => {
+    expect(getFinderStoreForHost(FINDER_HOST_IDS.files)).toBe(useFinderStore);
+    expect(getFinderStoreForHost(undefined)).toBe(useFinderStore);
+  });
+
+  it('does not leak currentFolder between two hosts', () => {
+    const page = getFinderStoreForHost(FINDER_HOST_IDS.page);
+    const canvas = getFinderStoreForHost(FINDER_HOST_IDS.canvas);
+
+    page.getState().navigateTo(pathAt('folder-lesson'));
+    canvas.getState().navigateTo(pathAt('folder-scratch'));
+
+    expect(page.getState().currentPath.folderId).toBe('folder-lesson');
+    expect(canvas.getState().currentPath.folderId).toBe('folder-scratch');
+    expect(useFinderStore.getState().currentPath.folderId).toBeNull();
+  });
+
+  it('does not leak currentFolder between the mobile hosts either', () => {
+    const pageMobile = getFinderStoreForHost(FINDER_HOST_IDS.pageMobile);
+    const canvasMobile = getFinderStoreForHost(FINDER_HOST_IDS.canvasMobile);
+
+    pageMobile.getState().navigateTo(pathAt('mobile-lesson'));
+    canvasMobile.getState().navigateTo(pathAt('mobile-scratch'));
+
+    expect(pageMobile.getState().currentPath.folderId).toBe('mobile-lesson');
+    expect(canvasMobile.getState().currentPath.folderId).toBe('mobile-scratch');
+    // page 与 page-mobile 同桶：窄宽屏切换保留落点
+    expect(getFinderStoreForHost(FINDER_HOST_IDS.page).getState().currentPath.folderId)
+      .toBe('mobile-lesson');
+  });
+
+  it('keeps history stacks per bucket', () => {
+    const page = getFinderStoreForHost(FINDER_HOST_IDS.page);
+    const canvas = getFinderStoreForHost(FINDER_HOST_IDS.canvas);
+
+    page.getState().navigateTo(pathAt('a'));
+    page.getState().navigateTo(pathAt('b'));
+    canvas.getState().navigateTo(pathAt('z'));
+
+    expect(page.getState().historyIndex).toBe(2);
+    expect(canvas.getState().historyIndex).toBe(1);
+
+    page.getState().goBack();
+    expect(page.getState().currentPath.folderId).toBe('a');
+    expect(canvas.getState().currentPath.folderId).toBe('z');
+  });
+
+  it('keeps selection per bucket', () => {
+    const page = getFinderStoreForHost(FINDER_HOST_IDS.page);
+    const groupPicker = getFinderStoreForHost(FINDER_HOST_IDS.groupPicker);
+
+    page.getState().setSelectedIds(new Set(['res-1', 'res-2']));
+    groupPicker.getState().setSelectedIds(new Set(['res-9']));
+
+    expect(Array.from(page.getState().selectedIds)).toEqual(['res-1', 'res-2']);
+    expect(Array.from(groupPicker.getState().selectedIds)).toEqual(['res-9']);
+  });
+
+  it('keeps viewMode per bucket', () => {
+    const page = getFinderStoreForHost(FINDER_HOST_IDS.page);
+    const canvas = getFinderStoreForHost(FINDER_HOST_IDS.canvas);
+
+    page.getState().setViewMode('list');
+    canvas.getState().setViewMode('grid');
+
+    expect(page.getState().viewMode).toBe('list');
+    expect(canvas.getState().viewMode).toBe('grid');
+  });
+
+  it('persists each bucket under its own storage key', () => {
+    getFinderStoreForHost(FINDER_HOST_IDS.page).getState().setViewMode('list');
+    getFinderStoreForHost(FINDER_HOST_IDS.canvas).getState().setViewMode('grid');
+    useFinderStore.getState().setViewMode('columns');
+
+    expect(localStorage.getItem('learning-hub-finder')).toContain('"viewMode":"columns"');
+    expect(localStorage.getItem('learning-hub-finder:page')).toContain('"viewMode":"list"');
+    expect(localStorage.getItem('learning-hub-finder:canvas')).toContain('"viewMode":"grid"');
+  });
+});

--- a/src/features/learning-hub/stores/finderStore.ts
+++ b/src/features/learning-hub/stores/finderStore.ts
@@ -362,7 +362,65 @@ function getDstuListOptionsForPath(
 /** 历史记录最大条数，防止内存无限增长 */
 const MAX_HISTORY_SIZE = 100;
 
-export const useFinderStore = create<FinderState>()(
+// ============================================================================
+// ★ LH-HOST Step2：按 hostId 分桶
+//
+// finderStore 原本是全局单例，chat canvas / 学习中心 / 分组选择器共用一份
+// 导航位置、选中集合与 viewMode，互相带走落点。这里按「宿主桶」拆分 store
+// 实例：同一桶内的宿主共享状态（page 与 page-mobile 是同一个学习中心，
+// 窄宽屏切换不该丢落点），跨桶完全隔离。
+//
+// 默认桶保持 `learning-hub-finder` 这个 persist key 与 `useFinderStore`
+// 导出不变，workbench Files 窗、agent driver、mcp-debug 等既有全局调用点
+// 无需改动即可继续工作。
+// ============================================================================
+
+/** 默认桶 ID：承载 workbench Files 窗与未声明 hostId 的遗留调用点 */
+export const DEFAULT_FINDER_BUCKET = 'default';
+
+/** 已登记的 Finder 宿主 ID（与 LearningHubSidebar 的 hostId prop 一一对应） */
+export const FINDER_HOST_IDS = {
+  files: 'files',
+  page: 'page',
+  pageMobile: 'page-mobile',
+  canvas: 'canvas',
+  canvasMobile: 'canvas-mobile',
+  groupPicker: 'group-picker',
+} as const;
+
+export type FinderHostId = typeof FINDER_HOST_IDS[keyof typeof FINDER_HOST_IDS];
+
+/**
+ * hostId → 桶 ID 映射。
+ *
+ * 未登记的 hostId 一律落到默认桶（保持旧行为，不会因为新增宿主而静默丢状态）。
+ */
+const FINDER_BUCKET_BY_HOST: Record<string, string> = {
+  files: DEFAULT_FINDER_BUCKET,
+  page: 'page',
+  'page-mobile': 'page',
+  canvas: 'canvas',
+  'canvas-mobile': 'canvas',
+  'group-picker': 'group-picker',
+};
+
+/** 把 hostId 归一化为桶 ID；未知 / 缺省 hostId 落默认桶。 */
+export function resolveFinderBucketId(hostId?: string | null): string {
+  if (!hostId) return DEFAULT_FINDER_BUCKET;
+  return FINDER_BUCKET_BY_HOST[hostId] ?? DEFAULT_FINDER_BUCKET;
+}
+
+/** persist key：默认桶沿用历史 key，其余桶各自独立，刷新后不串台。 */
+function persistNameForBucket(bucketId: string): string {
+  return bucketId === DEFAULT_FINDER_BUCKET
+    ? 'learning-hub-finder'
+    : `learning-hub-finder:${bucketId}`;
+}
+
+export type FinderStoreApi = ReturnType<typeof createFinderStore>;
+
+export function createFinderStore(bucketId: string) {
+  return create<FinderState>()(
   persist(
     (set, get) => ({
       // 导航状态
@@ -1021,7 +1079,7 @@ export const useFinderStore = create<FinderState>()(
       },
     }),
     {
-      name: 'learning-hub-finder',
+      name: persistNameForBucket(bucketId),
       partialize: (state) => ({
         viewMode: state.viewMode,
         sortBy: state.sortBy,
@@ -1030,4 +1088,55 @@ export const useFinderStore = create<FinderState>()(
       }),
     }
   )
-);
+  );
+}
+
+// ============================================================================
+// 桶注册表
+// ============================================================================
+
+const finderStoreRegistry = new Map<string, FinderStoreApi>();
+
+/** 取（并按需创建）某个桶的 store 实例。 */
+export function getFinderStoreForBucket(bucketId: string): FinderStoreApi {
+  const existing = finderStoreRegistry.get(bucketId);
+  if (existing) return existing;
+  const created = createFinderStore(bucketId);
+  finderStoreRegistry.set(bucketId, created);
+  return created;
+}
+
+/** 取某个宿主（hostId）对应的 store 实例。 */
+export function getFinderStoreForHost(hostId?: string | null): FinderStoreApi {
+  return getFinderStoreForBucket(resolveFinderBucketId(hostId));
+}
+
+/** 已实例化的桶 ID 列表（调试 / 测试用）。 */
+export function listFinderBuckets(): string[] {
+  return Array.from(finderStoreRegistry.keys());
+}
+
+/** 仅供测试：清空注册表，让下一次 get 重新建实例。 */
+export function __resetFinderStoreRegistryForTests(): void {
+  finderStoreRegistry.clear();
+  finderStoreRegistry.set(DEFAULT_FINDER_BUCKET, useFinderStore);
+}
+
+/**
+ * 默认桶 store。
+ *
+ * 保持既有 `useFinderStore(selector)` / `useFinderStore.getState()` 用法不变，
+ * 未声明 hostId 的调用点行为与改造前一致。
+ */
+export const useFinderStore: FinderStoreApi = getFinderStoreForBucket(DEFAULT_FINDER_BUCKET);
+
+/**
+ * React 侧取宿主桶 store 的便捷 hook。
+ *
+ * 返回的是 store 本身（同一 hostId 下引用稳定），调用方按普通 zustand hook 使用：
+ * `const finder = useHostFinderStore(hostId); const items = finder((s) => s.items);`
+ */
+export function useHostFinderStore(hostId?: string | null): FinderStoreApi {
+  const bucketId = resolveFinderBucketId(hostId);
+  return getFinderStoreForBucket(bucketId);
+}

--- a/src/features/settings/components/DataGovernanceDashboard.tsx
+++ b/src/features/settings/components/DataGovernanceDashboard.tsx
@@ -91,6 +91,15 @@ import {
 
 const console = debugLog as Pick<typeof debugLog, 'log' | 'warn' | 'error' | 'info' | 'debug'>;
 
+/**
+ * Debug 页签是否可见。
+ *
+ * 生产构建里该页签的每个控件都被 `disabled={!import.meta.env.DEV}` 灰掉，
+ * 页签本身却照常渲染 —— 用户（尤其移动端只看得到一个虫子图标）点进去
+ * 只会看到一屏无法操作的按钮。实现保留，入口只在开发构建暴露。
+ */
+const isDebugTabEnabled = (): boolean => import.meta.env.DEV;
+
 // ==================== 调试面板（DEV only） ====================
 
 export const DebugTab: React.FC = () => {
@@ -597,11 +606,14 @@ export const DataGovernanceDashboard: React.FC<DataGovernanceDashboardProps> = (
     }))
   );
   const [activeTab, setActiveTab] = useState<DashboardTab>('overview');
+  const debugTabEnabled = isDebugTabEnabled();
 
   useEffect(() => {
     if (!tabTarget) return;
+    // 生产构建没有 debug 页签，外部深链不能把面板切到一个不存在的页签
+    if (tabTarget.tab === 'debug' && !debugTabEnabled) return;
     setActiveTab(tabTarget.tab);
-  }, [tabTarget]);
+  }, [tabTarget, debugTabEnabled]);
 
   const [loadingState, setLoadingState] = useState({
     overview: 0,
@@ -1752,39 +1764,49 @@ export const DataGovernanceDashboard: React.FC<DataGovernanceDashboardProps> = (
 
   const content = (
     <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as DashboardTab)}>
-      <TabsList className="scrollbar-none mb-4 flex h-auto min-h-11 w-full max-w-full justify-start overflow-x-auto">
-        <TabsTrigger value="overview" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+      {/* 页签文字在 <640px 被 `hidden sm:inline` 收掉，只剩图标。
+          每个 trigger 必须带 aria-label，否则移动端读屏（VoiceOver / TalkBack）
+          只会念「按钮」，8 个页签互相无法区分。 */}
+      <TabsList
+        aria-label={t('data:governance.tabs_nav_label')}
+        className="scrollbar-none mb-4 flex h-auto min-h-11 w-full max-w-full justify-start overflow-x-auto"
+      >
+        <TabsTrigger value="overview" aria-label={t('data:governance.tab_overview')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <Gauge className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_overview')}</span>
         </TabsTrigger>
-        <TabsTrigger value="recovery" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+        <TabsTrigger value="recovery" aria-label={t('data:governance.tab_recovery')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <ShieldCheck className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_recovery')}</span>
         </TabsTrigger>
-        <TabsTrigger value="archive" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+        <TabsTrigger value="archive" aria-label={t('data:governance.tab_archive')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <Archive className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_archive')}</span>
         </TabsTrigger>
-        <TabsTrigger value="backup" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+        <TabsTrigger value="backup" aria-label={t('data:governance.tab_backup')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <HardDrive className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_backup')}</span>
         </TabsTrigger>
-        <TabsTrigger value="sync" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+        <TabsTrigger value="sync" aria-label={t('data:governance.tab_sync')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <Cloud className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_sync')}</span>
         </TabsTrigger>
-        <TabsTrigger value="audit" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+        <TabsTrigger value="audit" aria-label={t('data:governance.tab_audit')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <FileText className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_audit')}</span>
         </TabsTrigger>
-        <TabsTrigger value="cache" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+        <TabsTrigger value="cache" aria-label={t('data:governance.tab_cache')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <Image className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_cache')}</span>
         </TabsTrigger>
-        <TabsTrigger value="debug" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 text-muted-foreground sm:min-h-0 sm:min-w-0">
-          <Bug className="h-4 w-4" />
-          <span className="hidden sm:inline">{t('data:governance.debug_tab_title')}</span>
-        </TabsTrigger>
+        {/* Debug 页签只在开发构建出现：生产里它的控件全部 disabled，
+            对用户是一个「点得到但什么都不能做」的死页签，移动端尤其误导。 */}
+        {debugTabEnabled && (
+          <TabsTrigger value="debug" aria-label={t('data:governance.debug_tab_title')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 text-muted-foreground sm:min-h-0 sm:min-w-0">
+            <Bug className="h-4 w-4" />
+            <span className="hidden sm:inline">{t('data:governance.debug_tab_title')}</span>
+          </TabsTrigger>
+        )}
       </TabsList>
 
       <TabsContent value="overview">
@@ -1910,9 +1932,11 @@ export const DataGovernanceDashboard: React.FC<DataGovernanceDashboardProps> = (
         </div>
       </TabsContent>
 
-      <TabsContent value="debug">
-        <DebugTab />
-      </TabsContent>
+      {debugTabEnabled && (
+        <TabsContent value="debug">
+          <DebugTab />
+        </TabsContent>
+      )}
     </Tabs>
   );
 

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -181,6 +181,9 @@ export const SettingsSidebar: React.FC<SettingsSidebarProps> = ({
                   <WorkbenchSidebarRow
                     rowType="nav"
                     isActive={isActive}
+                    // 收起态（以及任何只剩图标的窄形态）下标签文字不渲染，
+                    // 没有 aria-label 读屏就只念「按钮」
+                    aria-label={item.label}
                     aria-current={isActive ? 'page' : undefined}
                     onClick={isActive ? undefined : () => {
                       setActiveTab(item.value as any);

--- a/src/features/settings/components/useSettingsNavigation.tsx
+++ b/src/features/settings/components/useSettingsNavigation.tsx
@@ -17,6 +17,24 @@ import {
 } from '@phosphor-icons/react';
 import { isMobilePlatform } from '@/utils/platform';
 
+/**
+ * 设置导航的分类 accent（窄屏导航图标色）。
+ *
+ * 只写 token 引用，不写 hex：色值本体（亮色 / 暗色 / prefers-contrast 三档）
+ * 定义在 src/styles/theme-colors.css 的 --settings-nav-accent-* 里。曾经这里
+ * 直接写死浅色 hex（#e5ad3d 等），暗色下图标亮度不足且不随主题走。
+ */
+export const SETTINGS_NAV_ACCENT = {
+  amber: 'var(--settings-nav-accent-amber)',
+  blue: 'var(--settings-nav-accent-blue)',
+  slate: 'var(--settings-nav-accent-slate)',
+  purple: 'var(--settings-nav-accent-purple)',
+  orange: 'var(--settings-nav-accent-orange)',
+  green: 'var(--settings-nav-accent-green)',
+  sky: 'var(--settings-nav-accent-sky)',
+  pink: 'var(--settings-nav-accent-pink)',
+} as const;
+
 export type SettingsSidebarNavItem = {
   value: string;
   label: string;
@@ -48,7 +66,7 @@ export function useSettingsNavigation() {
         label: t('settings:tabs.api_config'),
         tourId: 'settings-tab-apis',
         mobileDescription: t('settings:mobile_descriptions.apis'),
-        mobileAccent: '#e5ad3d',
+        mobileAccent: SETTINGS_NAV_ACCENT.amber,
       },
       {
         value: 'models',
@@ -56,7 +74,7 @@ export function useSettingsNavigation() {
         label: t('settings:tabs.model_assignment'),
         tourId: 'settings-tab-models',
         mobileDescription: t('settings:mobile_descriptions.models'),
-        mobileAccent: '#4d86df',
+        mobileAccent: SETTINGS_NAV_ACCENT.blue,
       },
     ],
     [
@@ -65,21 +83,21 @@ export function useSettingsNavigation() {
         icon: SlidersHorizontal,
         label: t('settings:tabs.general'),
         mobileDescription: t('settings:mobile_descriptions.general'),
-        mobileAccent: '#6f7785',
+        mobileAccent: SETTINGS_NAV_ACCENT.slate,
       },
       {
         value: 'appearance',
         icon: Palette,
         label: t('settings:tabs.appearance'),
         mobileDescription: t('settings:mobile_descriptions.appearance'),
-        mobileAccent: '#a35de1',
+        mobileAccent: SETTINGS_NAV_ACCENT.purple,
       },
       {
         value: 'automation',
         icon: ClockCountdown,
         label: t('settings:tabs.automation'),
         mobileDescription: t('settings:mobile_descriptions.automation'),
-        mobileAccent: '#eb8d42',
+        mobileAccent: SETTINGS_NAV_ACCENT.orange,
       },
     ],
     [
@@ -88,14 +106,14 @@ export function useSettingsNavigation() {
         icon: Plug,
         label: t('settings:tabs.mcp_tools'),
         mobileDescription: t('settings:mobile_descriptions.mcp'),
-        mobileAccent: '#1db77c',
+        mobileAccent: SETTINGS_NAV_ACCENT.green,
       },
       {
         value: 'search',
         icon: Globe,
         label: t('settings:tabs.external_search'),
         mobileDescription: t('settings:mobile_descriptions.search'),
-        mobileAccent: '#4b9fe8',
+        mobileAccent: SETTINGS_NAV_ACCENT.sky,
       },
       ...(!hidePlugins
         ? [{
@@ -103,7 +121,7 @@ export function useSettingsNavigation() {
             icon: PuzzlePiece,
             label: t('settings:tabs.plugins'),
             mobileDescription: t('settings:mobile_descriptions.plugins'),
-            mobileAccent: '#a35de1',
+            mobileAccent: SETTINGS_NAV_ACCENT.purple,
           }]
         : []),
     ],
@@ -113,14 +131,14 @@ export function useSettingsNavigation() {
         icon: ChartBar,
         label: t('settings:tabs.statistics'),
         mobileDescription: t('settings:mobile_descriptions.statistics'),
-        mobileAccent: '#4b9fe8',
+        mobileAccent: SETTINGS_NAV_ACCENT.sky,
       },
       {
         value: 'data-governance',
         icon: Shield,
         label: t('settings:tabs.data_governance'),
         mobileDescription: t('settings:mobile_descriptions.data_governance'),
-        mobileAccent: '#4f9ecf',
+        mobileAccent: SETTINGS_NAV_ACCENT.sky,
       },
     ],
     [
@@ -129,7 +147,7 @@ export function useSettingsNavigation() {
         icon: Wrench,
         label: t('settings:tabs.params'),
         mobileDescription: t('settings:mobile_descriptions.params'),
-        mobileAccent: '#e1a642',
+        mobileAccent: SETTINGS_NAV_ACCENT.amber,
       },
       ...(!hideShortcuts
         ? [{
@@ -137,7 +155,7 @@ export function useSettingsNavigation() {
             icon: Keyboard,
             label: t('settings:tabs.shortcuts'),
             mobileDescription: t('settings:mobile_descriptions.shortcuts'),
-            mobileAccent: '#7d8490',
+            mobileAccent: SETTINGS_NAV_ACCENT.slate,
           }]
         : []),
       {
@@ -145,7 +163,7 @@ export function useSettingsNavigation() {
         icon: BookOpen,
         label: t('settings:tabs.about'),
         mobileDescription: t('settings:mobile_descriptions.about'),
-        mobileAccent: '#d978ae',
+        mobileAccent: SETTINGS_NAV_ACCENT.pink,
       },
     ],
   ]), [t, hidePlugins, hideShortcuts]);

--- a/src/locales/en-US/command_palette.json
+++ b/src/locales/en-US/command_palette.json
@@ -3,6 +3,7 @@
   "search_placeholder": "Search commands...",
   "session_search_placeholder": "Search sessions...",
   "no_results": "No matching commands found",
+  "results_label": "Command results",
   "placeholder": "Type a command or search notes...",
   "no_results_simple": "No results found",
   "command_disabled": "This command is currently unavailable",

--- a/src/locales/en-US/data.json
+++ b/src/locales/en-US/data.json
@@ -810,6 +810,7 @@
     "import_button": "Import",
     "title": "Data Governance",
     "description": "Manage database migrations, backups, sync, and audit logs",
+    "tabs_nav_label": "Data governance tabs",
     "tab_overview": "Overview",
     "tab_recovery": "Recovery",
     "tab_archive": "Archive",

--- a/src/locales/zh-CN/command_palette.json
+++ b/src/locales/zh-CN/command_palette.json
@@ -3,6 +3,7 @@
   "search_placeholder": "搜索命令...",
   "session_search_placeholder": "搜索会话...",
   "no_results": "未找到匹配的命令",
+  "results_label": "命令结果列表",
   "placeholder": "输入命令或搜索笔记...",
   "no_results_simple": "未找到结果",
   "command_disabled": "该命令当前不可用",

--- a/src/locales/zh-CN/data.json
+++ b/src/locales/zh-CN/data.json
@@ -810,6 +810,7 @@
     "import_button": "导入",
     "title": "数据治理",
     "description": "管理数据库迁移、备份、同步和审计日志",
+    "tabs_nav_label": "数据治理页签",
     "tab_overview": "概览",
     "tab_recovery": "恢复",
     "tab_archive": "归档",

--- a/src/styles/theme-colors.css
+++ b/src/styles/theme-colors.css
@@ -9,8 +9,19 @@
   --surface-overlay: color-mix(in hsl, hsl(var(--card)) 80%, transparent 20%);
   --surface-overlay-strong: color-mix(in hsl, hsl(var(--card)) 65%, hsl(var(--background)) 35%);
   --surface-divider: color-mix(in hsl, hsl(var(--border)) 55%, transparent 45%);
+
+  /* --surface-panel 是面板族的基准层（panel < panel-strong），语义与近邻一致：
+     elevated 与 root 的 mix。故障/恢复路径（StartupPreflight / RecoveryShell /
+     RecoveryCenter / ComponentRecoveryShell / FeatureUnavailablePanel）在
+     token 缺失时会因 background 计算失效而变透明——那正是最不能"没有底色"的
+     场景，所以这里先给不依赖 color-mix 的兜底值，再在文件末尾的 @supports
+     里升级为 mix 版本（Android WebView 等无 color-mix 环境仍有实色底）。 */
+  --surface-panel: hsl(var(--card));
   --surface-panel-muted: color-mix(in hsl, var(--surface-muted) 82%, var(--surface-elevated) 18%);
   --surface-panel-strong: color-mix(in hsl, var(--surface-elevated) 92%, var(--surface-root) 8%);
+
+  /* 语义 accent：对齐 shadcn --primary，供故障面板选中态边框等使用 */
+  --accent-primary: hsl(var(--primary));
 
   /* Desktop shell surfaces
      ------------------------------------------------------------
@@ -103,17 +114,32 @@
   --tooltip-surface: hsl(var(--foreground));
   --tooltip-foreground: hsl(var(--background));
 
+  /* 阴影体系
+     ------------------------------------------------------------
+     --shadow-base 是色相基（始终黑），投影强度全部抽到 --shadow-strength-*，
+     这样暗色主题只需覆写 alpha 档位，不必把整串 box-shadow 配方抄一遍。
+     暗色下沿用亮色 alpha（0.04~0.10）等于没有阴影：背景本身就接近纯黑，
+     浮层与底板完全糊在一起。暗色覆写见 :root.dark 同名 token。
+     ------------------------------------------------------------ */
   --shadow-base: 0 0% 0%;
-  --shadow-shell-soft: 0 12px 24px hsl(var(--shadow-base) / 0.04);
-  --shadow-shell-panel: 0 16px 32px hsl(var(--shadow-base) / 0.05);
-  --shadow-shell-floating: 0 18px 36px hsl(var(--shadow-base) / 0.08);
-  --shadow-shell-pressed: 0 8px 20px hsl(var(--shadow-base) / 0.05);
+  --shadow-strength-soft: 0.04;
+  --shadow-strength-panel: 0.05;
+  --shadow-strength-floating: 0.08;
+  --shadow-strength-pressed: 0.05;
+  --shadow-strength-content-subtle: 0.05;
+  --shadow-strength-content-soft: 0.10;
+  --shadow-strength-content-elevated: 0.06;
+  --shadow-strength-sheet: 0.10;
+  --shadow-shell-soft: 0 12px 24px hsl(var(--shadow-base) / var(--shadow-strength-soft));
+  --shadow-shell-panel: 0 16px 32px hsl(var(--shadow-base) / var(--shadow-strength-panel));
+  --shadow-shell-floating: 0 18px 36px hsl(var(--shadow-base) / var(--shadow-strength-floating));
+  --shadow-shell-pressed: 0 8px 20px hsl(var(--shadow-base) / var(--shadow-strength-pressed));
 
   /* 兼容别名：hover:shadow-[var(--shadow-card)] 的存量消费者（原定义在 card-animations.css） */
   --shadow-card: var(--shadow-shell-soft);
-  --shadow-content-subtle: 0 1px 3px hsl(var(--shadow-base) / 0.05);
-  --shadow-content-soft: 0 2px 8px hsl(var(--shadow-base) / 0.10);
-  --shadow-content-elevated: 0 6px 18px hsl(var(--shadow-base) / 0.06);
+  --shadow-content-subtle: 0 1px 3px hsl(var(--shadow-base) / var(--shadow-strength-content-subtle));
+  --shadow-content-soft: 0 2px 8px hsl(var(--shadow-base) / var(--shadow-strength-content-soft));
+  --shadow-content-elevated: 0 6px 18px hsl(var(--shadow-base) / var(--shadow-strength-content-elevated));
   --text-shadow-contrast-subtle: 0 1px 2px hsl(var(--shadow-base) / 0.10);
   --text-shadow-contrast-medium: 0 1px 2px hsl(var(--shadow-base) / 0.30);
   --text-shadow-contrast-strong: 0 1px 3px hsl(var(--shadow-base) / 0.50);
@@ -133,6 +159,10 @@
   --button-tonal-hover-bg: color-mix(in oklab, hsl(var(--muted)) 78%, hsl(var(--background)) 22%);
   --button-tonal-active-bg: color-mix(in oklab, hsl(var(--accent)) 82%, hsl(var(--background)) 18%);
   --button-tonal-border: color-mix(in oklab, hsl(var(--border)) 78%, hsl(var(--foreground)) 6%);
+
+  /* secondary 按钮表面 = tonal 表面的语义别名（ComposerPlusMenu 的 open 态等
+     直接消费该名字）。无 color-mix 时退回 hsl(var(--secondary)) 实色。 */
+  --button-secondary-surface: hsl(var(--secondary));
   --button-outline-bg: color-mix(in oklab, hsl(var(--background)) 92%, hsl(var(--secondary)) 8%);
   --button-outline-hover-bg: color-mix(in oklab, var(--interactive-hover) 84%, hsl(var(--background)) 16%);
   --button-outline-active-bg: color-mix(in oklab, var(--interactive-selected) 78%, hsl(var(--background)) 22%);
@@ -182,7 +212,7 @@
   --mobile-sheet-border: var(--border-soft);
   --mobile-sheet-header-border: var(--surface-divider);
   --mobile-sheet-handle: var(--border-strong);
-  --mobile-sheet-shadow: 0 -12px 34px hsl(var(--shadow-base) / 0.10);
+  --mobile-sheet-shadow: 0 -12px 34px hsl(var(--shadow-base) / var(--shadow-strength-sheet));
 
   /* Menu shell — AppMenu 下拉/右键菜单外壳，与 composer shell 同族
      设计目的：让弹出菜单看起来像"从输入框延伸出来的一片"，而不是独立风格的 popover。
@@ -256,6 +286,23 @@
   --neutral-muted: var(--neutral) / 0.35;
   --neutral-bg: var(--neutral) / 0.14;
 
+  /* 分类 accent（设置导航图标等"每一栏一个颜色"的场景）
+     ------------------------------------------------------------
+     这些色只承担"区分类别"，不表达状态，所以不能挂到 --success/--warning
+     那一族。原先是散落在 useSettingsNavigation.tsx 里的浅色 hex
+     （#e5ad3d / #4d86df …），在暗色下亮度不足、也无法随主题走，现在收进
+     token 层：亮色沿用原色相，暗色抬亮度、降饱和，高对比模式再抬一档。
+     新增分类请复用下面的档位，不要再往组件里写 hex。
+     ------------------------------------------------------------ */
+  --settings-nav-accent-amber: hsl(40 76% 57%);
+  --settings-nav-accent-blue: hsl(217 69% 59%);
+  --settings-nav-accent-slate: hsl(218 9% 50%);
+  --settings-nav-accent-purple: hsl(272 69% 62%);
+  --settings-nav-accent-orange: hsl(27 81% 59%);
+  --settings-nav-accent-green: hsl(157 73% 42%);
+  --settings-nav-accent-sky: hsl(208 77% 60%);
+  --settings-nav-accent-pink: hsl(327 56% 66%);
+
   /* Citation/source semantics */
   --citation-badge-bg-alpha: 0.10;
   --citation-badge-hover-alpha: 0.20;
@@ -267,6 +314,27 @@
 }
 
 :root.dark {
+  /* 面板族暗色兜底（无 color-mix 时生效，mix 版本见文件末尾 @supports） */
+  --surface-panel: hsl(var(--card));
+  --accent-primary: hsl(var(--primary));
+  --button-secondary-surface: hsl(var(--secondary));
+
+  /* 暗色阴影翻转
+     ------------------------------------------------------------
+     色基仍是黑（不用白阴影：白色投影在深灰底上是"发光"，与本设计体系
+     其余部分的物理光照隐喻冲突），改为整体抬高 alpha 档位。暗色背景
+     L≈9%~12%，0.05 的黑几乎不可见，需要 6~8 倍才能重新读出层次。
+     ------------------------------------------------------------ */
+  --shadow-base: 0 0% 0%;
+  --shadow-strength-soft: 0.32;
+  --shadow-strength-panel: 0.40;
+  --shadow-strength-floating: 0.54;
+  --shadow-strength-pressed: 0.36;
+  --shadow-strength-content-subtle: 0.28;
+  --shadow-strength-content-soft: 0.44;
+  --shadow-strength-content-elevated: 0.40;
+  --shadow-strength-sheet: 0.52;
+
   --interactive-hover: color-mix(in hsl, hsl(var(--foreground)) 10%, transparent 90%);
   --interactive-selected: color-mix(in hsl, hsl(var(--foreground)) 10%, transparent 90%);
   --overlay-control-hover: rgba(255, 255, 255, 0.2);
@@ -325,6 +393,64 @@
   --scrollbar-thumb: color-mix(in oklab, hsl(var(--foreground)) 22%, transparent);
   --scrollbar-thumb-hover: color-mix(in oklab, hsl(var(--foreground)) 36%, transparent);
   --scrollbar-thumb-active: color-mix(in oklab, hsl(var(--foreground)) 50%, transparent);
+
+  /* 分类 accent 暗色档：背景 L≈9%，亮色档（L 42%~62%）在其上对比不足，
+     统一抬到 L 56%~74% 并降一点饱和，避免深底上的荧光感。 */
+  --settings-nav-accent-amber: hsl(40 72% 66%);
+  --settings-nav-accent-blue: hsl(217 66% 72%);
+  --settings-nav-accent-slate: hsl(218 10% 68%);
+  --settings-nav-accent-purple: hsl(272 62% 74%);
+  --settings-nav-accent-orange: hsl(27 74% 68%);
+  --settings-nav-accent-green: hsl(157 55% 58%);
+  --settings-nav-accent-sky: hsl(208 70% 70%);
+  --settings-nav-accent-pink: hsl(327 52% 74%);
+}
+
+/* 高对比偏好：分类 accent 再抬一档亮度/饱和（亮色压暗、暗色提亮），
+   与 workbench a11y-cursor.css 的 prefers-contrast 策略同族。 */
+@media (prefers-contrast: more) {
+  :where(:root) {
+    --settings-nav-accent-amber: hsl(40 82% 38%);
+    --settings-nav-accent-blue: hsl(217 74% 44%);
+    --settings-nav-accent-slate: hsl(218 12% 34%);
+    --settings-nav-accent-purple: hsl(272 72% 46%);
+    --settings-nav-accent-orange: hsl(27 86% 42%);
+    --settings-nav-accent-green: hsl(157 78% 28%);
+    --settings-nav-accent-sky: hsl(208 82% 42%);
+    --settings-nav-accent-pink: hsl(327 62% 46%);
+  }
+
+  :root.dark {
+    --settings-nav-accent-amber: hsl(40 80% 76%);
+    --settings-nav-accent-blue: hsl(217 76% 80%);
+    --settings-nav-accent-slate: hsl(218 12% 80%);
+    --settings-nav-accent-purple: hsl(272 72% 82%);
+    --settings-nav-accent-orange: hsl(27 82% 78%);
+    --settings-nav-accent-green: hsl(157 62% 70%);
+    --settings-nav-accent-sky: hsl(208 80% 80%);
+    --settings-nav-accent-pink: hsl(327 62% 82%);
+  }
+}
+
+/* 面板族 / secondary 表面的 color-mix 升级档
+   ------------------------------------------------------------
+   自定义属性一旦存了不被支持的 color-mix()，替换到 background 时会
+   "computed-value time invalid" → 面板直接透明，故障面板会整块看不见底。
+   把 mix 版本收进 @supports，无 color-mix 的运行时（老 Android WebView）
+   停留在上面的实色兜底值。选择器必须与兜底处逐一对应，否则 :root.dark
+   的实色声明（特异性更高）会压过这里的 :where(:root)。
+   ------------------------------------------------------------ */
+@supports (background: color-mix(in hsl, red 50%, blue)) {
+  :where(:root) {
+    --surface-panel: color-mix(in hsl, var(--surface-elevated) 78%, var(--surface-root) 22%);
+    --button-secondary-surface: var(--button-tonal-bg);
+  }
+
+  :root.dark {
+    /* 暗色下面板要比 root 明显抬起一档，否则故障面板与背板同色 */
+    --surface-panel: color-mix(in hsl, var(--surface-elevated) 88%, var(--surface-root) 12%);
+    --button-secondary-surface: var(--button-tonal-bg);
+  }
 }
 
 @media (prefers-reduced-transparency: reduce) {

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -71,9 +71,19 @@ small, .text-sm {
 	font-size: var(--font-size-sm);
 }
 
-/* UI 文本 - 侧边栏、菜单等 */
-.text-ui {
-	font-size: var(--font-size-sm);
+/* UI 文本 - 侧边栏、菜单、按钮标签等
+ *
+ * 与 Tailwind 的 text-ui 工具类（tailwind.config.js fontSize.ui →
+ * --font-size-ui = 13px × --font-size-scale）是同一个类名。本文件在 App.tsx
+ * 里晚于 tailwind.css 引入，未加 :where() 时这条规则会盖掉工具类，导致
+ * text-ui 实际渲染成 12px，并顺带压掉同元素上的 font-* / tracking-* 工具类。
+ *
+ * 现在：字号对齐 --font-size-ui（与工具类同值，二者谁赢都是 13px 且吃
+ * 字号缩放），并用 :where() 把特异性归零，weight / letter-spacing 退化成
+ * 可被任意工具类覆盖的默认值。
+ */
+:where(.text-ui) {
+	font-size: var(--font-size-ui);
 	font-weight: var(--font-weight-medium);
 	letter-spacing: var(--letter-spacing-normal);
 }

--- a/tests/vitest/command-palette/commandPaletteA11yContract.test.tsx
+++ b/tests/vitest/command-palette/commandPaletteA11yContract.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * 命令面板键盘 / 读屏契约：
+ * - 搜索框是 combobox，通过 aria-controls / aria-activedescendant 关联结果 listbox
+ * - 结果项是 option 且有稳定 id，方向键改变 aria-activedescendant
+ * - Tab 不再被一刀切吞掉：可以走到面板内的收藏 / 模式 / 关闭按钮，并在两端回绕
+ * - 移动端（390 宽）：关闭入口可聚焦，焦点仍锁在面板内
+ */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@/command-palette/hooks/useResourceSearch', () => ({
+  useResourceSearch: () => ({ fileResults: [], sessionResults: [] }),
+  openFileFromPalette: vi.fn(),
+  openSessionFromPalette: vi.fn(),
+}));
+
+import { CommandPalette } from '@/command-palette/CommandPalette';
+import { CommandPaletteProvider, useCommandPalette } from '@/command-palette/CommandPaletteProvider';
+import { commandRegistry } from '@/command-palette/registry/commandRegistry';
+import { commandFavorites } from '@/command-palette/registry/commandFavorites';
+import type { Command } from '@/command-palette/registry/types';
+
+const DESKTOP_WIDTH = 1280;
+const MOBILE_WIDTH = 390;
+
+/** 让 matchMedia 按给定视口宽度回答 (min-width: Npx) 查询 */
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => {
+      const minWidth = /\(min-width:\s*(\d+)px\)/.exec(query);
+      const matches = minWidth ? width >= Number(minWidth[1]) : false;
+      return {
+        matches,
+        media: query,
+        onchange: null,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        dispatchEvent: () => false,
+      };
+    },
+  });
+}
+
+const TEST_COMMANDS: Command[] = [
+  {
+    id: 'test.alpha',
+    name: 'Alpha command',
+    category: 'navigation',
+    execute: () => undefined,
+  },
+  {
+    id: 'test.beta',
+    name: 'Beta command',
+    category: 'navigation',
+    execute: () => undefined,
+  },
+];
+
+function OpenPaletteButton() {
+  const { open } = useCommandPalette();
+  return (
+    <button type="button" onClick={open}>
+      open-palette
+    </button>
+  );
+}
+
+function renderPalette() {
+  return render(
+    <CommandPaletteProvider
+      currentView="chat-v2"
+      navigate={() => undefined}
+      toggleTheme={() => undefined}
+      isDarkMode={false}
+      switchLanguage={() => undefined}
+    >
+      <OpenPaletteButton />
+      <CommandPalette />
+    </CommandPaletteProvider>,
+  );
+}
+
+async function openPalette() {
+  renderPalette();
+  fireEvent.click(screen.getByText('open-palette'));
+  return screen.findByRole('combobox');
+}
+
+function paletteFocusables(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(
+      '.command-palette-container button, .command-palette-container input',
+    ),
+  );
+}
+
+beforeEach(() => {
+  setViewportWidth(DESKTOP_WIDTH);
+  commandRegistry.clear();
+  commandRegistry.registerAll(TEST_COMMANDS);
+  for (const id of commandFavorites.getAll()) {
+    commandFavorites.toggle(id);
+  }
+});
+
+afterEach(() => {
+  commandRegistry.clear();
+});
+
+describe('CommandPalette 键盘 / 读屏契约', () => {
+  it('搜索框是 combobox 且用 aria-controls 指向结果 listbox', async () => {
+    const input = await openPalette();
+
+    const listbox = screen.getByRole('listbox');
+    expect(listbox.id).toBeTruthy();
+    expect(input).toHaveAttribute('aria-controls', listbox.id);
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    expect(input).toHaveAttribute('aria-autocomplete', 'list');
+  });
+
+  it('aria-activedescendant 指向当前高亮的 option，方向键会跟着走', async () => {
+    const input = await openPalette();
+
+    const options = screen.getAllByRole('option');
+    expect(options.length).toBeGreaterThanOrEqual(2);
+    for (const option of options) {
+      expect(option.id).toBeTruthy();
+    }
+
+    expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-activedescendant', options[1].id);
+    });
+    expect(screen.getAllByRole('option')[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('结果分组是带可访问名的 group，不是裸 div', async () => {
+    await openPalette();
+
+    const groups = screen.getAllByRole('group');
+    expect(groups.length).toBeGreaterThanOrEqual(1);
+    const labelId = groups[0].getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    expect(document.getElementById(labelId!)).not.toBeNull();
+  });
+
+  it('Tab 不再被一刀切吞掉：可以从搜索框走到面板内的按钮', async () => {
+    const user = userEvent.setup();
+    const input = await openPalette();
+
+    await waitFor(() => expect(input).toHaveFocus());
+
+    // 旧实现在这里对 Tab 无条件 preventDefault，焦点永远停在输入框
+    expect(fireEvent.keyDown(input, { key: 'Tab' })).toBe(true);
+
+    await user.tab();
+    expect(document.activeElement).not.toBe(input);
+    expect(document.activeElement?.tagName).toBe('BUTTON');
+  });
+
+  it('面板内的图标按钮（收藏 / 模式 / 关闭）都有可访问名', async () => {
+    await openPalette();
+
+    expect(screen.getByRole('button', { name: /command_palette:mode_recent/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /command_palette:mode_favorites/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /关闭|common:close/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /command_palette:favorite — Alpha command/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('Tab 焦点环闭合：最后一个控件按 Tab 回到第一个，Shift+Tab 反向回绕', async () => {
+    const input = await openPalette();
+
+    const focusables = paletteFocusables();
+    expect(focusables.length).toBeGreaterThan(1);
+
+    const last = focusables[focusables.length - 1];
+    last.focus();
+    expect(fireEvent.keyDown(last, { key: 'Tab' })).toBe(false);
+    expect(document.activeElement).toBe(focusables[0]);
+
+    input.focus();
+    expect(fireEvent.keyDown(input, { key: 'Tab', shiftKey: true })).toBe(false);
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('焦点在面板内按钮上时，Enter 归按钮，不再被「执行高亮命令」抢走', async () => {
+    await openPalette();
+
+    const favoriteButton = screen.getByRole('button', {
+      name: /command_palette:favorite — Alpha command/,
+    });
+    favoriteButton.focus();
+
+    // 未被 preventDefault → 浏览器把 Enter 交给按钮的默认激活行为
+    expect(fireEvent.keyDown(favoriteButton, { key: 'Enter' })).toBe(true);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('Escape 关闭面板，焦点回到打开面板的元素', async () => {
+    renderPalette();
+    const trigger = screen.getByText('open-palette');
+    trigger.focus();
+    fireEvent.click(trigger);
+    const input = await screen.findByRole('combobox');
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    });
+    expect(document.activeElement).toBe(trigger);
+  });
+});
+
+describe('CommandPalette 移动端（390 宽）焦点契约', () => {
+  beforeEach(() => {
+    setViewportWidth(MOBILE_WIDTH);
+  });
+
+  it('全屏形态下关闭入口可聚焦，且焦点仍锁在面板内', async () => {
+    const input = await openPalette();
+
+    const closeButton = screen.getByRole('button', { name: /返回|common:back/ });
+    closeButton.focus();
+    expect(document.activeElement).toBe(closeButton);
+
+    // 关闭入口是面板内第一个可聚焦控件：Shift+Tab 应回绕到面板末尾，而不是逃到背景页
+    const focusables = paletteFocusables();
+    expect(focusables[0]).toBe(closeButton);
+    expect(fireEvent.keyDown(closeButton, { key: 'Tab', shiftKey: true })).toBe(false);
+    expect(document.activeElement).toBe(focusables[focusables.length - 1]);
+
+    // 输入框依旧是 combobox
+    expect(input).toHaveAttribute('role', 'combobox');
+  });
+
+  it('点击关闭入口能关掉面板', async () => {
+    await openPalette();
+
+    fireEvent.click(screen.getByRole('button', { name: /返回|common:back/ }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/tests/vitest/command-palette/commandPaletteMobileTouchContract.source.test.ts
+++ b/tests/vitest/command-palette/commandPaletteMobileTouchContract.source.test.ts
@@ -1,0 +1,69 @@
+/**
+ * 命令面板移动端触控/缩放契约（源码断言）：
+ * CSS 由 vitest 的 `css: false` 跳过处理，无法在 jsdom 里量到真实计算值，
+ * 因此对样式表源码做契约断言，锁住 390px 宽下的三条硬指标。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const css = readFileSync(
+  resolve(process.cwd(), 'src/command-palette/styles/command-palette.css'),
+  'utf-8',
+);
+
+/** 取出某个 @media 块的内容（按大括号配平截取） */
+function mediaBlock(header: string): string {
+  const start = css.indexOf(header);
+  expect(start).toBeGreaterThanOrEqual(0);
+  let depth = 0;
+  for (let i = css.indexOf('{', start); i < css.length; i += 1) {
+    if (css[i] === '{') depth += 1;
+    if (css[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return css.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unbalanced media block: ${header}`);
+}
+
+describe('命令面板移动端触控契约', () => {
+  const narrowViewportBlocks = css
+    .split('@media')
+    .filter((chunk) => chunk.trimStart().startsWith('(width < 768px)'));
+
+  it('窄视口下输入框字号不低于 iOS 自动缩放阈值 16px', () => {
+    const inputRule = narrowViewportBlocks
+      .join('\n')
+      .match(/\.command-palette-input\s*\{[^}]*\}/);
+    expect(inputRule).not.toBeNull();
+    expect(inputRule![0]).toMatch(/font-size:\s*16px/);
+  });
+
+  it('窄视口下结果行触控高度 ≥44px（不依赖 pointer: coarse）', () => {
+    expect(narrowViewportBlocks.join('\n')).toMatch(
+      /\.command-palette-item\s*\{[^}]*min-height:\s*44px/,
+    );
+  });
+
+  it('窄视口下关闭/返回/模式按钮触控目标 ≥44px', () => {
+    const joined = narrowViewportBlocks.join('\n');
+    const touchTargetRule = joined.match(
+      /\.command-palette-back-btn,\s*\n\s*\.command-palette-close-btn,\s*\n\s*\.command-palette-mode-btn\s*\{[^}]*\}/,
+    );
+    expect(touchTargetRule).not.toBeNull();
+    expect(touchTargetRule![0]).toMatch(/width:\s*44px/);
+    expect(touchTargetRule![0]).toMatch(/height:\s*44px/);
+  });
+
+  it('粗指针下同样保留 44px 触控目标与常显收藏按钮', () => {
+    const coarse = mediaBlock('@media (pointer: coarse)');
+    expect(coarse).toMatch(/\.command-palette-item\s*\{[^}]*min-height:\s*44px/);
+    expect(coarse).toMatch(/\.command-palette-item-favorite\s*\{[^}]*opacity:\s*1/);
+  });
+
+  it('收藏按钮聚焦时必须显形，避免「不可见但可 Tab 到」的键盘陷阱', () => {
+    expect(css).toContain('.command-palette-item-favorite:focus-visible');
+  });
+});

--- a/tests/vitest/darkShadowElevationContract.test.ts
+++ b/tests/vitest/darkShadowElevationContract.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * 暗色阴影层次契约。
+ *
+ * --shadow-base 是纯黑色相基，投影强度由 --shadow-strength-* 承担。暗色主题
+ * 背景 L≈9%~12%，沿用亮色的 0.04~0.10 alpha 等于没有阴影，浮层与底板完全
+ * 糊在一起。本测试锁住：强度 token 存在、暗色确实抬高了每一档、配方不再
+ * 内联写死 alpha，并且暗色仍然用黑基（白阴影是"发光"，与本体系的光照隐喻
+ * 冲突）。
+ */
+describe('dark mode shadow elevation contract', () => {
+  const themeSource = readFileSync(resolve(process.cwd(), 'src/styles/theme-colors.css'), 'utf-8');
+
+  const blockOf = (selector: string) => {
+    const start = themeSource.indexOf(`${selector} {`);
+    expect(start, `theme-colors.css should contain a ${selector} block`).toBeGreaterThan(-1);
+    return themeSource.slice(start, themeSource.indexOf('\n}', start));
+  };
+
+  const lightBlock = blockOf(':where(:root)');
+  const darkBlock = blockOf(':root.dark');
+
+  const strengths = (block: string) => {
+    const map = new Map<string, number>();
+    for (const match of block.matchAll(/(--shadow-strength-[a-z-]+):\s*([\d.]+);/g)) {
+      map.set(match[1], Number.parseFloat(match[2]));
+    }
+    return map;
+  };
+
+  const lightStrengths = strengths(lightBlock);
+  const darkStrengths = strengths(darkBlock);
+
+  it('exposes a shadow strength scale in the light token block', () => {
+    expect([...lightStrengths.keys()].sort()).toEqual([
+      '--shadow-strength-content-elevated',
+      '--shadow-strength-content-soft',
+      '--shadow-strength-content-subtle',
+      '--shadow-strength-floating',
+      '--shadow-strength-panel',
+      '--shadow-strength-pressed',
+      '--shadow-strength-sheet',
+      '--shadow-strength-soft',
+    ]);
+  });
+
+  it('raises every shadow strength step in dark mode to a visible alpha', () => {
+    expect(darkStrengths.size).toBe(lightStrengths.size);
+    for (const [token, lightValue] of lightStrengths) {
+      const darkValue = darkStrengths.get(token);
+      expect(darkValue, `${token} must be re-tuned for dark mode`).toBeDefined();
+      expect(darkValue!, `${token} must be stronger in dark mode`).toBeGreaterThan(lightValue);
+      // 0.25 以下的黑色投影在 L≈9% 的底上肉眼不可见
+      expect(darkValue!, `${token} must be visible on a near-black surface`).toBeGreaterThanOrEqual(0.25);
+    }
+  });
+
+  it('keeps a black shadow base in both themes instead of flipping to a white glow', () => {
+    expect(lightBlock).toMatch(/--shadow-base:\s*0 0% 0%;/);
+    expect(darkBlock).toMatch(/--shadow-base:\s*0 0% 0%;/);
+  });
+
+  it('routes the shared shadow recipes through the strength scale', () => {
+    const recipes = [
+      '--shadow-shell-soft',
+      '--shadow-shell-panel',
+      '--shadow-shell-floating',
+      '--shadow-shell-pressed',
+      '--shadow-content-subtle',
+      '--shadow-content-soft',
+      '--shadow-content-elevated',
+      '--mobile-sheet-shadow',
+    ];
+
+    for (const recipe of recipes) {
+      const declaration = lightBlock.match(new RegExp(`${recipe}:\\s*([^;]+);`))?.[1] ?? '';
+      expect(declaration, `${recipe} should be defined in the light token block`).not.toBe('');
+      expect(declaration, `${recipe} should read its alpha from --shadow-strength-*`).toMatch(
+        /hsl\(var\(--shadow-base\) \/ var\(--shadow-strength-[a-z-]+\)\)/,
+      );
+      expect(declaration, `${recipe} should not inline a hardcoded alpha`).not.toMatch(
+        /var\(--shadow-base\)\s*\/\s*[\d.]+/,
+      );
+    }
+  });
+});

--- a/tests/vitest/data-governance/DataGovernanceDashboard.debug-tab-visibility.test.tsx
+++ b/tests/vitest/data-governance/DataGovernanceDashboard.debug-tab-visibility.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Debug 页签只在开发构建暴露 + 8 个图标页签的读屏可访问名。
+ *
+ * 生产构建里 Debug 页签的控件全部 `disabled`，页签本身却照常渲染；
+ * 移动端（<640px）页签文字被 `hidden sm:inline` 收掉，只剩一个虫子图标，
+ * 读屏读出来就是一个无名按钮。这里同时锁住这两条契约。
+ */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const mockDataGovernanceApi = vi.hoisted(() => ({
+  getMigrationStatus: vi.fn(),
+  runHealthCheck: vi.fn(),
+  getBackupList: vi.fn(),
+  listResumableJobs: vi.fn(),
+  getSyncStatus: vi.fn(),
+  getAuditLogs: vi.fn(),
+}));
+
+vi.mock('@/api/dataGovernance', () => ({
+  DataGovernanceApi: mockDataGovernanceApi,
+  BACKUP_JOB_PROGRESS_EVENT: 'backup-job-progress',
+  isBackupJobTerminal: (status: string) =>
+    status === 'completed' || status === 'failed' || status === 'cancelled',
+}));
+
+vi.mock('@/hooks/useBackupJobListener', () => ({
+  useBackupJobListener: () => ({
+    startListening: vi.fn(),
+    stopListening: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/settings/components/MediaCacheSection', () => ({
+  MediaCacheSection: () => <div data-testid="media-cache-section">cache-section</div>,
+}));
+
+vi.mock('@/utils/tauriApi', () => ({
+  TauriAPI: { restartApp: vi.fn() },
+}));
+
+import { DataGovernanceDashboard } from '@/features/settings';
+
+const TAB_NAMES = [
+  /概览|data:governance\.tab_overview/i,
+  /恢复|data:governance\.tab_recovery/i,
+  /归档|data:governance\.tab_archive/i,
+  /备份|data:governance\.tab_backup/i,
+  /同步|data:governance\.tab_sync/i,
+  /审计|data:governance\.tab_audit/i,
+  /缓存|data:governance\.tab_cache/i,
+];
+
+const DEBUG_TAB_NAME = /^调试$|data:governance\.debug_tab_title/i;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDataGovernanceApi.getMigrationStatus.mockResolvedValue({
+    global_version: 10,
+    all_healthy: true,
+    databases: [],
+    pending_migrations_total: 0,
+    has_pending_migrations: false,
+    last_error: null,
+  });
+  mockDataGovernanceApi.runHealthCheck.mockResolvedValue({
+    overall_healthy: true,
+    total_databases: 3,
+    initialized_count: 3,
+    uninitialized_count: 0,
+    dependency_check_passed: true,
+    dependency_error: null,
+    databases: [],
+    checked_at: '2026-02-07T00:00:00Z',
+    pending_migrations_count: 0,
+    has_pending_migrations: false,
+    audit_log_healthy: true,
+    audit_log_error: null,
+    audit_log_error_at: null,
+  });
+  mockDataGovernanceApi.getSyncStatus.mockResolvedValue(null);
+  mockDataGovernanceApi.getAuditLogs.mockResolvedValue({ logs: [], total: 0 });
+  mockDataGovernanceApi.getBackupList.mockResolvedValue([]);
+  mockDataGovernanceApi.listResumableJobs.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('数据治理页签可访问名', () => {
+  it('每个页签都有可访问名（文字在窄屏被隐藏时靠 aria-label 兜底）', async () => {
+    render(<DataGovernanceDashboard embedded />);
+
+    for (const name of TAB_NAMES) {
+      expect(screen.getByRole('button', { name })).toBeInTheDocument();
+    }
+
+    // 每个 trigger 的可访问名必须来自 aria-label，而不是只存在于 `hidden sm:inline` 的文字里
+    const overviewTab = screen.getByRole('button', { name: TAB_NAMES[0] });
+    expect(overviewTab).toHaveAttribute('aria-label');
+  });
+
+  it('页签容器带导航可访问名', () => {
+    render(<DataGovernanceDashboard embedded />);
+
+    const overviewTab = screen.getByRole('button', { name: TAB_NAMES[0] });
+    const tabsList = overviewTab.parentElement;
+    expect(tabsList).toHaveAttribute('aria-label');
+  });
+});
+
+describe('Debug 页签的 DEV 门槛', () => {
+  it('开发构建下渲染 Debug 页签', () => {
+    vi.stubEnv('DEV', true);
+
+    render(<DataGovernanceDashboard embedded />);
+
+    expect(screen.getByRole('button', { name: DEBUG_TAB_NAME })).toBeInTheDocument();
+  });
+
+  it('非 DEV（生产构建）不渲染 Debug 页签', async () => {
+    vi.stubEnv('DEV', false);
+
+    render(<DataGovernanceDashboard embedded />);
+
+    // 其他页签照常在，只有 Debug 消失
+    expect(screen.getByRole('button', { name: TAB_NAMES[0] })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: DEBUG_TAB_NAME })).not.toBeInTheDocument();
+  });
+
+  it('非 DEV 时外部深链也切不到 debug 页签', async () => {
+    vi.stubEnv('DEV', false);
+
+    render(
+      <DataGovernanceDashboard embedded tabTarget={{ tab: 'debug', requestId: 1 }} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: TAB_NAMES[0] })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: DEBUG_TAB_NAME })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slot-c-empty-db-test-button')).not.toBeInTheDocument();
+  });
+});

--- a/tests/vitest/failurePathSurfaceTokenContract.test.ts
+++ b/tests/vitest/failurePathSurfaceTokenContract.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * 故障/恢复路径的底色契约。
+ *
+ * 这些面板是「其他东西已经坏了」时唯一还会渲染的界面，一旦它们消费的
+ * surface token 没有定义，background 会在 computed-value time 失效 →
+ * 整块透明，用户看到的是叠字。2026-08 审计发现 --surface-panel /
+ * --accent-primary / --button-secondary-surface 三个 token 从未在 token 层
+ * 定义过，本测试防止再次退化。
+ */
+describe('failure-path surface token contract', () => {
+  const themeSource = readFileSync(resolve(process.cwd(), 'src/styles/theme-colors.css'), 'utf-8');
+
+  /** 消费这些 token 的故障/恢复路径与输入栏菜单 */
+  const CONSUMERS = [
+    'src/features/data-recovery/StartupPreflight.tsx',
+    'src/features/data-recovery/ComponentRecoveryShell.tsx',
+    'src/features/data-recovery/RecoveryCenter.tsx',
+    'src/features/data-recovery/RecoveryShell.tsx',
+    'src/components/system-status/FeatureUnavailablePanel.tsx',
+    'src/features/chat/components/input-bar/ComposerPlusMenu.tsx',
+  ];
+
+  const collectCssFiles = (dir: string, acc: string[] = []): string[] => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) collectCssFiles(full, acc);
+      else if (entry.name.endsWith('.css')) acc.push(full);
+    }
+    return acc;
+  };
+
+  const definedCustomProperties = (() => {
+    const names = new Set<string>();
+    for (const file of collectCssFiles(resolve(process.cwd(), 'src'))) {
+      for (const match of readFileSync(file, 'utf-8').matchAll(/(--[a-zA-Z0-9-]+)\s*:/g)) {
+        names.add(match[1]);
+      }
+    }
+    return names;
+  })();
+
+  /** 取某个选择器块的正文（只取第一段，够用来断言 token 是否在该主题下定义） */
+  const blockOf = (selector: string) => {
+    const start = themeSource.indexOf(`${selector} {`);
+    expect(start, `theme-colors.css should contain a ${selector} block`).toBeGreaterThan(-1);
+    const end = themeSource.indexOf('\n}', start);
+    return themeSource.slice(start, end);
+  };
+
+  const lightBlock = blockOf(':where(:root)');
+  const darkBlock = blockOf(':root.dark');
+
+  const NEW_TOKENS = ['--surface-panel', '--accent-primary', '--button-secondary-surface'] as const;
+
+  it('defines every custom property the failure-path panels consume', () => {
+    for (const consumer of CONSUMERS) {
+      const source = readFileSync(resolve(process.cwd(), consumer), 'utf-8');
+      const consumed = [...source.matchAll(/var\((--[a-zA-Z0-9-]+)\s*[,)]/g)].map(match => match[1]);
+      expect(consumed.length, `${consumer} should consume design tokens`).toBeGreaterThan(0);
+      for (const token of consumed) {
+        expect(
+          definedCustomProperties.has(token),
+          `${token} is consumed by ${consumer} but never defined in any src/**/*.css token layer`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('defines the panel/accent/secondary tokens in both the light and dark token blocks', () => {
+    for (const token of NEW_TOKENS) {
+      expect(lightBlock, `${token} must be defined for the light theme`).toContain(`${token}:`);
+      expect(darkBlock, `${token} must be defined for the dark theme`).toContain(`${token}:`);
+    }
+  });
+
+  it('keeps a non-color-mix fallback so panels never fall back to transparent', () => {
+    // 兜底声明（:where(:root) / :root.dark 里的那一份）必须是实色，
+    // 老 Android WebView 不认 color-mix 时仍然有底。
+    for (const block of [lightBlock, darkBlock]) {
+      for (const token of NEW_TOKENS) {
+        const declaration = block.match(new RegExp(`${token}:\\s*([^;]+);`))?.[1] ?? '';
+        expect(declaration, `${token} fallback should not depend on color-mix`).not.toContain('color-mix');
+        expect(declaration.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('upgrades the panel/secondary surfaces to color-mix behind @supports', () => {
+    const supportsStart = themeSource.indexOf('@supports (background: color-mix(');
+    expect(supportsStart, 'theme-colors.css should guard the color-mix upgrade with @supports').toBeGreaterThan(-1);
+    const supportsBlock = themeSource.slice(supportsStart, themeSource.indexOf('\n}\n', supportsStart));
+
+    // 两个选择器都要覆写：:root.dark 的实色兜底特异性高于 :where(:root)，
+    // 只升级 :where(:root) 的话暗色会停在兜底值。
+    expect(supportsBlock).toContain(':where(:root)');
+    expect(supportsBlock).toContain(':root.dark');
+    expect(supportsBlock).toMatch(/--surface-panel:\s*color-mix\(in hsl, var\(--surface-elevated\)/);
+    expect(supportsBlock.match(/--surface-panel:/g)).toHaveLength(2);
+    expect(supportsBlock.match(/--button-secondary-surface:\s*var\(--button-tonal-bg\)/g)).toHaveLength(2);
+  });
+
+  it('keeps --accent-primary aligned with the shadcn primary token', () => {
+    expect(lightBlock).toMatch(/--accent-primary:\s*hsl\(var\(--primary\)\);/);
+    expect(darkBlock).toMatch(/--accent-primary:\s*hsl\(var\(--primary\)\);/);
+  });
+
+  it('keeps the settings navigation accents in the token layer instead of hex literals', () => {
+    const navSource = readFileSync(
+      resolve(process.cwd(), 'src/features/settings/components/useSettingsNavigation.tsx'),
+      'utf-8',
+    );
+    expect(navSource).not.toMatch(/mobileAccent:\s*'#/);
+    expect(navSource).toContain('var(--settings-nav-accent-amber)');
+
+    for (const match of navSource.matchAll(/var\((--settings-nav-accent-[a-z]+)\)/g)) {
+      expect(lightBlock, `${match[1]} must have a light value`).toContain(`${match[1]}:`);
+      expect(darkBlock, `${match[1]} must be re-tuned for dark mode`).toContain(`${match[1]}:`);
+    }
+
+    // 高对比偏好档（与 workbench a11y-cursor.css 同族）
+    expect(themeSource).toMatch(/@media \(prefers-contrast: more\)[\s\S]*--settings-nav-accent-amber:/);
+  });
+});

--- a/tests/vitest/fontSizeScaleClosureContract.test.ts
+++ b/tests/vitest/fontSizeScaleClosureContract.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import {
+  buttonBaseClassName,
+  buttonIconSizeClassNames,
+  buttonSizeClassNames,
+  shellNavBaseClassName,
+} from '@/components/ui/buttonPrimitiveContract';
+
+/**
+ * 字号缩放闭环契约。
+ *
+ * 设置 → 外观 → 界面字号写的是 --font-size-scale（fontConfig.ts），所有
+ * --font-size-* token 都是 calc(Npx * var(--font-size-scale))。Tailwind 的
+ * 任意值字号（text-[13px] 这类）是编译期常量，完全不参与缩放——按钮标签曾
+ * 是最显眼的漏网层。本测试锁住共享按钮/基元这一层的闭环，并确认新增违规有
+ * lint 拦截。
+ */
+describe('font size scale closure contract', () => {
+  const readSource = (relative: string) => readFileSync(resolve(process.cwd(), relative), 'utf-8');
+
+  const ARBITRARY_FONT_SIZE = /(?<![a-zA-Z0-9])text-\[(?:length:)?\d*\.?\d+(?:px|rem|em|pt)\]/;
+
+  it('scales every font-size token off --font-size-scale', () => {
+    const shadcnVars = readSource('src/styles/shadcn-variables.css');
+    const sizeTokens = [...shadcnVars.matchAll(/(--font-size-(?!scale)[a-z0-9-]+):\s*([^;]+);/g)];
+    expect(sizeTokens.length).toBeGreaterThan(5);
+    for (const [, token, value] of sizeTokens) {
+      expect(value, `${token} must be derived from --font-size-scale`).toContain('var(--font-size-scale)');
+    }
+    expect(shadcnVars).toContain('--font-size-ui: calc(13px * var(--font-size-scale));');
+    expect(readSource('src/config/fontConfig.ts')).toContain("setProperty('--font-size-scale'");
+  });
+
+  it('maps the Tailwind text-ui utility onto the scalable ui token', () => {
+    expect(readSource('tailwind.config.js')).toMatch(/'ui':\s*'var\(--font-size-ui\)'/);
+  });
+
+  it('keeps the hand-written .text-ui rule from shadowing the Tailwind utility', () => {
+    const typography = readSource('src/styles/typography.css');
+    // typography.css 晚于 tailwind.css 引入：不加 :where() 归零特异性的话，
+    // 这条规则会盖掉 text-ui 工具类（12px vs 13px），并顺带压掉同元素上的
+    // font-* / tracking-* 工具类。
+    expect(typography).toMatch(/:where\(\.text-ui\)\s*\{/);
+    expect(typography).not.toMatch(/^\.text-ui\s*\{/m);
+    const rule = typography.match(/:where\(\.text-ui\)\s*\{([^}]*)\}/)?.[1] ?? '';
+    expect(rule).toContain('font-size: var(--font-size-ui);');
+  });
+
+  it('routes shared button recipes through token font sizes', () => {
+    expect(buttonBaseClassName).toContain('text-ui');
+    expect(shellNavBaseClassName).toContain('text-ui');
+    expect(buttonSizeClassNames.default).toContain('text-ui');
+    expect(buttonSizeClassNames.md).toContain('text-ui');
+    expect(buttonSizeClassNames.sm).toContain('text-xs');
+    expect(buttonSizeClassNames.lg).toContain('text-sm');
+
+    for (const [name, recipe] of Object.entries({ buttonBaseClassName, shellNavBaseClassName, ...buttonSizeClassNames })) {
+      expect(recipe, `${name} must not hardcode a font size`).not.toMatch(ARBITRARY_FONT_SIZE);
+    }
+  });
+
+  it('keeps touch targets at the 44px baseline regardless of font scale', () => {
+    // 字号放大不能把触控目标压小：高度走固定几何 token，桌面才在 lg 断点压缩。
+    for (const [size, recipe] of Object.entries(buttonSizeClassNames)) {
+      expect(recipe, `size=${size} must keep the coarse-pointer touch target`).toContain(
+        'h-[var(--touch-target-size)]',
+      );
+    }
+    for (const [size, recipe] of Object.entries(buttonIconSizeClassNames)) {
+      expect(recipe, `iconOnly size=${size} must keep the coarse-pointer touch target`).toContain(
+        'h-[var(--touch-target-size)] w-[var(--touch-target-size)]',
+      );
+    }
+    expect(readSource('src/styles/shadcn-variables.css')).toContain('--control-height-touch: 44px;');
+    expect(readSource('src/styles/shadcn-variables.css')).toContain('--touch-target-size: var(--control-height-touch);');
+  });
+
+  it('leaves no hardcoded font size in the shared UI primitives', () => {
+    const collect = (dir: string, acc: string[] = []): string[] => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) collect(full, acc);
+        else if (/\.tsx?$/.test(entry.name)) acc.push(full);
+      }
+      return acc;
+    };
+
+    const offenders: string[] = [];
+    for (const file of collect(resolve(process.cwd(), 'src/components/ui'))) {
+      const source = readFileSync(file, 'utf-8')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/\/\/[^\n]*/g, '');
+      const match = source.match(ARBITRARY_FONT_SIZE);
+      if (match) offenders.push(`${file.replace(`${process.cwd()}/`, '')}: ${match[0]}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('wires the lint guard that blocks new hardcoded font sizes', () => {
+    const eslintConfig = readSource('eslint.config.js');
+    expect(eslintConfig).toContain("import noArbitraryFontSize from './eslint-rules/no-arbitrary-font-size.js'");
+    expect(eslintConfig).toContain("'no-arbitrary-font-size': noArbitraryFontSize");
+    expect(eslintConfig).toContain("'ds-components/no-arbitrary-font-size': 'warn'");
+    // 共享基元目录已清零，必须是 error 而不是 warn
+    expect(eslintConfig).toMatch(
+      /files:\s*\['src\/components\/ui\/\*\*\/\*\.\{ts,tsx\}'\][\s\S]{0,320}?'ds-components\/no-arbitrary-font-size':\s*'error'/,
+    );
+  });
+});

--- a/tests/vitest/noArbitraryFontSizeRule.test.ts
+++ b/tests/vitest/noArbitraryFontSizeRule.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { Linter } from 'eslint';
+import rule from '../../eslint-rules/no-arbitrary-font-size.js';
+
+/**
+ * ds-components/no-arbitrary-font-size 的行为契约。
+ * 规则本体见 eslint-rules/no-arbitrary-font-size.js。
+ */
+describe('ds-components/no-arbitrary-font-size', () => {
+  const linter = new Linter();
+
+  const lint = (code: string) =>
+    linter.verify(code, {
+      plugins: { 'ds-components': { rules: { 'no-arbitrary-font-size': rule as never } } },
+      languageOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+        parserOptions: { ecmaFeatures: { jsx: true } },
+      },
+      rules: { 'ds-components/no-arbitrary-font-size': 'error' },
+    });
+
+  it.each([
+    ["const a = 'text-[13px]';", 'px'],
+    ["const a = 'flex items-center text-[10px] font-medium';", 'inside a class list'],
+    ["const a = 'md:text-[0.8rem]';", 'responsive variant'],
+    ['const a = `gap-2 ${x} text-[15px]`;', 'template literal'],
+    ["const a = 'data-[state=open]:text-[11px]';", 'data variant'],
+  ])('flags %s (%s)', code => {
+    const messages = lint(code);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].messageId).toBe('noArbitraryFontSize');
+  });
+
+  it.each([
+    "const a = 'text-ui';",
+    "const a = 'text-2xs text-caption';",
+    "const a = 'text-[length:var(--font-size-ui)]';",
+    "const a = 'h-[var(--touch-target-size)] px-[14px]';",
+    "const a = 'leading-[13px]';",
+    "const a = 'subtext-[13px]';",
+  ])('allows %s', code => {
+    expect(lint(code)).toEqual([]);
+  });
+
+  it('reports the offending class in the message', () => {
+    const [message] = lint("const a = 'text-[13px]';");
+    expect(message.message).toContain('text-[13px]');
+    expect(message.message).toContain('--font-size-scale');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

补故障面板缺失 token、翻转暗色阴影、按钮字号走 `text-ui` 并禁新增 `text-[Npx]`；同提交还含命令面板 combobox/Tab 契约、数据治理 Debug 仅 DEV、Finder hostId 分桶。

### Changes
- `--surface-panel` / `--accent-primary` / `--button-secondary-surface` 亮暗色都有定义
- 暗色 `--shadow-base` 翻转；设置 `mobileAccent` 改走 token
- 按钮/共享基元改 `text-ui`；eslint 规则拦截任意 `text-[Npx]`
- 命令面板：combobox + Tab 可达收藏/关闭
- 数据治理页签 `aria-label`，Debug 页签仅 DEV
- Finder `hostId` 分桶（与 #162 重叠）

### How to test
- 数据恢复/不可用面板亮暗色都有底色
- 暗色浮层有阴影；设置字号变化时按钮标签跟着变
- 命令面板 Tab 能到关闭/收藏；读屏能听到 combobox
- 生产构建看不到数据治理 Debug 页签；移动端图标页签有名字
- `npm test -- tests/vitest/failurePathSurfaceTokenContract.test.ts tests/vitest/darkShadowElevationContract.test.ts tests/vitest/fontSizeScaleClosureContract.test.ts tests/vitest/command-palette/commandPaletteA11yContract.test.tsx tests/vitest/data-governance/DataGovernanceDashboard.debug-tab-visibility.test.tsx`

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

### 重叠说明
与 #159 在 token/阴影/text-ui 上重叠；本分支多 eslint、`mobileAccent`、命令面板 a11y、Debug DEV。Finder 与 #162 重叠。不要和 #159+#162 无差别全合。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92ea5725-a196-4c8d-97b6-cf85cfe2ecb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92ea5725-a196-4c8d-97b6-cf85cfe2ecb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

