### PR TITLE
fix(ui): 故障面板 token、暗色阴影与字号缩放闭环

### DIFF
--- a/eslint-rules/no-arbitrary-font-size.js
+++ b/eslint-rules/no-arbitrary-font-size.js
@@ -1,0 +1,63 @@
+/**
+ * ESLint 自定义规则：禁止 Tailwind 硬编码字号（text-[13px] 等）
+ *
+ * 背景：设置 → 外观 → 界面字号写的是 `--font-size-scale`
+ * （src/config/fontConfig.ts → applyFontSizeToDocument），所有字号 token
+ * （--font-size-2xs / xs / sm / base / md / lg / ui / --m-text-caption）都是
+ * `calc(Npx * var(--font-size-scale))`。而 `text-[13px]` 是编译期常量，
+ * 完全不参与缩放——用户把字号调到 130% 时，按钮标签仍是 13px，
+ * 这正是"字号缩放没闭环"的根因。
+ *
+ * 允许的写法：
+ *   - token 类：text-ui / text-sm / text-2xs / text-caption ...
+ *   - 显式走 token 的任意值：text-[length:var(--font-size-ui)]
+ *
+ * @example
+ * // ❌ 错误
+ * <span className="text-[13px]" />
+ * // ✅ 正确
+ * <span className="text-ui" />
+ */
+
+/** 匹配 text-[13px] / md:text-[0.8rem] / data-[state=open]:text-[2em]，
+ *  放过 text-[length:var(--font-size-ui)] 这类 token 引用 */
+const ARBITRARY_FONT_SIZE = /(?<![a-zA-Z0-9])text-\[(?:length:)?\d*\.?\d+(?:px|rem|em|pt)\]/;
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: '禁止 text-[Npx] 硬编码字号，必须使用参与 --font-size-scale 的字号 token 类',
+      recommended: true,
+    },
+    messages: {
+      noArbitraryFontSize:
+        '❌ 禁止硬编码字号 "{{value}}"。它不参与设置里的界面字号缩放（--font-size-scale）。'
+        + '请改用字号 token 类（text-2xs/xs/sm/base/md/lg/ui/caption，见 tailwind.config.js fontSize），'
+        + '确需任意值时写 text-[length:var(--font-size-*)]。',
+    },
+    schema: [],
+  },
+  create(context) {
+    const report = (node, value) => {
+      const match = value.match(ARBITRARY_FONT_SIZE);
+      if (!match) return;
+      context.report({
+        node,
+        messageId: 'noArbitraryFontSize',
+        data: { value: match[0].trim() },
+      });
+    };
+
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string') report(node, node.value);
+      },
+      TemplateElement(node) {
+        const raw = node.value?.cooked ?? node.value?.raw ?? '';
+        if (raw) report(node, raw);
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import tseslint from 'typescript-eslint';
 import boundaries from 'eslint-plugin-boundaries';
 import reactHooks from 'eslint-plugin-react-hooks';
 import noNativeButton from './eslint-rules/no-native-button.js';
+import noArbitraryFontSize from './eslint-rules/no-arbitrary-font-size.js';
 
 export default tseslint.config(
   // 基础 JS 推荐配置
@@ -22,7 +23,8 @@ export default tseslint.config(
     plugins: {
       'ds-components': {
         rules: {
-          'no-native-button': noNativeButton
+          'no-native-button': noNativeButton,
+          'no-arbitrary-font-size': noArbitraryFontSize
         }
       },
       'react-hooks': reactHooks
@@ -105,6 +107,11 @@ export default tseslint.config(
       // 6. 禁止使用原生 <button> 元素 - 必须使用 DsButton（设为 warn 便于逐步修复）
       'ds-components/no-native-button': 'warn',
 
+      // 6.1 禁止 text-[Npx] 硬编码字号（不参与 --font-size-scale 缩放）。
+      // 全仓约 950 处历史欠账，先 warn；共享 UI 基元目录（src/components/ui/**）
+      // 已清零，在下方单独升为 error，防止按钮/对话框配方再退化。
+      'ds-components/no-arbitrary-font-size': 'warn',
+
       // 禁用与 TypeScript 不兼容的规则（TypeScript 已处理）
       'no-undef': 'off',
       'no-unused-vars': 'off',
@@ -134,6 +141,15 @@ export default tseslint.config(
     rules: {
       'no-restricted-imports': 'off',
       'ds-components/no-native-button': 'off'
+    }
+  },
+
+  // 共享 UI 基元（按钮/对话框/侧边栏配方）：字号必须走 token 类，
+  // 这里是字号缩放闭环的上游，退化一次就会扩散到全部消费方。
+  {
+    files: ['src/components/ui/**/*.{ts,tsx}'],
+    rules: {
+      'ds-components/no-arbitrary-font-size': 'error'
     }
   },
 

--- a/src/components/style-lab/TokenInspectorTab.tsx
+++ b/src/components/style-lab/TokenInspectorTab.tsx
@@ -15,8 +15,10 @@ const TOKEN_GROUPS: TokenGroup[] = [
       { name: 'surface-elevated', var: '--surface-elevated', type: 'color' },
       { name: 'surface-muted', var: '--surface-muted', type: 'color' },
       { name: 'surface-overlay', var: '--surface-overlay', type: 'color' },
+      { name: 'surface-panel', var: '--surface-panel', type: 'color' },
       { name: 'surface-panel-muted', var: '--surface-panel-muted', type: 'color' },
       { name: 'surface-panel-strong', var: '--surface-panel-strong', type: 'color' },
+      { name: 'accent-primary', var: '--accent-primary', type: 'color' },
     ],
   },
   {
@@ -83,6 +85,7 @@ const TOKEN_GROUPS: TokenGroup[] = [
     title: 'Button Tonal / Outline / Plain',
     tokens: [
       { name: 'button-tonal-bg', var: '--button-tonal-bg', type: 'color' },
+      { name: 'button-secondary-surface', var: '--button-secondary-surface', type: 'color' },
       { name: 'button-tonal-hover-bg', var: '--button-tonal-hover-bg', type: 'color' },
       { name: 'button-tonal-border', var: '--button-tonal-border', type: 'color' },
       { name: 'button-outline-bg', var: '--button-outline-bg', type: 'color' },

--- a/src/components/ui/DsDialog.tsx
+++ b/src/components/ui/DsDialog.tsx
@@ -284,7 +284,7 @@ export function DsDialogTitle({ className, children, ...props }: React.HTMLAttri
 
 export function DsDialogDescription({ className, children, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
   return (
-    <p className={cn('text-[13px] text-muted-foreground leading-relaxed', className)} {...props}>
+    <p className={cn('text-ui font-normal text-muted-foreground leading-relaxed', className)} {...props}>
       {children}
     </p>
   );
@@ -463,7 +463,7 @@ export function DsAlertDialog({
             <div className="flex-1 min-w-0 space-y-1.5">
               <h3 className="text-base font-semibold leading-tight text-foreground">{title}</h3>
               {description && (
-                <p className="text-[13px] text-muted-foreground leading-relaxed">{description}</p>
+                <p className="text-ui font-normal text-muted-foreground leading-relaxed">{description}</p>
               )}
             </div>
           </div>

--- a/src/components/ui/SnappySlider.tsx
+++ b/src/components/ui/SnappySlider.tsx
@@ -325,7 +325,7 @@ export const SnappySlider = React.forwardRef<HTMLDivElement, SnappySliderProps>(
           >
             {showBubble && (
               <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-0.5 whitespace-nowrap">
-                <span className={cn('text-[10px] font-medium text-muted-foreground', isOutOfBounds && 'opacity-75')}>
+                <span className={cn('text-2xs font-medium text-muted-foreground', isOutOfBounds && 'opacity-75')}>
                   {displayedBubbleValue}
                 </span>
               </div>

--- a/src/components/ui/buttonPrimitiveContract.ts
+++ b/src/components/ui/buttonPrimitiveContract.ts
@@ -21,8 +21,8 @@ export type ButtonPrimitiveSize = 'sm' | 'md' | 'lg' | 'icon' | 'default';
 // 不影响桌面鼠标 active 手感；定义见 src/styles/ui-motion.css 移动追加区）
 //
 // 字号一律走 token 类（text-ui / text-xs / text-sm → --font-size-* ，内含
-// --font-size-scale），不再写 text-[13px]：设置里的"界面字号"缩放对硬编码
-// px 无效，按钮标签会成为唯一不跟随缩放的一层。高度仍是
+// --font-size-scale），不写 Tailwind 任意值字号：设置里的「界面字号」缩放
+// 对硬编码 px 无效，按钮标签会成为唯一不跟随缩放的一层。高度仍是
 // --touch-target-size（移动 44px）/ --button-height（桌面 32px）等固定
 // 几何 token，字号放大不会把触控目标压小。
 // 新增违规由 eslint 规则 ds-components/no-arbitrary-font-size 拦截。

--- a/src/components/ui/buttonPrimitiveContract.ts
+++ b/src/components/ui/buttonPrimitiveContract.ts
@@ -19,11 +19,18 @@ export type ButtonPrimitiveSize = 'sm' | 'md' | 'lg' | 'icon' | 'default';
 
 // ui-press-coarse：触屏（pointer:coarse）统一按压反馈（独立 scale 属性，
 // 不影响桌面鼠标 active 手感；定义见 src/styles/ui-motion.css 移动追加区）
+//
+// 字号一律走 token 类（text-ui / text-xs / text-sm → --font-size-* ，内含
+// --font-size-scale），不再写 text-[13px]：设置里的"界面字号"缩放对硬编码
+// px 无效，按钮标签会成为唯一不跟随缩放的一层。高度仍是
+// --touch-target-size（移动 44px）/ --button-height（桌面 32px）等固定
+// 几何 token，字号放大不会把触控目标压小。
+// 新增违规由 eslint 规则 ds-components/no-arbitrary-font-size 拦截。
 export const buttonBaseClassName =
-  'ui-press-coarse inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--button-radius)] border text-[13px] font-medium leading-none transition-[background-color,border-color,color] duration-150 ease-out outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 select-none motion-reduce:transition-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-inherit';
+  'ui-press-coarse inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--button-radius)] border text-ui font-medium leading-none transition-[background-color,border-color,color] duration-150 ease-out outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 select-none motion-reduce:transition-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-inherit';
 
 export const shellNavBaseClassName =
-  'ui-press-coarse inline-flex shrink-0 appearance-none items-center gap-2 whitespace-nowrap text-[13px] leading-none outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-inherit';
+  'ui-press-coarse inline-flex shrink-0 appearance-none items-center gap-2 whitespace-nowrap text-ui font-normal leading-none outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-inherit';
 
 export const buttonToneClassNames: Record<ButtonPrimitiveVariant, string> = {
   primary:
@@ -55,9 +62,9 @@ export const buttonToneClassNames: Record<ButtonPrimitiveVariant, string> = {
 };
 
 export const buttonSizeClassNames: Record<ButtonPrimitiveSize, string> = {
-  default: 'h-[var(--touch-target-size)] px-[var(--button-padding-x)] text-[13px] lg:h-[var(--button-height)]',
+  default: 'h-[var(--touch-target-size)] px-[var(--button-padding-x)] text-ui lg:h-[var(--button-height)]',
   sm: 'h-[var(--touch-target-size)] px-[var(--button-padding-x-sm)] text-xs lg:h-[var(--button-height-sm)]',
-  md: 'h-[var(--touch-target-size)] px-[var(--button-padding-x)] text-[13px] lg:h-[var(--button-height)]',
+  md: 'h-[var(--touch-target-size)] px-[var(--button-padding-x)] text-ui lg:h-[var(--button-height)]',
   lg: 'h-[var(--touch-target-size)] px-[var(--button-padding-x-lg)] text-sm lg:h-[var(--button-height-lg)]',
   icon:
     'h-[var(--touch-target-size)] w-[var(--touch-target-size)] rounded-[var(--button-radius)] p-0 lg:h-[var(--button-icon-size)] lg:w-[var(--button-icon-size)]',

--- a/src/components/ui/shad/CollapsibleModelSelector.tsx
+++ b/src/components/ui/shad/CollapsibleModelSelector.tsx
@@ -140,7 +140,7 @@ export function CollapsibleModelSelector({
                   <span>{t('model_selector.total_model_count', { count: totalCount })}</span>
                   {cacheTimeText && (
                     <span className="flex items-center gap-1">
-                      {isFromCache && <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted">{t('model_selector.cached')}</span>}
+                      {isFromCache && <span className="text-2xs px-1.5 py-0.5 rounded bg-muted">{t('model_selector.cached')}</span>}
                       {cacheTimeText}
                     </span>
                   )}

--- a/src/components/ui/shad/Tooltip.tsx
+++ b/src/components/ui/shad/Tooltip.tsx
@@ -194,7 +194,7 @@ interface TooltipContentProps extends React.HTMLAttributes<HTMLDivElement> {
 // 基础样式 - 最小化，让用户传递的类可以完全覆盖
 // ui-tooltip-in：ui-motion 入场（fade + scale 0.97 + 朝最终位置 2px 漂移，方向随 data-side）
 const getBaseClasses = () => {
-  return 'rounded-md px-2 py-1.5 text-[13px] shadow-none border border-border/40 bg-[var(--tooltip-surface)] text-[var(--tooltip-foreground)] font-medium leading-none ui-tooltip-in';
+  return 'rounded-md px-2 py-1.5 text-ui shadow-none border border-border/40 bg-[var(--tooltip-surface)] text-[var(--tooltip-foreground)] font-medium leading-none ui-tooltip-in';
 };
 
 export const TooltipContent: React.FC<TooltipContentProps>

--- a/src/components/ui/unified-sidebar/UnifiedSidebar.tsx
+++ b/src/components/ui/unified-sidebar/UnifiedSidebar.tsx
@@ -51,7 +51,7 @@ const SIDEBAR_STYLES = {
     header: { height: '40px', padding: 'px-2', gap: 'gap-0.5' },
     search: { iconSize: 'w-3.5 h-3.5', inputPadding: 'pl-8 pr-3 py-1.5 text-sm' },
     button: { padding: 'p-1.5', iconSize: 'w-4 h-4' },
-    item: { padding: 'gap-2.5 px-2 py-2 mx-1', iconSize: 'w-4 h-4', textSize: 'text-[13px]', indicator: 'w-[3px] h-4' },
+    item: { padding: 'gap-2.5 px-2 py-2 mx-1', iconSize: 'w-4 h-4', textSize: 'text-ui', indicator: 'w-[3px] h-4' },
     content: { viewportPadding: 'py-1', spacing: 'space-y-0.5' },
     footer: { padding: 'p-3' },
     actions: { gap: 'gap-0.5', opacity: 'opacity-0 group-hover:opacity-100', btnPadding: 'p-1', iconSize: 'w-3 h-3' },
@@ -80,7 +80,7 @@ const SIDEBAR_STYLES = {
     header: { height: 'var(--touch-target-size)', padding: 'px-2 py-1.5', gap: 'gap-0.5' },
     search: { iconSize: 'w-4 h-4', inputPadding: 'pl-9 pr-3 py-2 text-base' },
     button: { padding: 'p-2', iconSize: 'w-5 h-5' },
-    item: { padding: 'gap-3 px-3 py-2.5 mx-1 min-h-[44px]', iconSize: 'w-5 h-5', textSize: 'text-[15px]', indicator: 'w-[3px] h-5' },
+    item: { padding: 'gap-3 px-3 py-2.5 mx-1 min-h-[44px]', iconSize: 'w-5 h-5', textSize: 'text-md', indicator: 'w-[3px] h-5' },
     content: { viewportPadding: 'py-1', spacing: 'space-y-0.5' },
     footer: { padding: 'p-3' },
     actions: { gap: 'gap-1', opacity: 'opacity-100', btnPadding: 'p-2', iconSize: 'w-4 h-4' },
@@ -626,7 +626,7 @@ export const UnifiedSidebarItem: React.FC<UnifiedSidebarItemProps> = ({
               {badge && (
                 <span className={cn(
                   'px-1.5 py-0.5 rounded bg-accent text-accent-foreground font-medium flex-shrink-0',
-                  isMobileMode && !isMobileSlidingMode ? 'text-xs' : 'text-[10px]'
+                  isMobileMode && !isMobileSlidingMode ? 'text-xs' : 'text-2xs'
                 )}>
                   {badge}
                 </span>
@@ -650,10 +650,7 @@ export const UnifiedSidebarItem: React.FC<UnifiedSidebarItemProps> = ({
               </p>
             )}
             {stats && (
-              <div className={cn(
-                'flex items-center gap-2 mt-0.5 text-muted-foreground',
-                isMobileMode && !isMobileSlidingMode ? 'text-xs' : 'text-[11px]'
-              )}>
+              <div className="flex items-center gap-2 mt-0.5 text-xs text-muted-foreground">
                 {stats}
               </div>
             )}

--- a/src/components/ui/unified-sidebar/UnifiedSidebarSection.tsx
+++ b/src/components/ui/unified-sidebar/UnifiedSidebarSection.tsx
@@ -89,7 +89,7 @@ export const UnifiedSidebarSection: React.FC<UnifiedSidebarSectionProps> = ({
         >
           <div className="flex items-center gap-2">
             {Icon && <Icon className="w-4 h-4 text-foreground/90" />}
-            <span className={cn('font-normal text-foreground/90', isMobileMode ? 'text-sm' : 'text-[13px]')}>
+            <span className={cn('font-normal text-foreground/90', isMobileMode ? 'text-sm' : 'text-ui')}>
               {title}
             </span>
             {count !== undefined && (
@@ -136,12 +136,7 @@ export const UnifiedSidebarSection: React.FC<UnifiedSidebarSectionProps> = ({
       >
         <div className="flex items-center gap-2">
           {Icon && <Icon className="w-3 h-3 text-muted-foreground/60" />}
-          <span
-            className={cn(
-              'font-normal text-muted-foreground/60',
-              isMobileMode ? 'text-xs' : 'text-[11px]'
-            )}
-          >
+          <span className="text-xs font-normal text-muted-foreground/60">
             {title}
           </span>
           {count !== undefined && (

--- a/src/features/settings/components/useSettingsNavigation.tsx
+++ b/src/features/settings/components/useSettingsNavigation.tsx
@@ -17,6 +17,24 @@ import {
 } from '@phosphor-icons/react';
 import { isMobilePlatform } from '@/utils/platform';
 
+/**
+ * 设置导航的分类 accent（窄屏导航图标色）。
+ *
+ * 只写 token 引用，不写 hex：色值本体（亮色 / 暗色 / prefers-contrast 三档）
+ * 定义在 src/styles/theme-colors.css 的 --settings-nav-accent-* 里。曾经这里
+ * 直接写死浅色 hex（#e5ad3d 等），暗色下图标亮度不足且不随主题走。
+ */
+export const SETTINGS_NAV_ACCENT = {
+  amber: 'var(--settings-nav-accent-amber)',
+  blue: 'var(--settings-nav-accent-blue)',
+  slate: 'var(--settings-nav-accent-slate)',
+  purple: 'var(--settings-nav-accent-purple)',
+  orange: 'var(--settings-nav-accent-orange)',
+  green: 'var(--settings-nav-accent-green)',
+  sky: 'var(--settings-nav-accent-sky)',
+  pink: 'var(--settings-nav-accent-pink)',
+} as const;
+
 export type SettingsSidebarNavItem = {
   value: string;
   label: string;
@@ -48,7 +66,7 @@ export function useSettingsNavigation() {
         label: t('settings:tabs.api_config'),
         tourId: 'settings-tab-apis',
         mobileDescription: t('settings:mobile_descriptions.apis'),
-        mobileAccent: '#e5ad3d',
+        mobileAccent: SETTINGS_NAV_ACCENT.amber,
       },
       {
         value: 'models',
@@ -56,7 +74,7 @@ export function useSettingsNavigation() {
         label: t('settings:tabs.model_assignment'),
         tourId: 'settings-tab-models',
         mobileDescription: t('settings:mobile_descriptions.models'),
-        mobileAccent: '#4d86df',
+        mobileAccent: SETTINGS_NAV_ACCENT.blue,
       },
     ],
     [
@@ -65,21 +83,21 @@ export function useSettingsNavigation() {
         icon: SlidersHorizontal,
         label: t('settings:tabs.general'),
         mobileDescription: t('settings:mobile_descriptions.general'),
-        mobileAccent: '#6f7785',
+        mobileAccent: SETTINGS_NAV_ACCENT.slate,
       },
       {
         value: 'appearance',
         icon: Palette,
         label: t('settings:tabs.appearance'),
         mobileDescription: t('settings:mobile_descriptions.appearance'),
-        mobileAccent: '#a35de1',
+        mobileAccent: SETTINGS_NAV_ACCENT.purple,
       },
       {
         value: 'automation',
         icon: ClockCountdown,
         label: t('settings:tabs.automation'),
         mobileDescription: t('settings:mobile_descriptions.automation'),
-        mobileAccent: '#eb8d42',
+        mobileAccent: SETTINGS_NAV_ACCENT.orange,
       },
     ],
     [
@@ -88,14 +106,14 @@ export function useSettingsNavigation() {
         icon: Plug,
         label: t('settings:tabs.mcp_tools'),
         mobileDescription: t('settings:mobile_descriptions.mcp'),
-        mobileAccent: '#1db77c',
+        mobileAccent: SETTINGS_NAV_ACCENT.green,
       },
       {
         value: 'search',
         icon: Globe,
         label: t('settings:tabs.external_search'),
         mobileDescription: t('settings:mobile_descriptions.search'),
-        mobileAccent: '#4b9fe8',
+        mobileAccent: SETTINGS_NAV_ACCENT.sky,
       },
       ...(!hidePlugins
         ? [{
@@ -103,7 +121,7 @@ export function useSettingsNavigation() {
             icon: PuzzlePiece,
             label: t('settings:tabs.plugins'),
             mobileDescription: t('settings:mobile_descriptions.plugins'),
-            mobileAccent: '#a35de1',
+            mobileAccent: SETTINGS_NAV_ACCENT.purple,
           }]
         : []),
     ],
@@ -113,14 +131,14 @@ export function useSettingsNavigation() {
         icon: ChartBar,
         label: t('settings:tabs.statistics'),
         mobileDescription: t('settings:mobile_descriptions.statistics'),
-        mobileAccent: '#4b9fe8',
+        mobileAccent: SETTINGS_NAV_ACCENT.sky,
       },
       {
         value: 'data-governance',
         icon: Shield,
         label: t('settings:tabs.data_governance'),
         mobileDescription: t('settings:mobile_descriptions.data_governance'),
-        mobileAccent: '#4f9ecf',
+        mobileAccent: SETTINGS_NAV_ACCENT.sky,
       },
     ],
     [
@@ -129,7 +147,7 @@ export function useSettingsNavigation() {
         icon: Wrench,
         label: t('settings:tabs.params'),
         mobileDescription: t('settings:mobile_descriptions.params'),
-        mobileAccent: '#e1a642',
+        mobileAccent: SETTINGS_NAV_ACCENT.amber,
       },
       ...(!hideShortcuts
         ? [{
@@ -137,7 +155,7 @@ export function useSettingsNavigation() {
             icon: Keyboard,
             label: t('settings:tabs.shortcuts'),
             mobileDescription: t('settings:mobile_descriptions.shortcuts'),
-            mobileAccent: '#7d8490',
+            mobileAccent: SETTINGS_NAV_ACCENT.slate,
           }]
         : []),
       {
@@ -145,7 +163,7 @@ export function useSettingsNavigation() {
         icon: BookOpen,
         label: t('settings:tabs.about'),
         mobileDescription: t('settings:mobile_descriptions.about'),
-        mobileAccent: '#d978ae',
+        mobileAccent: SETTINGS_NAV_ACCENT.pink,
       },
     ],
   ]), [t, hidePlugins, hideShortcuts]);

--- a/src/styles/__tests__/transitionsDev.cardResize.test.ts
+++ b/src/styles/__tests__/transitionsDev.cardResize.test.ts
@@ -12,7 +12,9 @@ describe('transitions-dev card resize hook', () => {
     expect(css).toContain('.t-resize {');
     expect(css).toContain('width  var(--resize-dur) var(--resize-ease)');
     expect(css).toContain('height var(--resize-dur) var(--resize-ease)');
-    expect(css).toContain('will-change: width, height;');
+    // will-change: width/height 是布局属性，声明 will-change 换不来合成器
+    // 加速、只多占图层内存——合入 main 时 CSS 已删掉该行，这里不再断言。
+    expect(css).not.toContain('will-change: width, height;');
 
     const reducedMotion = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));
     expect(reducedMotion).toContain('.t-resize { transition: none !important; }');

--- a/src/styles/responsive-utilities.css
+++ b/src/styles/responsive-utilities.css
@@ -115,16 +115,19 @@
     max-height: none !important;
   }
 
-  /* 移动统一抽屉：导航行/分组标题字号整体放大，便于触控阅读 */
+  /* 移动统一抽屉：导航行/分组标题字号整体放大，便于触控阅读。
+     max(地板, token)：跟随界面字号缩放（--font-size-scale 0.85~1.3）放大，
+     但缩小档不跌破移动可读地板（shadcn-variables.css「移动字号地板」约定：
+     正文/列表行 ≥14px；输入框 ≥16px，否则 iOS WKWebView 聚焦时自动放大页面）。 */
   [data-mobile-unified-drawer] .desktop-shell-nav-section-label {
-    font-size: 14px !important;
-    line-height: 18px !important;
+    font-size: max(14px, var(--font-size-base)) !important;
+    line-height: 1.3 !important;
   }
 
   [data-mobile-unified-drawer] .desktop-shell-sidebar-row,
   [data-mobile-unified-drawer] .desktop-shell-nav-row,
   [data-mobile-unified-drawer] .desktop-shell-thread-row {
-    font-size: 16px !important;
+    font-size: max(16px, var(--font-size-lg)) !important;
     /* 豁免 app.css 的 min-height:32px !important 桌面密度（该处同为
        !important，但本选择器特异性 (0,2,0) 更高）：移动抽屉导航行
        必须满足 44px 触控高度基线 */
@@ -139,7 +142,7 @@
 
   /* 笔记树等页内侧栏内容 */
   [data-mobile-unified-drawer] .rct-tree {
-    font-size: 16px;
+    font-size: max(16px, var(--font-size-lg));
   }
 
   [data-mobile-unified-drawer] .rct-tree-item-button {
@@ -147,8 +150,9 @@
     height: auto;
   }
 
+  /* 搜索框是输入控件：16px 是 iOS 聚焦缩放地板，只允许向上跟随缩放 */
   [data-mobile-unified-drawer] .sidebar-shell-search {
-    font-size: 16px !important;
+    font-size: max(16px, var(--font-size-lg)) !important;
   }
 }
 

--- a/src/styles/theme-colors.css
+++ b/src/styles/theme-colors.css
@@ -9,8 +9,19 @@
   --surface-overlay: color-mix(in hsl, hsl(var(--card)) 80%, transparent 20%);
   --surface-overlay-strong: color-mix(in hsl, hsl(var(--card)) 65%, hsl(var(--background)) 35%);
   --surface-divider: color-mix(in hsl, hsl(var(--border)) 55%, transparent 45%);
+
+  /* --surface-panel 是面板族的基准层（panel < panel-strong），语义与近邻一致：
+     elevated 与 root 的 mix。故障/恢复路径（StartupPreflight / RecoveryShell /
+     RecoveryCenter / ComponentRecoveryShell / FeatureUnavailablePanel）在
+     token 缺失时会因 background 计算失效而变透明——那正是最不能"没有底色"的
+     场景，所以这里先给不依赖 color-mix 的兜底值，再在文件末尾的 @supports
+     里升级为 mix 版本（Android WebView 等无 color-mix 环境仍有实色底）。 */
+  --surface-panel: hsl(var(--card));
   --surface-panel-muted: color-mix(in hsl, var(--surface-muted) 82%, var(--surface-elevated) 18%);
   --surface-panel-strong: color-mix(in hsl, var(--surface-elevated) 92%, var(--surface-root) 8%);
+
+  /* 语义 accent：对齐 shadcn --primary，供故障面板选中态边框等使用 */
+  --accent-primary: hsl(var(--primary));
 
   /* Desktop shell surfaces
      ------------------------------------------------------------
@@ -103,17 +114,32 @@
   --tooltip-surface: hsl(var(--foreground));
   --tooltip-foreground: hsl(var(--background));
 
+  /* 阴影体系
+     ------------------------------------------------------------
+     --shadow-base 是色相基（始终黑），投影强度全部抽到 --shadow-strength-*，
+     这样暗色主题只需覆写 alpha 档位，不必把整串 box-shadow 配方抄一遍。
+     暗色下沿用亮色 alpha（0.04~0.10）等于没有阴影：背景本身就接近纯黑，
+     浮层与底板完全糊在一起。暗色覆写见 :root.dark 同名 token。
+     ------------------------------------------------------------ */
   --shadow-base: 0 0% 0%;
-  --shadow-shell-soft: 0 12px 24px hsl(var(--shadow-base) / 0.04);
-  --shadow-shell-panel: 0 16px 32px hsl(var(--shadow-base) / 0.05);
-  --shadow-shell-floating: 0 18px 36px hsl(var(--shadow-base) / 0.08);
-  --shadow-shell-pressed: 0 8px 20px hsl(var(--shadow-base) / 0.05);
+  --shadow-strength-soft: 0.04;
+  --shadow-strength-panel: 0.05;
+  --shadow-strength-floating: 0.08;
+  --shadow-strength-pressed: 0.05;
+  --shadow-strength-content-subtle: 0.05;
+  --shadow-strength-content-soft: 0.10;
+  --shadow-strength-content-elevated: 0.06;
+  --shadow-strength-sheet: 0.10;
+  --shadow-shell-soft: 0 12px 24px hsl(var(--shadow-base) / var(--shadow-strength-soft));
+  --shadow-shell-panel: 0 16px 32px hsl(var(--shadow-base) / var(--shadow-strength-panel));
+  --shadow-shell-floating: 0 18px 36px hsl(var(--shadow-base) / var(--shadow-strength-floating));
+  --shadow-shell-pressed: 0 8px 20px hsl(var(--shadow-base) / var(--shadow-strength-pressed));
 
   /* 兼容别名：hover:shadow-[var(--shadow-card)] 的存量消费者（原定义在 card-animations.css） */
   --shadow-card: var(--shadow-shell-soft);
-  --shadow-content-subtle: 0 1px 3px hsl(var(--shadow-base) / 0.05);
-  --shadow-content-soft: 0 2px 8px hsl(var(--shadow-base) / 0.10);
-  --shadow-content-elevated: 0 6px 18px hsl(var(--shadow-base) / 0.06);
+  --shadow-content-subtle: 0 1px 3px hsl(var(--shadow-base) / var(--shadow-strength-content-subtle));
+  --shadow-content-soft: 0 2px 8px hsl(var(--shadow-base) / var(--shadow-strength-content-soft));
+  --shadow-content-elevated: 0 6px 18px hsl(var(--shadow-base) / var(--shadow-strength-content-elevated));
   --text-shadow-contrast-subtle: 0 1px 2px hsl(var(--shadow-base) / 0.10);
   --text-shadow-contrast-medium: 0 1px 2px hsl(var(--shadow-base) / 0.30);
   --text-shadow-contrast-strong: 0 1px 3px hsl(var(--shadow-base) / 0.50);
@@ -133,6 +159,10 @@
   --button-tonal-hover-bg: color-mix(in oklab, hsl(var(--muted)) 78%, hsl(var(--background)) 22%);
   --button-tonal-active-bg: color-mix(in oklab, hsl(var(--accent)) 82%, hsl(var(--background)) 18%);
   --button-tonal-border: color-mix(in oklab, hsl(var(--border)) 78%, hsl(var(--foreground)) 6%);
+
+  /* secondary 按钮表面 = tonal 表面的语义别名（ComposerPlusMenu 的 open 态等
+     直接消费该名字）。无 color-mix 时退回 hsl(var(--secondary)) 实色。 */
+  --button-secondary-surface: hsl(var(--secondary));
   --button-outline-bg: color-mix(in oklab, hsl(var(--background)) 92%, hsl(var(--secondary)) 8%);
   --button-outline-hover-bg: color-mix(in oklab, var(--interactive-hover) 84%, hsl(var(--background)) 16%);
   --button-outline-active-bg: color-mix(in oklab, var(--interactive-selected) 78%, hsl(var(--background)) 22%);
@@ -182,7 +212,7 @@
   --mobile-sheet-border: var(--border-soft);
   --mobile-sheet-header-border: var(--surface-divider);
   --mobile-sheet-handle: var(--border-strong);
-  --mobile-sheet-shadow: 0 -12px 34px hsl(var(--shadow-base) / 0.10);
+  --mobile-sheet-shadow: 0 -12px 34px hsl(var(--shadow-base) / var(--shadow-strength-sheet));
 
   /* Menu shell — AppMenu 下拉/右键菜单外壳，与 composer shell 同族
      设计目的：让弹出菜单看起来像"从输入框延伸出来的一片"，而不是独立风格的 popover。
@@ -256,6 +286,23 @@
   --neutral-muted: var(--neutral) / 0.35;
   --neutral-bg: var(--neutral) / 0.14;
 
+  /* 分类 accent（设置导航图标等"每一栏一个颜色"的场景）
+     ------------------------------------------------------------
+     这些色只承担"区分类别"，不表达状态，所以不能挂到 --success/--warning
+     那一族。原先是散落在 useSettingsNavigation.tsx 里的浅色 hex
+     （#e5ad3d / #4d86df …），在暗色下亮度不足、也无法随主题走，现在收进
+     token 层：亮色沿用原色相，暗色抬亮度、降饱和，高对比模式再抬一档。
+     新增分类请复用下面的档位，不要再往组件里写 hex。
+     ------------------------------------------------------------ */
+  --settings-nav-accent-amber: hsl(40 76% 57%);
+  --settings-nav-accent-blue: hsl(217 69% 59%);
+  --settings-nav-accent-slate: hsl(218 9% 50%);
+  --settings-nav-accent-purple: hsl(272 69% 62%);
+  --settings-nav-accent-orange: hsl(27 81% 59%);
+  --settings-nav-accent-green: hsl(157 73% 42%);
+  --settings-nav-accent-sky: hsl(208 77% 60%);
+  --settings-nav-accent-pink: hsl(327 56% 66%);
+
   /* Citation/source semantics */
   --citation-badge-bg-alpha: 0.10;
   --citation-badge-hover-alpha: 0.20;
@@ -267,6 +314,27 @@
 }
 
 :root.dark {
+  /* 面板族暗色兜底（无 color-mix 时生效，mix 版本见文件末尾 @supports） */
+  --surface-panel: hsl(var(--card));
+  --accent-primary: hsl(var(--primary));
+  --button-secondary-surface: hsl(var(--secondary));
+
+  /* 暗色阴影翻转
+     ------------------------------------------------------------
+     色基仍是黑（不用白阴影：白色投影在深灰底上是"发光"，与本设计体系
+     其余部分的物理光照隐喻冲突），改为整体抬高 alpha 档位。暗色背景
+     L≈9%~12%，0.05 的黑几乎不可见，需要 6~8 倍才能重新读出层次。
+     ------------------------------------------------------------ */
+  --shadow-base: 0 0% 0%;
+  --shadow-strength-soft: 0.32;
+  --shadow-strength-panel: 0.40;
+  --shadow-strength-floating: 0.54;
+  --shadow-strength-pressed: 0.36;
+  --shadow-strength-content-subtle: 0.28;
+  --shadow-strength-content-soft: 0.44;
+  --shadow-strength-content-elevated: 0.40;
+  --shadow-strength-sheet: 0.52;
+
   --interactive-hover: color-mix(in hsl, hsl(var(--foreground)) 10%, transparent 90%);
   --interactive-selected: color-mix(in hsl, hsl(var(--foreground)) 10%, transparent 90%);
   --overlay-control-hover: rgba(255, 255, 255, 0.2);
@@ -325,6 +393,64 @@
   --scrollbar-thumb: color-mix(in oklab, hsl(var(--foreground)) 22%, transparent);
   --scrollbar-thumb-hover: color-mix(in oklab, hsl(var(--foreground)) 36%, transparent);
   --scrollbar-thumb-active: color-mix(in oklab, hsl(var(--foreground)) 50%, transparent);
+
+  /* 分类 accent 暗色档：背景 L≈9%，亮色档（L 42%~62%）在其上对比不足，
+     统一抬到 L 56%~74% 并降一点饱和，避免深底上的荧光感。 */
+  --settings-nav-accent-amber: hsl(40 72% 66%);
+  --settings-nav-accent-blue: hsl(217 66% 72%);
+  --settings-nav-accent-slate: hsl(218 10% 68%);
+  --settings-nav-accent-purple: hsl(272 62% 74%);
+  --settings-nav-accent-orange: hsl(27 74% 68%);
+  --settings-nav-accent-green: hsl(157 55% 58%);
+  --settings-nav-accent-sky: hsl(208 70% 70%);
+  --settings-nav-accent-pink: hsl(327 52% 74%);
+}
+
+/* 高对比偏好：分类 accent 再抬一档亮度/饱和（亮色压暗、暗色提亮），
+   与 workbench a11y-cursor.css 的 prefers-contrast 策略同族。 */
+@media (prefers-contrast: more) {
+  :where(:root) {
+    --settings-nav-accent-amber: hsl(40 82% 38%);
+    --settings-nav-accent-blue: hsl(217 74% 44%);
+    --settings-nav-accent-slate: hsl(218 12% 34%);
+    --settings-nav-accent-purple: hsl(272 72% 46%);
+    --settings-nav-accent-orange: hsl(27 86% 42%);
+    --settings-nav-accent-green: hsl(157 78% 28%);
+    --settings-nav-accent-sky: hsl(208 82% 42%);
+    --settings-nav-accent-pink: hsl(327 62% 46%);
+  }
+
+  :root.dark {
+    --settings-nav-accent-amber: hsl(40 80% 76%);
+    --settings-nav-accent-blue: hsl(217 76% 80%);
+    --settings-nav-accent-slate: hsl(218 12% 80%);
+    --settings-nav-accent-purple: hsl(272 72% 82%);
+    --settings-nav-accent-orange: hsl(27 82% 78%);
+    --settings-nav-accent-green: hsl(157 62% 70%);
+    --settings-nav-accent-sky: hsl(208 80% 80%);
+    --settings-nav-accent-pink: hsl(327 62% 82%);
+  }
+}
+
+/* 面板族 / secondary 表面的 color-mix 升级档
+   ------------------------------------------------------------
+   自定义属性一旦存了不被支持的 color-mix()，替换到 background 时会
+   "computed-value time invalid" → 面板直接透明，故障面板会整块看不见底。
+   把 mix 版本收进 @supports，无 color-mix 的运行时（老 Android WebView）
+   停留在上面的实色兜底值。选择器必须与兜底处逐一对应，否则 :root.dark
+   的实色声明（特异性更高）会压过这里的 :where(:root)。
+   ------------------------------------------------------------ */
+@supports (background: color-mix(in hsl, red 50%, blue)) {
+  :where(:root) {
+    --surface-panel: color-mix(in hsl, var(--surface-elevated) 78%, var(--surface-root) 22%);
+    --button-secondary-surface: var(--button-tonal-bg);
+  }
+
+  :root.dark {
+    /* 暗色下面板要比 root 明显抬起一档，否则故障面板与背板同色 */
+    --surface-panel: color-mix(in hsl, var(--surface-elevated) 88%, var(--surface-root) 12%);
+    --button-secondary-surface: var(--button-tonal-bg);
+  }
 }
 
 @media (prefers-reduced-transparency: reduce) {

--- a/src/styles/theme-colors.css
+++ b/src/styles/theme-colors.css
@@ -232,7 +232,10 @@
   --menu-shell-row-padding-y: 7px;
   --menu-shell-row-padding-x: 10px;
   --menu-shell-row-gap: 8px;
-  --menu-shell-font-size: 13px;
+  /* 走 --font-size-ui（13px × --font-size-scale）而不是写死 13px：
+     AppMenu / ModelPicker 桌面档经此 token 消费字号，硬编码会让菜单
+     成为界面字号缩放里唯一不跟随的一层。 */
+  --menu-shell-font-size: var(--font-size-ui);
 
   /* Borders */
   --border-default: hsl(var(--border));

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -71,9 +71,19 @@ small, .text-sm {
 	font-size: var(--font-size-sm);
 }
 
-/* UI 文本 - 侧边栏、菜单等 */
-.text-ui {
-	font-size: var(--font-size-sm);
+/* UI 文本 - 侧边栏、菜单、按钮标签等
+ *
+ * 与 Tailwind 的 text-ui 工具类（tailwind.config.js fontSize.ui →
+ * --font-size-ui = 13px × --font-size-scale）是同一个类名。本文件在 App.tsx
+ * 里晚于 tailwind.css 引入，未加 :where() 时这条规则会盖掉工具类，导致
+ * text-ui 实际渲染成 12px，并顺带压掉同元素上的 font-* / tracking-* 工具类。
+ *
+ * 现在：字号对齐 --font-size-ui（与工具类同值，二者谁赢都是 13px 且吃
+ * 字号缩放），并用 :where() 把特异性归零，weight / letter-spacing 退化成
+ * 可被任意工具类覆盖的默认值。
+ */
+:where(.text-ui) {
+	font-size: var(--font-size-ui);
 	font-weight: var(--font-weight-medium);
 	letter-spacing: var(--letter-spacing-normal);
 }

--- a/tests/vitest/darkShadowElevationContract.test.ts
+++ b/tests/vitest/darkShadowElevationContract.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * 暗色阴影层次契约。
+ *
+ * --shadow-base 是纯黑色相基，投影强度由 --shadow-strength-* 承担。暗色主题
+ * 背景 L≈9%~12%，沿用亮色的 0.04~0.10 alpha 等于没有阴影，浮层与底板完全
+ * 糊在一起。本测试锁住：强度 token 存在、暗色确实抬高了每一档、配方不再
+ * 内联写死 alpha，并且暗色仍然用黑基（白阴影是发光，与本体系的光照隐喻
+ * 冲突）。
+ */
+describe('dark mode shadow elevation contract', () => {
+  const themeSource = readFileSync(resolve(process.cwd(), 'src/styles/theme-colors.css'), 'utf-8');
+
+  const blockOf = (selector: string) => {
+    const start = themeSource.indexOf(`${selector} {`);
+    expect(start, `theme-colors.css should contain a ${selector} block`).toBeGreaterThan(-1);
+    return themeSource.slice(start, themeSource.indexOf('\n}', start));
+  };
+
+  const lightBlock = blockOf(':where(:root)');
+  const darkBlock = blockOf(':root.dark');
+
+  const strengths = (block: string) => {
+    const map = new Map<string, number>();
+    for (const match of block.matchAll(/(--shadow-strength-[a-z-]+):\s*([\d.]+);/g)) {
+      map.set(match[1], Number.parseFloat(match[2]));
+    }
+    return map;
+  };
+
+  const lightStrengths = strengths(lightBlock);
+  const darkStrengths = strengths(darkBlock);
+
+  it('exposes a shadow strength scale in the light token block', () => {
+    expect([...lightStrengths.keys()].sort()).toEqual([
+      '--shadow-strength-content-elevated',
+      '--shadow-strength-content-soft',
+      '--shadow-strength-content-subtle',
+      '--shadow-strength-floating',
+      '--shadow-strength-panel',
+      '--shadow-strength-pressed',
+      '--shadow-strength-sheet',
+      '--shadow-strength-soft',
+    ]);
+  });
+
+  it('raises every shadow strength step in dark mode to a visible alpha', () => {
+    expect(darkStrengths.size).toBe(lightStrengths.size);
+    for (const [token, lightValue] of lightStrengths) {
+      const darkValue = darkStrengths.get(token);
+      expect(darkValue, `${token} must be re-tuned for dark mode`).toBeDefined();
+      expect(darkValue!, `${token} must be stronger in dark mode`).toBeGreaterThan(lightValue);
+      // 0.25 以下的黑色投影在 L≈9% 的底上肉眼不可见
+      expect(darkValue!, `${token} must be visible on a near-black surface`).toBeGreaterThanOrEqual(0.25);
+    }
+  });
+
+  it('keeps a black shadow base in both themes instead of flipping to a white glow', () => {
+    expect(lightBlock).toMatch(/--shadow-base:\s*0 0% 0%;/);
+    expect(darkBlock).toMatch(/--shadow-base:\s*0 0% 0%;/);
+  });
+
+  it('routes the shared shadow recipes through the strength scale', () => {
+    const recipes = [
+      '--shadow-shell-soft',
+      '--shadow-shell-panel',
+      '--shadow-shell-floating',
+      '--shadow-shell-pressed',
+      '--shadow-content-subtle',
+      '--shadow-content-soft',
+      '--shadow-content-elevated',
+      '--mobile-sheet-shadow',
+    ];
+
+    for (const recipe of recipes) {
+      const declaration = lightBlock.match(new RegExp(`${recipe}:\\s*([^;]+);`))?.[1] ?? '';
+      expect(declaration, `${recipe} should be defined in the light token block`).not.toBe('');
+      expect(declaration, `${recipe} should read its alpha from --shadow-strength-*`).toMatch(
+        /hsl\(var\(--shadow-base\) \/ var\(--shadow-strength-[a-z-]+\)\)/,
+      );
+      expect(declaration, `${recipe} should not inline a hardcoded alpha`).not.toMatch(
+        /var\(--shadow-base\)\s*\/\s*[\d.]+/,
+      );
+    }
+  });
+});

--- a/tests/vitest/failurePathSurfaceTokenContract.test.ts
+++ b/tests/vitest/failurePathSurfaceTokenContract.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * 故障/恢复路径的底色契约。
+ *
+ * 这些面板是「其他东西已经坏了」时唯一还会渲染的界面，一旦它们消费的
+ * surface token 没有定义，background 会在 computed-value time 失效 →
+ * 整块透明，用户看到的是叠字。2026-08 审计发现 --surface-panel /
+ * --accent-primary / --button-secondary-surface 三个 token 从未在 token 层
+ * 定义过，本测试防止再次退化。
+ */
+describe('failure-path surface token contract', () => {
+  const themeSource = readFileSync(resolve(process.cwd(), 'src/styles/theme-colors.css'), 'utf-8');
+
+  /** 消费这些 token 的故障/恢复路径与输入栏菜单 */
+  const CONSUMERS = [
+    'src/features/data-recovery/StartupPreflight.tsx',
+    'src/features/data-recovery/ComponentRecoveryShell.tsx',
+    'src/features/data-recovery/RecoveryCenter.tsx',
+    'src/features/data-recovery/RecoveryShell.tsx',
+    'src/components/system-status/FeatureUnavailablePanel.tsx',
+    'src/features/chat/components/input-bar/ComposerPlusMenu.tsx',
+  ];
+
+  const collectCssFiles = (dir: string, acc: string[] = []): string[] => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) collectCssFiles(full, acc);
+      else if (entry.name.endsWith('.css')) acc.push(full);
+    }
+    return acc;
+  };
+
+  const definedCustomProperties = (() => {
+    const names = new Set<string>();
+    for (const file of collectCssFiles(resolve(process.cwd(), 'src'))) {
+      for (const match of readFileSync(file, 'utf-8').matchAll(/(--[a-zA-Z0-9-]+)\s*:/g)) {
+        names.add(match[1]);
+      }
+    }
+    return names;
+  })();
+
+  /** 取某个选择器块的正文（只取第一段，够用来断言 token 是否在该主题下定义） */
+  const blockOf = (selector: string) => {
+    const start = themeSource.indexOf(`${selector} {`);
+    expect(start, `theme-colors.css should contain a ${selector} block`).toBeGreaterThan(-1);
+    const end = themeSource.indexOf('\n}', start);
+    return themeSource.slice(start, end);
+  };
+
+  const lightBlock = blockOf(':where(:root)');
+  const darkBlock = blockOf(':root.dark');
+
+  const NEW_TOKENS = ['--surface-panel', '--accent-primary', '--button-secondary-surface'] as const;
+
+  it('defines every custom property the failure-path panels consume', () => {
+    for (const consumer of CONSUMERS) {
+      const source = readFileSync(resolve(process.cwd(), consumer), 'utf-8');
+      const consumed = [...source.matchAll(/var\((--[a-zA-Z0-9-]+)\s*[,)]/g)].map(match => match[1]);
+      expect(consumed.length, `${consumer} should consume design tokens`).toBeGreaterThan(0);
+      for (const token of consumed) {
+        expect(
+          definedCustomProperties.has(token),
+          `${token} is consumed by ${consumer} but never defined in any src/**/*.css token layer`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('defines the panel/accent/secondary tokens in both the light and dark token blocks', () => {
+    for (const token of NEW_TOKENS) {
+      expect(lightBlock, `${token} must be defined for the light theme`).toContain(`${token}:`);
+      expect(darkBlock, `${token} must be defined for the dark theme`).toContain(`${token}:`);
+    }
+  });
+
+  it('keeps a non-color-mix fallback so panels never fall back to transparent', () => {
+    // 兜底声明（:where(:root) / :root.dark 里的那一份）必须是实色，
+    // 老 Android WebView 不认 color-mix 时仍然有底。
+    for (const block of [lightBlock, darkBlock]) {
+      for (const token of NEW_TOKENS) {
+        const declaration = block.match(new RegExp(`${token}:\\s*([^;]+);`))?.[1] ?? '';
+        expect(declaration, `${token} fallback should not depend on color-mix`).not.toContain('color-mix');
+        expect(declaration.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('upgrades the panel/secondary surfaces to color-mix behind @supports', () => {
+    const supportsStart = themeSource.indexOf('@supports (background: color-mix(');
+    expect(supportsStart, 'theme-colors.css should guard the color-mix upgrade with @supports').toBeGreaterThan(-1);
+    const supportsBlock = themeSource.slice(supportsStart, themeSource.indexOf('\n}\n', supportsStart));
+
+    // 两个选择器都要覆写：:root.dark 的实色兜底特异性高于 :where(:root)，
+    // 只升级 :where(:root) 的话暗色会停在兜底值。
+    expect(supportsBlock).toContain(':where(:root)');
+    expect(supportsBlock).toContain(':root.dark');
+    expect(supportsBlock).toMatch(/--surface-panel:\s*color-mix\(in hsl, var\(--surface-elevated\)/);
+    expect(supportsBlock.match(/--surface-panel:/g)).toHaveLength(2);
+    expect(supportsBlock.match(/--button-secondary-surface:\s*var\(--button-tonal-bg\)/g)).toHaveLength(2);
+  });
+
+  it('keeps --accent-primary aligned with the shadcn primary token', () => {
+    expect(lightBlock).toMatch(/--accent-primary:\s*hsl\(var\(--primary\)\);/);
+    expect(darkBlock).toMatch(/--accent-primary:\s*hsl\(var\(--primary\)\);/);
+  });
+
+  it('keeps the settings navigation accents in the token layer instead of hex literals', () => {
+    const navSource = readFileSync(
+      resolve(process.cwd(), 'src/features/settings/components/useSettingsNavigation.tsx'),
+      'utf-8',
+    );
+    expect(navSource).not.toMatch(/mobileAccent:\s*'#/);
+    expect(navSource).toContain('var(--settings-nav-accent-amber)');
+
+    for (const match of navSource.matchAll(/var\((--settings-nav-accent-[a-z]+)\)/g)) {
+      expect(lightBlock, `${match[1]} must have a light value`).toContain(`${match[1]}:`);
+      expect(darkBlock, `${match[1]} must be re-tuned for dark mode`).toContain(`${match[1]}:`);
+    }
+
+    // 高对比偏好档（与 workbench a11y-cursor.css 同族）
+    expect(themeSource).toMatch(/@media \(prefers-contrast: more\)[\s\S]*--settings-nav-accent-amber:/);
+  });
+});

--- a/tests/vitest/fontSizeScaleClosureContract.test.ts
+++ b/tests/vitest/fontSizeScaleClosureContract.test.ts
@@ -37,6 +37,49 @@ describe('font size scale closure contract', () => {
     expect(readSource('tailwind.config.js')).toMatch(/'ui':\s*'var\(--font-size-ui\)'/);
   });
 
+  it('routes the menu shell font size through the ui token', () => {
+    // AppMenu / ModelPicker 桌面档经 --menu-shell-font-size 消费字号，
+    // 写死 13px 会让所有弹出菜单脱离界面字号缩放。
+    expect(readSource('src/styles/theme-colors.css')).toContain(
+      '--menu-shell-font-size: var(--font-size-ui);',
+    );
+  });
+
+  it('keeps src/styles free of bare hardcoded px font sizes', () => {
+    const collectCss = (dir: string, acc: string[] = []): string[] => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) collectCss(full, acc);
+        else if (entry.name.endsWith('.css')) acc.push(full);
+      }
+      return acc;
+    };
+
+    // notes-typography.css 属于 notes 功能域（由 notes 线维护），不在本契约范围。
+    const EXEMPT = new Set(['notes-typography.css']);
+
+    const offenders: string[] = [];
+    for (const file of collectCss(resolve(process.cwd(), 'src/styles'))) {
+      if (EXEMPT.has(file.split('/').pop() ?? '')) continue;
+      const source = readFileSync(file, 'utf-8').replace(/\/\*[\s\S]*?\*\//g, '');
+      // 裸 px 字号不参与 --font-size-scale；max(Npx, var(--font-size-*)) 地板
+      // 写法（floor 只兜下限、放大照常跟随）不在此列。
+      for (const match of source.matchAll(/font-size:\s*[0-9.]+(?:px|pt)\s*(?:!important)?\s*;/g)) {
+        offenders.push(`${file.replace(`${process.cwd()}/`, '')}: ${match[0]}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps the mobile drawer readability floors while following the scale', () => {
+    const responsive = readSource('src/styles/responsive-utilities.css');
+    // 列表行地板 14px、输入框/触控行地板 16px（iOS WKWebView 聚焦 <16px
+    // 输入框会自动放大页面），放大档跟随 --font-size-scale。
+    expect(responsive).toContain('font-size: max(14px, var(--font-size-base)) !important;');
+    expect(responsive).toContain('font-size: max(16px, var(--font-size-lg)) !important;');
+    expect(responsive).toContain('font-size: max(16px, var(--font-size-lg));');
+  });
+
   it('keeps the hand-written .text-ui rule from shadowing the Tailwind utility', () => {
     const typography = readSource('src/styles/typography.css');
     // typography.css 晚于 tailwind.css 引入：不加 :where() 归零特异性的话，

--- a/tests/vitest/fontSizeScaleClosureContract.test.ts
+++ b/tests/vitest/fontSizeScaleClosureContract.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import {
+  buttonBaseClassName,
+  buttonIconSizeClassNames,
+  buttonSizeClassNames,
+  shellNavBaseClassName,
+} from '@/components/ui/buttonPrimitiveContract';
+
+/**
+ * 字号缩放闭环契约。
+ *
+ * 设置 → 外观 → 界面字号写的是 --font-size-scale（fontConfig.ts），所有
+ * --font-size-* token 都是 calc(Npx * var(--font-size-scale))。Tailwind 的
+ * 任意值字号（text-[13px] 这类）是编译期常量，完全不参与缩放——按钮标签曾
+ * 是最显眼的漏网层。本测试锁住共享按钮/基元这一层的闭环，并确认新增违规有
+ * lint 拦截。
+ */
+describe('font size scale closure contract', () => {
+  const readSource = (relative: string) => readFileSync(resolve(process.cwd(), relative), 'utf-8');
+
+  const ARBITRARY_FONT_SIZE = /(?<![a-zA-Z0-9])text-\[(?:length:)?\d*\.?\d+(?:px|rem|em|pt)\]/;
+
+  it('scales every font-size token off --font-size-scale', () => {
+    const shadcnVars = readSource('src/styles/shadcn-variables.css');
+    const sizeTokens = [...shadcnVars.matchAll(/(--font-size-(?!scale)[a-z0-9-]+):\s*([^;]+);/g)];
+    expect(sizeTokens.length).toBeGreaterThan(5);
+    for (const [, token, value] of sizeTokens) {
+      expect(value, `${token} must be derived from --font-size-scale`).toContain('var(--font-size-scale)');
+    }
+    expect(shadcnVars).toContain('--font-size-ui: calc(13px * var(--font-size-scale));');
+    expect(readSource('src/config/fontConfig.ts')).toContain("setProperty('--font-size-scale'");
+  });
+
+  it('maps the Tailwind text-ui utility onto the scalable ui token', () => {
+    expect(readSource('tailwind.config.js')).toMatch(/'ui':\s*'var\(--font-size-ui\)'/);
+  });
+
+  it('keeps the hand-written .text-ui rule from shadowing the Tailwind utility', () => {
+    const typography = readSource('src/styles/typography.css');
+    // typography.css 晚于 tailwind.css 引入：不加 :where() 归零特异性的话，
+    // 这条规则会盖掉 text-ui 工具类（12px vs 13px），并顺带压掉同元素上的
+    // font-* / tracking-* 工具类。
+    expect(typography).toMatch(/:where\(\.text-ui\)\s*\{/);
+    expect(typography).not.toMatch(/^\.text-ui\s*\{/m);
+    const rule = typography.match(/:where\(\.text-ui\)\s*\{([^}]*)\}/)?.[1] ?? '';
+    expect(rule).toContain('font-size: var(--font-size-ui);');
+  });
+
+  it('routes shared button recipes through token font sizes', () => {
+    expect(buttonBaseClassName).toContain('text-ui');
+    expect(shellNavBaseClassName).toContain('text-ui');
+    expect(buttonSizeClassNames.default).toContain('text-ui');
+    expect(buttonSizeClassNames.md).toContain('text-ui');
+    expect(buttonSizeClassNames.sm).toContain('text-xs');
+    expect(buttonSizeClassNames.lg).toContain('text-sm');
+
+    const recipes = { buttonBaseClassName, shellNavBaseClassName, ...buttonSizeClassNames };
+    for (const [name, recipe] of Object.entries(recipes)) {
+      expect(recipe, `${name} must not hardcode a font size`).not.toMatch(ARBITRARY_FONT_SIZE);
+    }
+  });
+
+  it('keeps touch targets at the 44px baseline regardless of font scale', () => {
+    // 字号放大不能把触控目标压小：高度走固定几何 token，桌面才在 lg 断点压缩。
+    for (const [size, recipe] of Object.entries(buttonSizeClassNames)) {
+      expect(recipe, `size=${size} must keep the coarse-pointer touch target`).toContain(
+        'h-[var(--touch-target-size)]',
+      );
+    }
+    for (const [size, recipe] of Object.entries(buttonIconSizeClassNames)) {
+      expect(recipe, `iconOnly size=${size} must keep the coarse-pointer touch target`).toContain(
+        'h-[var(--touch-target-size)] w-[var(--touch-target-size)]',
+      );
+    }
+    const shadcnVars = readSource('src/styles/shadcn-variables.css');
+    expect(shadcnVars).toContain('--control-height-touch: 44px;');
+    expect(shadcnVars).toContain('--touch-target-size: var(--control-height-touch);');
+  });
+
+  it('leaves no hardcoded font size in the shared UI primitives', () => {
+    const collect = (dir: string, acc: string[] = []): string[] => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) collect(full, acc);
+        else if (/\.tsx?$/.test(entry.name)) acc.push(full);
+      }
+      return acc;
+    };
+
+    const offenders: string[] = [];
+    for (const file of collect(resolve(process.cwd(), 'src/components/ui'))) {
+      const source = readFileSync(file, 'utf-8')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/\/\/[^\n]*/g, '');
+      const match = source.match(ARBITRARY_FONT_SIZE);
+      if (match) offenders.push(`${file.replace(`${process.cwd()}/`, '')}: ${match[0]}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('wires the lint guard that blocks new hardcoded font sizes', () => {
+    const eslintConfig = readSource('eslint.config.js');
+    expect(eslintConfig).toContain("import noArbitraryFontSize from './eslint-rules/no-arbitrary-font-size.js'");
+    expect(eslintConfig).toContain("'no-arbitrary-font-size': noArbitraryFontSize");
+    expect(eslintConfig).toContain("'ds-components/no-arbitrary-font-size': 'warn'");
+    // 共享基元目录已清零，必须是 error 而不是 warn
+    expect(eslintConfig).toMatch(
+      /files:\s*\['src\/components\/ui\/\*\*\/\*\.\{ts,tsx\}'\][\s\S]{0,320}?'ds-components\/no-arbitrary-font-size':\s*'error'/,
+    );
+  });
+});

--- a/tests/vitest/noArbitraryFontSizeRule.test.ts
+++ b/tests/vitest/noArbitraryFontSizeRule.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { Linter } from 'eslint';
+import rule from '../../eslint-rules/no-arbitrary-font-size.js';
+
+/**
+ * ds-components/no-arbitrary-font-size 的行为契约。
+ * 规则本体见 eslint-rules/no-arbitrary-font-size.js。
+ */
+describe('ds-components/no-arbitrary-font-size', () => {
+  const linter = new Linter();
+
+  const lint = (code: string) =>
+    linter.verify(code, {
+      plugins: { 'ds-components': { rules: { 'no-arbitrary-font-size': rule as never } } },
+      languageOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+        parserOptions: { ecmaFeatures: { jsx: true } },
+      },
+      rules: { 'ds-components/no-arbitrary-font-size': 'error' },
+    });
+
+  it.each([
+    ["const a = 'text-[13px]';", 'px'],
+    ["const a = 'flex items-center text-[10px] font-medium';", 'inside a class list'],
+    ["const a = 'md:text-[0.8rem]';", 'responsive variant'],
+    ['const a = `gap-2 ${x} text-[15px]`;', 'template literal'],
+    ["const a = 'data-[state=open]:text-[11px]';", 'data variant'],
+  ])('flags %s (%s)', code => {
+    const messages = lint(code);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].messageId).toBe('noArbitraryFontSize');
+  });
+
+  it.each([
+    "const a = 'text-ui';",
+    "const a = 'text-2xs text-caption';",
+    "const a = 'text-[length:var(--font-size-ui)]';",
+    "const a = 'h-[var(--touch-target-size)] px-[14px]';",
+    "const a = 'leading-[13px]';",
+    "const a = 'subtext-[13px]';",
+  ])('allows %s', code => {
+    expect(lint(code)).toEqual([]);
+  });
+
+  it('reports the offending class in the message', () => {
+    const [message] = lint("const a = 'text-[13px]';");
+    expect(message.message).toContain('text-[13px]');
+    expect(message.message).toContain('--font-size-scale');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

补齐被故障面板消费但未定义的 token，翻转暗色阴影，按钮字号走 `text-ui` 并禁新增 `text-[Npx]`。比 #159 多 eslint 规则和契约测试。

续推补上字号缩放闭环缺口：菜单外壳和移动抽屉不再写死 px；`src/styles` 禁止裸 px 字号（notes 域豁免）。

### Changes
- `--surface-panel` / `--accent-primary` / `--button-secondary-surface`
- 暗色阴影档位翻转
- 按钮/共享基元改 `text-ui`；eslint 拦截 `text-[Npx]`
- `--menu-shell-font-size` 走 `--font-size-ui`；移动抽屉用 `max(地板, token)`
- 契约测试覆盖故障面板 token、暗色阴影档位与字号缩放

### How to test
- 数据恢复/功能不可用面板亮暗色都有底色
- 暗色浮层有阴影层次
- 设置字号变化时按钮标签、AppMenu、移动抽屉跟着变
- `tests/vitest/failurePathSurfaceTokenContract.test.ts`、`darkShadowElevationContract.test.ts`、`fontSizeScaleClosureContract.test.ts`

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

### 重叠说明
与 #159、#164 在 token/阴影/text-ui 上重叠。本分支不含 Finder/命令面板。建议只要设计系统+eslint 合本分支；#159 是更小切片，#164 是大杂烩。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92ea5725-a196-4c8d-97b6-cf85cfe2ecb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92ea5725-a196-4c8d-97b6-cf85cfe2ecb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

