### PR TITLE
fix(a11y): 命令面板 combobox/Tab 可达，数据治理 Debug 仅 DEV

### DIFF
--- a/src/command-palette/CommandPalette.tsx
+++ b/src/command-palette/CommandPalette.tsx
@@ -6,6 +6,7 @@
 import React, {
   useState,
   useEffect,
+  useId,
   useRef,
   useCallback,
   useMemo,
@@ -56,6 +57,21 @@ import './styles/command-palette.css';
 
 /** 资源命令 id 前缀（不进入命令注册表，仅在面板内即时构造） */
 const RESOURCE_COMMAND_PREFIX = '__resource.';
+
+/**
+ * 面板内可聚焦控件选择器。
+ *
+ * 面板是 aria-modal 对话框：焦点不能逃到背景页，
+ * 但必须能在搜索框 / 模式按钮 / 收藏按钮 / 关闭按钮之间流转。
+ */
+const PALETTE_FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
 
 /** DSTU 资源类型 → 图标 */
 const RESOURCE_TYPE_ICONS: Partial<Record<DstuNodeType, Icon>> = {
@@ -125,6 +141,12 @@ export function CommandPalette() {
     sessionSearchOnly,
   } = useCommandPalette();
   
+  // combobox / listbox / option 之间用稳定 id 关联（aria-controls、aria-activedescendant）
+  const baseId = useId();
+  const listboxId = `${baseId}-listbox`;
+  const optionId = useCallback((index: number) => `${baseId}-option-${index}`, [baseId]);
+  const groupLabelId = useCallback((category: string) => `${baseId}-group-${category}`, [baseId]);
+
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [viewMode, setViewMode] = useState<ViewMode>('search');
@@ -254,6 +276,18 @@ export function CommandPalette() {
     }
   }, [isOpen, sessionSearchOnly]);
 
+  // 关闭后把焦点还给打开面板的那个元素，避免焦点掉回 body（读屏丢失上下文）
+  useEffect(() => {
+    if (!isOpen) return;
+    const previouslyFocused = document.activeElement;
+    const restoreTarget = previouslyFocused instanceof HTMLElement ? previouslyFocused : null;
+    return () => {
+      if (restoreTarget && document.contains(restoreTarget)) {
+        restoreTarget.focus();
+      }
+    };
+  }, [isOpen]);
+
   // Android 系统返回键 = 关闭面板（自绘 dialog 无 data-state，协调器 Radix 兜底覆盖不到）
   const closeRef = useRef(close);
   closeRef.current = close;
@@ -333,8 +367,64 @@ export function CommandPalette() {
     isKeyboardNavRef.current = false;
   }, [selectedIndex]);
   
+  /**
+   * Tab：只把焦点圈在面板内，不再一刀切吞掉。
+   *
+   * 旧实现对 Tab 无条件 preventDefault，面板内的收藏 / 模式切换 / 关闭按钮
+   * 对键盘和读屏用户完全不可达。现在只在到达焦点环两端时接管并回绕，
+   * 中间的 Tab 交给浏览器默认行为，正常走到下一个控件。
+   */
+  const handleTabKey = useCallback((e: React.KeyboardEvent) => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const focusables = Array.from(
+      container.querySelectorAll<HTMLElement>(PALETTE_FOCUSABLE_SELECTOR),
+    ).filter((el) => el.getAttribute('aria-hidden') !== 'true');
+
+    if (focusables.length === 0) {
+      e.preventDefault();
+      return;
+    }
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+    const isInside = active instanceof HTMLElement && container.contains(active);
+
+    if (e.shiftKey) {
+      if (!isInside || active === first) {
+        e.preventDefault();
+        last.focus();
+      }
+      return;
+    }
+
+    if (!isInside || active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }, []);
+
   // 键盘事件处理
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // Escape / Tab 与焦点所在控件无关，始终由面板处理
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+      return;
+    }
+    if (e.key === 'Tab') {
+      handleTabKey(e);
+      return;
+    }
+
+    // 焦点已经进入面板内的按钮时，Enter 属于该按钮，
+    // 不能再被「执行当前高亮命令」抢走
+    const target = e.target as HTMLElement | null;
+    const isOnInnerControl = target !== inputRef.current && !!target?.closest('button');
+    if (isOnInnerControl && e.key === 'Enter') return;
+
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault();
@@ -367,18 +457,8 @@ export function CommandPalette() {
           }
         }
         break;
-        
-      case 'Escape':
-        e.preventDefault();
-        close();
-        break;
-        
-      case 'Tab':
-        // 阻止 Tab 离开面板
-        e.preventDefault();
-        break;
     }
-  }, [flatCommands, selectedIndex, handleExecuteCommand, close, deps, t]);
+  }, [flatCommands, selectedIndex, handleExecuteCommand, close, deps, t, handleTabKey]);
   
   // 点击遮罩关闭
   const handleBackdropClick = useCallback((e: React.MouseEvent) => {
@@ -396,6 +476,11 @@ export function CommandPalette() {
   
   // 计算当前命令在扁平列表中的索引
   let currentFlatIndex = 0;
+
+  const hasResults = flatCommands.length > 0;
+  const activeOptionId = hasResults && flatCommands[selectedIndex]
+    ? optionId(selectedIndex)
+    : undefined;
   
   return (
     <div 
@@ -414,6 +499,7 @@ export function CommandPalette() {
         <div className="command-palette-search">
           {isSmallScreen && (
             <button
+              type="button"
               className="command-palette-back-btn"
               onClick={close}
               aria-label={t('common:back')}
@@ -441,11 +527,19 @@ export function CommandPalette() {
               aria-label={sessionSearchOnly
                 ? t('command_palette:session_search_placeholder', 'Search sessions...')
                 : t('command_palette:search_placeholder')}
+              // 读屏契约：搜索框是 combobox，结果列表是它控制的 listbox，
+              // 高亮项通过 aria-activedescendant 播报（焦点始终留在输入框）
+              role="combobox"
+              aria-autocomplete="list"
+              aria-controls={listboxId}
+              aria-expanded={hasResults}
+              aria-activedescendant={activeOptionId}
             />
           </div>
           {/* 模式切换按钮 */}
           {!sessionSearchOnly ? <div className="command-palette-mode-buttons">
             <button
+              type="button"
               className={cn(
                 'command-palette-mode-btn',
                 viewMode === 'recent' && 'command-palette-mode-btn-active'
@@ -455,10 +549,13 @@ export function CommandPalette() {
                 setSelectedIndex(0);
               }}
               title={t('command_palette:mode_recent')}
+              aria-label={t('command_palette:mode_recent')}
+              aria-pressed={viewMode === 'recent'}
             >
               <Clock size={16} />
             </button>
             <button
+              type="button"
               className={cn(
                 'command-palette-mode-btn',
                 viewMode === 'favorites' && 'command-palette-mode-btn-active'
@@ -468,12 +565,15 @@ export function CommandPalette() {
                 setSelectedIndex(0);
               }}
               title={t('command_palette:mode_favorites')}
+              aria-label={t('command_palette:mode_favorites')}
+              aria-pressed={viewMode === 'favorites'}
             >
               <Star size={16} />
             </button>
           </div> : null}
           {!isSmallScreen && (
             <button
+              type="button"
               className="command-palette-close-btn"
               onClick={close}
               aria-label={t('common:close')}
@@ -488,7 +588,11 @@ export function CommandPalette() {
           className="command-palette-scroll-area"
           viewportRef={listRef}
           viewportClassName="command-palette-list"
-          viewportProps={{ role: 'listbox' }}
+          viewportProps={{
+            role: 'listbox',
+            id: listboxId,
+            'aria-label': t('command_palette:results_label', 'Command results'),
+          } as React.HTMLAttributes<HTMLDivElement>}
           hideTrackWhenIdle={true}
           trackOffsetTop={4}
           trackOffsetBottom={4}
@@ -523,8 +627,13 @@ export function CommandPalette() {
               }
 
               return (
-                <div key={category} className="command-palette-group">
-                  <div className="command-palette-group-label">
+                <div
+                  key={category}
+                  className="command-palette-group"
+                  role="group"
+                  aria-labelledby={groupLabelId(category)}
+                >
+                  <div className="command-palette-group-label" id={groupLabelId(category)}>
                     {categoryLabel}
                   </div>
                   {commands.map((command) => {
@@ -537,6 +646,7 @@ export function CommandPalette() {
                     return (
                       <div
                         key={command.id}
+                        id={optionId(flatIndex)}
                         data-index={flatIndex}
                         className={cn(
                           'command-palette-item',
@@ -563,6 +673,7 @@ export function CommandPalette() {
                         {/* 收藏按钮（资源直达项为动态结果，不支持收藏） */}
                         {!isResource && (
                           <button
+                            type="button"
                             className={cn(
                               'command-palette-item-favorite',
                               commandFavorites.isFavorite(command.id) && 'command-palette-item-favorite-active'
@@ -572,6 +683,11 @@ export function CommandPalette() {
                               ? t('command_palette:unfavorite')
                               : t('command_palette:favorite')
                             }
+                            // 图标按钮：读屏可访问名 = 收藏/取消收藏 + 命令名
+                            aria-label={`${commandFavorites.isFavorite(command.id)
+                              ? t('command_palette:unfavorite')
+                              : t('command_palette:favorite')} — ${command.name}`}
+                            aria-pressed={commandFavorites.isFavorite(command.id)}
                           >
                             {commandFavorites.isFavorite(command.id) ? (
                               <Star size={14} className="fill-current" />

--- a/src/command-palette/styles/command-palette.css
+++ b/src/command-palette/styles/command-palette.css
@@ -278,8 +278,16 @@
 }
 
 .command-palette-item:hover .command-palette-item-favorite,
-.command-palette-item-selected .command-palette-item-favorite {
+.command-palette-item-selected .command-palette-item-favorite,
+/* Tab 现在可以走到收藏按钮：聚焦时必须显形，
+   否则是「不可见但可聚焦」的键盘陷阱 */
+.command-palette-item-favorite:focus-visible {
   opacity: 1;
+}
+
+.command-palette-item-favorite:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 1px;
 }
 
 .command-palette-item-favorite:hover {
@@ -456,6 +464,19 @@
   .command-palette-item-description {
     max-width: 100%;
   }
+
+  /* ★ 移动视口触控规范（不依赖 pointer: coarse——390px 宽的桌面窗口 / 设备模拟器
+     指针仍是 fine，但布局已经是全屏子屏形态）：结果行触控高度 ≥44px。 */
+  .command-palette-item {
+    min-height: 44px;
+  }
+
+  /* 窄屏没有 hover 可依赖：收藏按钮常显并放大触控区 */
+  .command-palette-item-favorite {
+    opacity: 1;
+    width: 40px;
+    height: 40px;
+  }
 }
 
 @keyframes command-palette-page-in {
@@ -503,6 +524,16 @@
   .command-palette-mode-btn {
     border-radius: 9999px;
     color: hsl(var(--shell-navigation-muted, var(--muted-foreground)));
+  }
+
+  /* 顶栏触控目标 ≥44px：与 (pointer: coarse) 分支互补，覆盖
+     「窄视口 + fine 指针」这一档（桌面窄窗 / 设备模拟器）。
+     390px 宽下关闭 / 返回入口必须点得到。 */
+  .command-palette-back-btn,
+  .command-palette-close-btn,
+  .command-palette-mode-btn {
+    width: 44px;
+    height: 44px;
   }
 
   .command-palette-mode-btn-active,

--- a/src/features/settings/components/DataGovernanceDashboard.tsx
+++ b/src/features/settings/components/DataGovernanceDashboard.tsx
@@ -598,6 +598,16 @@ export const DataGovernanceDashboard: React.FC<DataGovernanceDashboardProps> = (
   tabTarget = null,
 }) => {
   const { t } = useTranslation(['data', 'common']);
+  /**
+   * `t` 的身份不保证跨渲染稳定。
+   *
+   * 「按 activeTab 拉数据」的 effect 依赖各个 loader，只要有一个 loader 把 `t` 放进
+   * useCallback 依赖，它就每渲染换一次身份 → effect 每渲染重跑 → loader 里的
+   * setState 又触发下一次渲染，构成自激循环（jsdom 下会一路吃到堆溢出）。
+   * 这些地方只在报错分支用文案，从 ref 读即可，不需要参与依赖。
+   */
+  const tRef = useRef(t);
+  tRef.current = t;
   const { enterMaintenanceMode, requireMaintenanceRestart, exitMaintenanceMode } = useSystemStatusStore(
     useShallow((state) => ({
       enterMaintenanceMode: state.enterMaintenanceMode,
@@ -782,10 +792,10 @@ export const DataGovernanceDashboard: React.FC<DataGovernanceDashboardProps> = (
       console.error('加载可恢复任务失败:', error);
       showGlobalNotification(
         'warning',
-        t('data:governance.resumable_jobs_load_failed')
+        tRef.current('data:governance.resumable_jobs_load_failed')
       );
     }
-  }, [t]);
+  }, []);
 
   /**
    * 以后端聚合状态为真相收敛前端维护横幅。
@@ -1653,7 +1663,7 @@ export const DataGovernanceDashboard: React.FC<DataGovernanceDashboardProps> = (
           if (event.payload.length > 0) {
             showGlobalNotification(
               'info',
-              t('data:governance.resumable_jobs_found', {
+              tRef.current('data:governance.resumable_jobs_found', {
                 count: event.payload.length,
               })
             );
@@ -1680,7 +1690,7 @@ export const DataGovernanceDashboard: React.FC<DataGovernanceDashboardProps> = (
       mounted = false;
       unlisten?.();
     };
-  }, [t]);
+  }, []);
 
   // 组件挂载时自动重连到正在运行的备份任务
   useEffect(() => {

--- a/src/features/settings/components/DataGovernanceDashboard.tsx
+++ b/src/features/settings/components/DataGovernanceDashboard.tsx
@@ -91,6 +91,15 @@ import {
 
 const console = debugLog as Pick<typeof debugLog, 'log' | 'warn' | 'error' | 'info' | 'debug'>;
 
+/**
+ * Debug 页签是否可见。
+ *
+ * 生产构建里该页签的每个控件都被 `disabled={!import.meta.env.DEV}` 灰掉，
+ * 页签本身却照常渲染 —— 用户（移动端更只看得到一个虫子图标）点进去
+ * 只会看到一屏无法操作的按钮。实现保留，入口只在开发构建暴露。
+ */
+const isDebugTabEnabled = (): boolean => import.meta.env.DEV;
+
 // ==================== 调试面板（DEV only） ====================
 
 export const DebugTab: React.FC = () => {
@@ -597,11 +606,14 @@ export const DataGovernanceDashboard: React.FC<DataGovernanceDashboardProps> = (
     }))
   );
   const [activeTab, setActiveTab] = useState<DashboardTab>('overview');
+  const debugTabEnabled = isDebugTabEnabled();
 
   useEffect(() => {
     if (!tabTarget) return;
+    // 生产构建没有 debug 页签，外部深链不能把面板切到一个不存在的页签
+    if (tabTarget.tab === 'debug' && !debugTabEnabled) return;
     setActiveTab(tabTarget.tab);
-  }, [tabTarget]);
+  }, [tabTarget, debugTabEnabled]);
 
   const [loadingState, setLoadingState] = useState({
     overview: 0,
@@ -1752,39 +1764,49 @@ export const DataGovernanceDashboard: React.FC<DataGovernanceDashboardProps> = (
 
   const content = (
     <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as DashboardTab)}>
-      <TabsList className="scrollbar-none mb-4 flex h-auto min-h-11 w-full max-w-full justify-start overflow-x-auto">
-        <TabsTrigger value="overview" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+      {/* 页签文字在 <640px 被 `hidden sm:inline` 收掉，只剩图标。
+          每个 trigger 必须带 aria-label，否则移动端读屏（VoiceOver / TalkBack）
+          只会念「按钮」，8 个页签互相无法区分。 */}
+      <TabsList
+        aria-label={t('data:governance.tabs_nav_label')}
+        className="scrollbar-none mb-4 flex h-auto min-h-11 w-full max-w-full justify-start overflow-x-auto"
+      >
+        <TabsTrigger value="overview" aria-label={t('data:governance.tab_overview')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <Gauge className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_overview')}</span>
         </TabsTrigger>
-        <TabsTrigger value="recovery" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+        <TabsTrigger value="recovery" aria-label={t('data:governance.tab_recovery')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <ShieldCheck className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_recovery')}</span>
         </TabsTrigger>
-        <TabsTrigger value="archive" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+        <TabsTrigger value="archive" aria-label={t('data:governance.tab_archive')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <Archive className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_archive')}</span>
         </TabsTrigger>
-        <TabsTrigger value="backup" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+        <TabsTrigger value="backup" aria-label={t('data:governance.tab_backup')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <HardDrive className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_backup')}</span>
         </TabsTrigger>
-        <TabsTrigger value="sync" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+        <TabsTrigger value="sync" aria-label={t('data:governance.tab_sync')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <Cloud className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_sync')}</span>
         </TabsTrigger>
-        <TabsTrigger value="audit" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+        <TabsTrigger value="audit" aria-label={t('data:governance.tab_audit')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <FileText className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_audit')}</span>
         </TabsTrigger>
-        <TabsTrigger value="cache" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
+        <TabsTrigger value="cache" aria-label={t('data:governance.tab_cache')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 sm:min-h-0 sm:min-w-0">
           <Image className="h-4 w-4" />
           <span className="hidden sm:inline">{t('data:governance.tab_cache')}</span>
         </TabsTrigger>
-        <TabsTrigger value="debug" className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 text-muted-foreground sm:min-h-0 sm:min-w-0">
-          <Bug className="h-4 w-4" />
-          <span className="hidden sm:inline">{t('data:governance.debug_tab_title')}</span>
-        </TabsTrigger>
+        {/* Debug 页签只在开发构建出现：生产里它的控件全部 disabled，
+            对用户是一个「点得到但什么都不能做」的死页签，移动端尤其误导。 */}
+        {debugTabEnabled && (
+          <TabsTrigger value="debug" aria-label={t('data:governance.debug_tab_title')} className="flex min-h-11 min-w-11 shrink-0 items-center gap-1 text-muted-foreground sm:min-h-0 sm:min-w-0">
+            <Bug className="h-4 w-4" />
+            <span className="hidden sm:inline">{t('data:governance.debug_tab_title')}</span>
+          </TabsTrigger>
+        )}
       </TabsList>
 
       <TabsContent value="overview">
@@ -1910,9 +1932,11 @@ export const DataGovernanceDashboard: React.FC<DataGovernanceDashboardProps> = (
         </div>
       </TabsContent>
 
-      <TabsContent value="debug">
-        <DebugTab />
-      </TabsContent>
+      {debugTabEnabled && (
+        <TabsContent value="debug">
+          <DebugTab />
+        </TabsContent>
+      )}
     </Tabs>
   );
 

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -181,6 +181,9 @@ export const SettingsSidebar: React.FC<SettingsSidebarProps> = ({
                   <WorkbenchSidebarRow
                     rowType="nav"
                     isActive={isActive}
+                    // 收起态（以及任何只剩图标的窄形态）下标签文字不渲染，
+                    // 没有 aria-label 读屏就只念「按钮」
+                    aria-label={item.label}
                     aria-current={isActive ? 'page' : undefined}
                     onClick={isActive ? undefined : () => {
                       setActiveTab(item.value as any);

--- a/src/locales/en-US/command_palette.json
+++ b/src/locales/en-US/command_palette.json
@@ -3,6 +3,7 @@
   "search_placeholder": "Search commands...",
   "session_search_placeholder": "Search sessions...",
   "no_results": "No matching commands found",
+  "results_label": "Command results",
   "placeholder": "Type a command or search notes...",
   "no_results_simple": "No results found",
   "command_disabled": "This command is currently unavailable",

--- a/src/locales/en-US/data.json
+++ b/src/locales/en-US/data.json
@@ -810,6 +810,7 @@
     "import_button": "Import",
     "title": "Data Governance",
     "description": "Manage database migrations, backups, sync, and audit logs",
+    "tabs_nav_label": "Data governance tabs",
     "tab_overview": "Overview",
     "tab_recovery": "Recovery",
     "tab_archive": "Archive",

--- a/src/locales/zh-CN/command_palette.json
+++ b/src/locales/zh-CN/command_palette.json
@@ -3,6 +3,7 @@
   "search_placeholder": "搜索命令...",
   "session_search_placeholder": "搜索会话...",
   "no_results": "未找到匹配的命令",
+  "results_label": "命令结果列表",
   "placeholder": "输入命令或搜索笔记...",
   "no_results_simple": "未找到结果",
   "command_disabled": "该命令当前不可用",

--- a/src/locales/zh-CN/data.json
+++ b/src/locales/zh-CN/data.json
@@ -810,6 +810,7 @@
     "import_button": "导入",
     "title": "数据治理",
     "description": "管理数据库迁移、备份、同步和审计日志",
+    "tabs_nav_label": "数据治理页签",
     "tab_overview": "概览",
     "tab_recovery": "恢复",
     "tab_archive": "归档",

--- a/tests/vitest/command-palette/commandPaletteA11yContract.test.tsx
+++ b/tests/vitest/command-palette/commandPaletteA11yContract.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * 命令面板键盘 / 读屏契约：
+ * - 搜索框是 combobox，通过 aria-controls / aria-activedescendant 关联结果 listbox
+ * - 结果项是 option 且有稳定 id，方向键改变 aria-activedescendant
+ * - Tab 不再被一刀切吞掉：可以走到面板内的收藏 / 模式 / 关闭按钮，并在两端回绕
+ * - 移动端（390 宽）：关闭入口可聚焦，焦点仍锁在面板内
+ */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@/command-palette/hooks/useResourceSearch', () => ({
+  useResourceSearch: () => ({ fileResults: [], sessionResults: [] }),
+  openFileFromPalette: vi.fn(),
+  openSessionFromPalette: vi.fn(),
+}));
+
+import { CommandPalette } from '@/command-palette/CommandPalette';
+import { CommandPaletteProvider, useCommandPalette } from '@/command-palette/CommandPaletteProvider';
+import { commandRegistry } from '@/command-palette/registry/commandRegistry';
+import { commandFavorites } from '@/command-palette/registry/commandFavorites';
+import type { Command } from '@/command-palette/registry/types';
+
+const DESKTOP_WIDTH = 1280;
+const MOBILE_WIDTH = 390;
+
+/** 让 matchMedia 按给定视口宽度回答 (min-width: Npx) 查询 */
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => {
+      const minWidth = /\(min-width:\s*(\d+)px\)/.exec(query);
+      const matches = minWidth ? width >= Number(minWidth[1]) : false;
+      return {
+        matches,
+        media: query,
+        onchange: null,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        dispatchEvent: () => false,
+      };
+    },
+  });
+}
+
+const TEST_COMMANDS: Command[] = [
+  {
+    id: 'test.alpha',
+    name: 'Alpha command',
+    category: 'navigation',
+    execute: () => undefined,
+  },
+  {
+    id: 'test.beta',
+    name: 'Beta command',
+    category: 'navigation',
+    execute: () => undefined,
+  },
+];
+
+function OpenPaletteButton() {
+  const { open } = useCommandPalette();
+  return (
+    <button type="button" onClick={open}>
+      open-palette
+    </button>
+  );
+}
+
+function renderPalette() {
+  return render(
+    <CommandPaletteProvider
+      currentView="chat-v2"
+      navigate={() => undefined}
+      toggleTheme={() => undefined}
+      isDarkMode={false}
+      switchLanguage={() => undefined}
+    >
+      <OpenPaletteButton />
+      <CommandPalette />
+    </CommandPaletteProvider>,
+  );
+}
+
+async function openPalette() {
+  renderPalette();
+  fireEvent.click(screen.getByText('open-palette'));
+  return screen.findByRole('combobox');
+}
+
+function paletteFocusables(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(
+      '.command-palette-container button, .command-palette-container input',
+    ),
+  );
+}
+
+beforeEach(() => {
+  setViewportWidth(DESKTOP_WIDTH);
+  commandRegistry.clear();
+  commandRegistry.registerAll(TEST_COMMANDS);
+  for (const id of commandFavorites.getAll()) {
+    commandFavorites.toggle(id);
+  }
+});
+
+afterEach(() => {
+  commandRegistry.clear();
+});
+
+describe('CommandPalette 键盘 / 读屏契约', () => {
+  it('搜索框是 combobox 且用 aria-controls 指向结果 listbox', async () => {
+    const input = await openPalette();
+
+    const listbox = screen.getByRole('listbox');
+    expect(listbox.id).toBeTruthy();
+    expect(input).toHaveAttribute('aria-controls', listbox.id);
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    expect(input).toHaveAttribute('aria-autocomplete', 'list');
+  });
+
+  it('aria-activedescendant 指向当前高亮的 option，方向键会跟着走', async () => {
+    const input = await openPalette();
+
+    const options = screen.getAllByRole('option');
+    expect(options.length).toBeGreaterThanOrEqual(2);
+    for (const option of options) {
+      expect(option.id).toBeTruthy();
+    }
+
+    expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-activedescendant', options[1].id);
+    });
+    expect(screen.getAllByRole('option')[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('结果分组是带可访问名的 group，不是裸 div', async () => {
+    await openPalette();
+
+    const groups = screen.getAllByRole('group');
+    expect(groups.length).toBeGreaterThanOrEqual(1);
+    const labelId = groups[0].getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    expect(document.getElementById(labelId!)).not.toBeNull();
+  });
+
+  it('Tab 不再被一刀切吞掉：可以从搜索框走到面板内的按钮', async () => {
+    const user = userEvent.setup();
+    const input = await openPalette();
+
+    await waitFor(() => expect(input).toHaveFocus());
+
+    // 旧实现在这里对 Tab 无条件 preventDefault，焦点永远停在输入框
+    expect(fireEvent.keyDown(input, { key: 'Tab' })).toBe(true);
+
+    await user.tab();
+    expect(document.activeElement).not.toBe(input);
+    expect(document.activeElement?.tagName).toBe('BUTTON');
+  });
+
+  it('面板内的图标按钮（收藏 / 模式 / 关闭）都有可访问名', async () => {
+    await openPalette();
+
+    expect(screen.getByRole('button', { name: /command_palette:mode_recent/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /command_palette:mode_favorites/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /关闭|common:close/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /command_palette:favorite — Alpha command/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('Tab 焦点环闭合：最后一个控件按 Tab 回到第一个，Shift+Tab 反向回绕', async () => {
+    const input = await openPalette();
+
+    const focusables = paletteFocusables();
+    expect(focusables.length).toBeGreaterThan(1);
+
+    const last = focusables[focusables.length - 1];
+    last.focus();
+    expect(fireEvent.keyDown(last, { key: 'Tab' })).toBe(false);
+    expect(document.activeElement).toBe(focusables[0]);
+
+    input.focus();
+    expect(fireEvent.keyDown(input, { key: 'Tab', shiftKey: true })).toBe(false);
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('焦点在面板内按钮上时，Enter 归按钮，不再被「执行高亮命令」抢走', async () => {
+    await openPalette();
+
+    const favoriteButton = screen.getByRole('button', {
+      name: /command_palette:favorite — Alpha command/,
+    });
+    favoriteButton.focus();
+
+    // 未被 preventDefault → 浏览器把 Enter 交给按钮的默认激活行为
+    expect(fireEvent.keyDown(favoriteButton, { key: 'Enter' })).toBe(true);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('Escape 关闭面板，焦点回到打开面板的元素', async () => {
+    renderPalette();
+    const trigger = screen.getByText('open-palette');
+    trigger.focus();
+    fireEvent.click(trigger);
+    const input = await screen.findByRole('combobox');
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    });
+    expect(document.activeElement).toBe(trigger);
+  });
+});
+
+describe('CommandPalette 移动端（390 宽）焦点契约', () => {
+  beforeEach(() => {
+    setViewportWidth(MOBILE_WIDTH);
+  });
+
+  it('全屏形态下关闭入口可聚焦，且焦点仍锁在面板内', async () => {
+    const input = await openPalette();
+
+    const closeButton = screen.getByRole('button', { name: /返回|common:back/ });
+    closeButton.focus();
+    expect(document.activeElement).toBe(closeButton);
+
+    // 关闭入口是面板内第一个可聚焦控件：Shift+Tab 应回绕到面板末尾，而不是逃到背景页
+    const focusables = paletteFocusables();
+    expect(focusables[0]).toBe(closeButton);
+    expect(fireEvent.keyDown(closeButton, { key: 'Tab', shiftKey: true })).toBe(false);
+    expect(document.activeElement).toBe(focusables[focusables.length - 1]);
+
+    // 输入框依旧是 combobox
+    expect(input).toHaveAttribute('role', 'combobox');
+  });
+
+  it('点击关闭入口能关掉面板', async () => {
+    await openPalette();
+
+    fireEvent.click(screen.getByRole('button', { name: /返回|common:back/ }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/tests/vitest/command-palette/commandPaletteMobileTouchContract.source.test.ts
+++ b/tests/vitest/command-palette/commandPaletteMobileTouchContract.source.test.ts
@@ -1,0 +1,69 @@
+/**
+ * 命令面板移动端触控/缩放契约（源码断言）：
+ * vitest 配置里 `css: false`，jsdom 量不到真实计算值，
+ * 因此对样式表源码做契约断言，锁住 390px 宽下的硬指标。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const css = readFileSync(
+  resolve(process.cwd(), 'src/command-palette/styles/command-palette.css'),
+  'utf-8',
+);
+
+/** 取出某个 @media 块的内容（按大括号配平截取） */
+function mediaBlock(header: string): string {
+  const start = css.indexOf(header);
+  expect(start).toBeGreaterThanOrEqual(0);
+  let depth = 0;
+  for (let i = css.indexOf('{', start); i < css.length; i += 1) {
+    if (css[i] === '{') depth += 1;
+    if (css[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return css.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unbalanced media block: ${header}`);
+}
+
+describe('命令面板移动端触控契约', () => {
+  const narrowViewportBlocks = css
+    .split('@media')
+    .filter((chunk) => chunk.trimStart().startsWith('(width < 768px)'));
+
+  it('窄视口下输入框字号不低于 iOS 自动缩放阈值 16px', () => {
+    const inputRule = narrowViewportBlocks
+      .join('\n')
+      .match(/\.command-palette-input\s*\{[^}]*\}/);
+    expect(inputRule).not.toBeNull();
+    expect(inputRule![0]).toMatch(/font-size:\s*16px/);
+  });
+
+  it('窄视口下结果行触控高度 ≥44px（不依赖 pointer: coarse）', () => {
+    expect(narrowViewportBlocks.join('\n')).toMatch(
+      /\.command-palette-item\s*\{[^}]*min-height:\s*44px/,
+    );
+  });
+
+  it('窄视口下关闭/返回/模式按钮触控目标 ≥44px', () => {
+    const joined = narrowViewportBlocks.join('\n');
+    const touchTargetRule = joined.match(
+      /\.command-palette-back-btn,\s*\n\s*\.command-palette-close-btn,\s*\n\s*\.command-palette-mode-btn\s*\{[^}]*\}/,
+    );
+    expect(touchTargetRule).not.toBeNull();
+    expect(touchTargetRule![0]).toMatch(/width:\s*44px/);
+    expect(touchTargetRule![0]).toMatch(/height:\s*44px/);
+  });
+
+  it('粗指针下同样保留 44px 触控目标与常显收藏按钮', () => {
+    const coarse = mediaBlock('@media (pointer: coarse)');
+    expect(coarse).toMatch(/\.command-palette-item\s*\{[^}]*min-height:\s*44px/);
+    expect(coarse).toMatch(/\.command-palette-item-favorite\s*\{[^}]*opacity:\s*1/);
+  });
+
+  it('收藏按钮聚焦时必须显形，避免「不可见但可 Tab 到」的键盘陷阱', () => {
+    expect(css).toContain('.command-palette-item-favorite:focus-visible');
+  });
+});

--- a/tests/vitest/data-governance/DataGovernanceDashboard.debug-tab-visibility.test.tsx
+++ b/tests/vitest/data-governance/DataGovernanceDashboard.debug-tab-visibility.test.tsx
@@ -8,13 +8,15 @@
 
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 
 const mockDataGovernanceApi = vi.hoisted(() => ({
   getMigrationStatus: vi.fn(),
   runHealthCheck: vi.fn(),
   getBackupList: vi.fn(),
   listResumableJobs: vi.fn(),
+  listBackupJobs: vi.fn(),
+  getMaintenanceStatus: vi.fn(),
   getSyncStatus: vi.fn(),
   getAuditLogs: vi.fn(),
 }));
@@ -43,17 +45,14 @@ vi.mock('@/utils/tauriApi', () => ({
 
 import { DataGovernanceDashboard } from '@/features/settings';
 
-const TAB_NAMES = [
-  /概览|data:governance\.tab_overview/i,
-  /恢复|data:governance\.tab_recovery/i,
-  /归档|data:governance\.tab_archive/i,
-  /备份|data:governance\.tab_backup/i,
-  /同步|data:governance\.tab_sync/i,
-  /审计|data:governance\.tab_audit/i,
-  /缓存|data:governance\.tab_cache/i,
-];
+const TABS_NAV_LABEL = '数据治理页签';
+const TAB_NAMES = ['概览', '恢复', '归档', '备份', '同步', '审计', '缓存'];
+const DEBUG_TAB_NAME = '调试';
 
-const DEBUG_TAB_NAME = /^调试$|data:governance\.debug_tab_title/i;
+/** 页签只在页签容器里找：面板正文同样有「恢复」「备份」等字样的按钮。 */
+function getTabsNav(): HTMLElement {
+  return screen.getByLabelText(TABS_NAV_LABEL);
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -84,6 +83,10 @@ beforeEach(() => {
   mockDataGovernanceApi.getAuditLogs.mockResolvedValue({ logs: [], total: 0 });
   mockDataGovernanceApi.getBackupList.mockResolvedValue([]);
   mockDataGovernanceApi.listResumableJobs.mockResolvedValue([]);
+  mockDataGovernanceApi.listBackupJobs.mockResolvedValue([]);
+  mockDataGovernanceApi.getMaintenanceStatus.mockResolvedValue({
+    is_in_maintenance_mode: false,
+  });
 });
 
 afterEach(() => {
@@ -94,21 +97,17 @@ describe('数据治理页签可访问名', () => {
   it('每个页签都有可访问名（文字在窄屏被隐藏时靠 aria-label 兜底）', () => {
     render(<DataGovernanceDashboard embedded />);
 
+    const nav = getTabsNav();
     for (const name of TAB_NAMES) {
-      expect(screen.getByRole('button', { name })).toBeInTheDocument();
-    }
-
-    // 可访问名必须来自 aria-label，而不是只存在于 `hidden sm:inline` 的文字里
-    for (const name of TAB_NAMES) {
-      expect(screen.getByRole('button', { name })).toHaveAttribute('aria-label');
+      // 可访问名必须来自 aria-label，而不是只存在于 `hidden sm:inline` 的文字里
+      expect(within(nav).getByRole('button', { name })).toHaveAttribute('aria-label', name);
     }
   });
 
   it('页签容器带导航可访问名', () => {
     render(<DataGovernanceDashboard embedded />);
 
-    const overviewTab = screen.getByRole('button', { name: TAB_NAMES[0] });
-    expect(overviewTab.parentElement).toHaveAttribute('aria-label');
+    expect(getTabsNav()).toHaveAttribute('aria-label', TABS_NAV_LABEL);
   });
 });
 
@@ -118,7 +117,8 @@ describe('Debug 页签的 DEV 门槛', () => {
 
     render(<DataGovernanceDashboard embedded />);
 
-    expect(screen.getByRole('button', { name: DEBUG_TAB_NAME })).toBeInTheDocument();
+    expect(within(getTabsNav()).getByRole('button', { name: DEBUG_TAB_NAME }))
+      .toBeInTheDocument();
   });
 
   it('非 DEV（生产构建）不渲染 Debug 页签', () => {
@@ -126,9 +126,10 @@ describe('Debug 页签的 DEV 门槛', () => {
 
     render(<DataGovernanceDashboard embedded />);
 
+    const nav = getTabsNav();
     // 其他页签照常在，只有 Debug 消失
-    expect(screen.getByRole('button', { name: TAB_NAMES[0] })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: DEBUG_TAB_NAME })).not.toBeInTheDocument();
+    expect(within(nav).getByRole('button', { name: '概览' })).toBeInTheDocument();
+    expect(within(nav).queryByRole('button', { name: DEBUG_TAB_NAME })).not.toBeInTheDocument();
   });
 
   it('非 DEV 时外部深链也切不到 debug 页签', async () => {
@@ -137,9 +138,10 @@ describe('Debug 页签的 DEV 门槛', () => {
     render(<DataGovernanceDashboard embedded tabTarget={{ tab: 'debug', requestId: 1 }} />);
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: TAB_NAMES[0] })).toBeInTheDocument();
+      expect(within(getTabsNav()).getByRole('button', { name: '概览' })).toBeInTheDocument();
     });
-    expect(screen.queryByRole('button', { name: DEBUG_TAB_NAME })).not.toBeInTheDocument();
+    expect(within(getTabsNav()).queryByRole('button', { name: DEBUG_TAB_NAME }))
+      .not.toBeInTheDocument();
     expect(screen.queryByTestId('slot-c-empty-db-test-button')).not.toBeInTheDocument();
   });
 });

--- a/tests/vitest/data-governance/DataGovernanceDashboard.debug-tab-visibility.test.tsx
+++ b/tests/vitest/data-governance/DataGovernanceDashboard.debug-tab-visibility.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Debug 页签只在开发构建暴露 + 图标页签的读屏可访问名。
+ *
+ * 生产构建里 Debug 页签的控件全部 `disabled`，页签本身却照常渲染；
+ * 移动端（<640px）页签文字被 `hidden sm:inline` 收掉，只剩一个虫子图标，
+ * 读屏读出来就是一个无名按钮。这里同时锁住这两条契约。
+ */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const mockDataGovernanceApi = vi.hoisted(() => ({
+  getMigrationStatus: vi.fn(),
+  runHealthCheck: vi.fn(),
+  getBackupList: vi.fn(),
+  listResumableJobs: vi.fn(),
+  getSyncStatus: vi.fn(),
+  getAuditLogs: vi.fn(),
+}));
+
+vi.mock('@/api/dataGovernance', () => ({
+  DataGovernanceApi: mockDataGovernanceApi,
+  BACKUP_JOB_PROGRESS_EVENT: 'backup-job-progress',
+  isBackupJobTerminal: (status: string) =>
+    status === 'completed' || status === 'failed' || status === 'cancelled',
+}));
+
+vi.mock('@/hooks/useBackupJobListener', () => ({
+  useBackupJobListener: () => ({
+    startListening: vi.fn(),
+    stopListening: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/settings/components/MediaCacheSection', () => ({
+  MediaCacheSection: () => <div data-testid="media-cache-section">cache-section</div>,
+}));
+
+vi.mock('@/utils/tauriApi', () => ({
+  TauriAPI: { restartApp: vi.fn() },
+}));
+
+import { DataGovernanceDashboard } from '@/features/settings';
+
+const TAB_NAMES = [
+  /概览|data:governance\.tab_overview/i,
+  /恢复|data:governance\.tab_recovery/i,
+  /归档|data:governance\.tab_archive/i,
+  /备份|data:governance\.tab_backup/i,
+  /同步|data:governance\.tab_sync/i,
+  /审计|data:governance\.tab_audit/i,
+  /缓存|data:governance\.tab_cache/i,
+];
+
+const DEBUG_TAB_NAME = /^调试$|data:governance\.debug_tab_title/i;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDataGovernanceApi.getMigrationStatus.mockResolvedValue({
+    global_version: 10,
+    all_healthy: true,
+    databases: [],
+    pending_migrations_total: 0,
+    has_pending_migrations: false,
+    last_error: null,
+  });
+  mockDataGovernanceApi.runHealthCheck.mockResolvedValue({
+    overall_healthy: true,
+    total_databases: 3,
+    initialized_count: 3,
+    uninitialized_count: 0,
+    dependency_check_passed: true,
+    dependency_error: null,
+    databases: [],
+    checked_at: '2026-02-07T00:00:00Z',
+    pending_migrations_count: 0,
+    has_pending_migrations: false,
+    audit_log_healthy: true,
+    audit_log_error: null,
+    audit_log_error_at: null,
+  });
+  mockDataGovernanceApi.getSyncStatus.mockResolvedValue(null);
+  mockDataGovernanceApi.getAuditLogs.mockResolvedValue({ logs: [], total: 0 });
+  mockDataGovernanceApi.getBackupList.mockResolvedValue([]);
+  mockDataGovernanceApi.listResumableJobs.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('数据治理页签可访问名', () => {
+  it('每个页签都有可访问名（文字在窄屏被隐藏时靠 aria-label 兜底）', () => {
+    render(<DataGovernanceDashboard embedded />);
+
+    for (const name of TAB_NAMES) {
+      expect(screen.getByRole('button', { name })).toBeInTheDocument();
+    }
+
+    // 可访问名必须来自 aria-label，而不是只存在于 `hidden sm:inline` 的文字里
+    for (const name of TAB_NAMES) {
+      expect(screen.getByRole('button', { name })).toHaveAttribute('aria-label');
+    }
+  });
+
+  it('页签容器带导航可访问名', () => {
+    render(<DataGovernanceDashboard embedded />);
+
+    const overviewTab = screen.getByRole('button', { name: TAB_NAMES[0] });
+    expect(overviewTab.parentElement).toHaveAttribute('aria-label');
+  });
+});
+
+describe('Debug 页签的 DEV 门槛', () => {
+  it('开发构建下渲染 Debug 页签', () => {
+    vi.stubEnv('DEV', true);
+
+    render(<DataGovernanceDashboard embedded />);
+
+    expect(screen.getByRole('button', { name: DEBUG_TAB_NAME })).toBeInTheDocument();
+  });
+
+  it('非 DEV（生产构建）不渲染 Debug 页签', () => {
+    vi.stubEnv('DEV', false);
+
+    render(<DataGovernanceDashboard embedded />);
+
+    // 其他页签照常在，只有 Debug 消失
+    expect(screen.getByRole('button', { name: TAB_NAMES[0] })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: DEBUG_TAB_NAME })).not.toBeInTheDocument();
+  });
+
+  it('非 DEV 时外部深链也切不到 debug 页签', async () => {
+    vi.stubEnv('DEV', false);
+
+    render(<DataGovernanceDashboard embedded tabTarget={{ tab: 'debug', requestId: 1 }} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: TAB_NAMES[0] })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: DEBUG_TAB_NAME })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slot-c-empty-db-test-button')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

命令面板对 Tab 一律 preventDefault，收藏/关闭键盘到不了，搜索框也不是 combobox。数据治理移动端页签只有图标、读屏匿名；Debug 页签生产可见。

续推还修了 `DataGovernanceDashboard` 的自激渲染循环：`loadResumableJobs` 把不稳定的 `t` 放进 `useCallback` 依赖，effect 每渲染重跑并 `setState`，数据治理测试会把 Vitest 分片打到 OOM。只用于报错文案的 `t` 改为 `tRef`，移出依赖。

### Changes
- 命令面板：`role="combobox"` + `aria-activedescendant`，Tab 进入面板内控件
- 数据治理页签补 `aria-label`（窄屏图标按钮可读）
- Debug 页签仅 `import.meta.env.DEV` 渲染
- 断开 `t` 身份驱动的自激渲染；页签测试查询限定在页签容器内

### How to test
- 打开命令面板：Tab 能到关闭/收藏；读屏听到 combobox
- 窄屏打开数据治理：每个页签有名字
- 生产构建看不到 Debug 页签
- `tests/vitest/command-palette` 与 `DataGovernanceDashboard.debug-tab-visibility.test.tsx` 应通过
- 数据治理目录不再永久挂起（main 上对照仍有 38 个与本切片无关的旧失败，本 PR 未动）

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

### 重叠说明
与 #164 的命令面板/数据治理部分重叠。本分支更专注 a11y，不含 token/Finder。审查时不要两份一起无差别合并。基线 Vitest OOM / Cloud Provider / Rust archive 是主干继承的，本切片不声称修绿它们。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92ea5725-a196-4c8d-97b6-cf85cfe2ecb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92ea5725-a196-4c8d-97b6-cf85cfe2ecb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

