### PR TITLE
feat(notes): 笔记编辑器接入「生成卡片」

### DIFF
--- a/src/features/anki/__tests__/generateCardsFromText.test.ts
+++ b/src/features/anki/__tests__/generateCardsFromText.test.ts
@@ -1,0 +1,136 @@
+/**
+ * 共享制卡入口：太短直接拒（不发任务）、失败 toast 报错、成功 toast 带「查看任务」跳转 action。
+ * 笔记 / 错题本 / 作文批改都挂在这条链路上，行为回归会同时影响三处表面。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGenerateCards, mockWaitForReady, mockShowGlobalNotification, mockDispatchAppEvent } =
+  vi.hoisted(() => ({
+    mockGenerateCards: vi.fn(),
+    mockWaitForReady: vi.fn(),
+    mockShowGlobalNotification: vi.fn(),
+    mockDispatchAppEvent: vi.fn(),
+  }));
+
+vi.mock('@/components/anki/cardforge', () => ({
+  ChatV2AnkiAdapter: { generateCards: mockGenerateCards },
+  cardAgent: { waitForReady: mockWaitForReady },
+}));
+
+vi.mock('@/components/UnifiedNotification', () => ({
+  showGlobalNotification: mockShowGlobalNotification,
+}));
+
+vi.mock('@/events', () => ({
+  APP_EVENTS: { MOBILE_APP_NAVIGATE: 'deepstudent:mobile-sidebar-navigate' },
+  dispatchAppEvent: mockDispatchAppEvent,
+}));
+
+import {
+  MIN_CONTENT_LENGTH_FOR_CARDS,
+  generateCardsFromText,
+  type GenerateCardsFromTextInput,
+} from '../generateCardsFromText';
+
+const messages: GenerateCardsFromTextInput['messages'] = {
+  tooShort: '内容太短',
+  started: '已开始生成卡片',
+  failed: '生成卡片失败',
+  openTaskDashboard: '查看任务',
+};
+
+function input(overrides: Partial<GenerateCardsFromTextInput> = {}): GenerateCardsFromTextInput {
+  return {
+    content: '这是一段足够长的学习材料内容，用来生成记忆卡片。',
+    deckName: '生物 · 第三章',
+    messages,
+    ...overrides,
+  };
+}
+
+describe('generateCardsFromText', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWaitForReady.mockResolvedValue(true);
+    mockGenerateCards.mockResolvedValue({ ok: true, documentId: 'doc-1' });
+  });
+
+  it('内容短于阈值时只 toast 警告，不发制卡任务', async () => {
+    const short = 'x'.repeat(MIN_CONTENT_LENGTH_FOR_CARDS - 1);
+
+    const result = await generateCardsFromText(input({ content: short }));
+
+    expect(result).toEqual({ ok: false, reason: 'too_short' });
+    expect(mockGenerateCards).not.toHaveBeenCalled();
+    expect(mockWaitForReady).not.toHaveBeenCalled();
+    expect(mockShowGlobalNotification).toHaveBeenCalledWith('warning', '内容太短');
+  });
+
+  it('长度按 trim 后计算，只有空白的内容同样拒绝', async () => {
+    const result = await generateCardsFromText(input({ content: '   \n\t  ' }));
+
+    expect(result).toEqual({ ok: false, reason: 'too_short' });
+    expect(mockGenerateCards).not.toHaveBeenCalled();
+  });
+
+  it('成功时 toast 带「查看任务」action，点击跳转任务面板', async () => {
+    const result = await generateCardsFromText(
+      input({ requirements: '保留原文术语', maxCards: 8 }),
+    );
+
+    expect(mockWaitForReady).toHaveBeenCalledTimes(1);
+    expect(mockGenerateCards).toHaveBeenCalledTimes(1);
+    const [content, options] = mockGenerateCards.mock.calls[0];
+    expect(content).toBe('这是一段足够长的学习材料内容，用来生成记忆卡片。');
+    expect(options).toMatchObject({
+      deckName: '生物 · 第三章',
+      maxCards: 8,
+      customRequirements: '保留原文术语',
+    });
+    expect(result).toEqual({ ok: true, documentId: 'doc-1' });
+
+    expect(mockShowGlobalNotification).toHaveBeenCalledWith(
+      'success',
+      '已开始生成卡片',
+      undefined,
+      expect.objectContaining({
+        action: expect.objectContaining({ label: '查看任务' }),
+      }),
+    );
+
+    const options4 = mockShowGlobalNotification.mock.calls[0][3] as {
+      action: { onClick: () => void };
+    };
+    options4.action.onClick();
+    expect(mockDispatchAppEvent).toHaveBeenCalledWith('deepstudent:mobile-sidebar-navigate', {
+      view: 'task-dashboard',
+    });
+  });
+
+  it('适配器返回 ok:false 时回报 generate_failed 并 toast 原始错误', async () => {
+    mockGenerateCards.mockResolvedValue({ ok: false, error: 'boom' });
+
+    const result = await generateCardsFromText(input());
+
+    expect(result).toEqual({ ok: false, reason: 'generate_failed', error: 'boom' });
+    expect(mockShowGlobalNotification).toHaveBeenCalledWith('error', 'boom');
+  });
+
+  it('适配器失败但没带错误文案时回退到调用方的 failed 文案', async () => {
+    mockGenerateCards.mockResolvedValue({ ok: false });
+
+    const result = await generateCardsFromText(input());
+
+    expect(result).toEqual({ ok: false, reason: 'generate_failed', error: '生成卡片失败' });
+    expect(mockShowGlobalNotification).toHaveBeenCalledWith('error', '生成卡片失败');
+  });
+
+  it('链路抛错时不外泄异常，转成 generate_failed 结果', async () => {
+    mockGenerateCards.mockRejectedValue(new Error('network down'));
+
+    const result = await generateCardsFromText(input());
+
+    expect(result).toEqual({ ok: false, reason: 'generate_failed', error: 'network down' });
+    expect(mockShowGlobalNotification).toHaveBeenCalledWith('error', 'network down');
+  });
+});

--- a/src/features/anki/generateCardsFromText.ts
+++ b/src/features/anki/generateCardsFromText.ts
@@ -1,0 +1,74 @@
+/**
+ * 从任意学习材料启动制卡任务的共享入口。
+ *
+ * 复用聊天划词制卡的同一条链路（CardForge → ChatV2AnkiAdapter.generateCards），
+ * 只是把文案交给调用方，让错题本 / 作文批改这类非聊天表面也能复用，
+ * 而不必依赖 chatV2 命名空间的 selectionToolbar.* 文案。
+ */
+import { ChatV2AnkiAdapter, cardAgent } from '@/components/anki/cardforge';
+import { showGlobalNotification } from '@/components/UnifiedNotification';
+import { APP_EVENTS, dispatchAppEvent } from '@/events';
+import { getErrorMessage } from '@/utils/errorUtils';
+
+/** 内容短于该长度时制卡质量不可控，直接拒绝而不是发一个必然失败的任务 */
+export const MIN_CONTENT_LENGTH_FOR_CARDS = 10;
+
+export interface GenerateCardsFromTextInput {
+  content: string;
+  deckName: string;
+  /** 传给模型的额外要求（题型偏好、覆盖重点等） */
+  requirements?: string;
+  maxCards?: number;
+  messages: {
+    tooShort: string;
+    started: string;
+    failed: string;
+    openTaskDashboard: string;
+  };
+}
+
+export type GenerateCardsFromTextResult =
+  | { ok: true; documentId?: string }
+  | { ok: false; reason: 'too_short' | 'generate_failed'; error?: string };
+
+function navigateToTaskDashboard(): void {
+  dispatchAppEvent(APP_EVENTS.MOBILE_APP_NAVIGATE, { view: 'task-dashboard' });
+}
+
+export async function generateCardsFromText(
+  input: GenerateCardsFromTextInput,
+): Promise<GenerateCardsFromTextResult> {
+  const content = input.content.trim();
+  if (content.length < MIN_CONTENT_LENGTH_FOR_CARDS) {
+    showGlobalNotification('warning', input.messages.tooShort);
+    return { ok: false, reason: 'too_short' };
+  }
+
+  try {
+    await cardAgent.waitForReady();
+    const result = await ChatV2AnkiAdapter.generateCards(content, {
+      deckName: input.deckName,
+      maxCards: input.maxCards,
+      customRequirements: input.requirements,
+    });
+
+    if (!result.ok) {
+      const error = result.error || input.messages.failed;
+      showGlobalNotification('error', error);
+      return { ok: false, reason: 'generate_failed', error };
+    }
+
+    showGlobalNotification('success', input.messages.started, undefined, {
+      action: {
+        label: input.messages.openTaskDashboard,
+        onClick: navigateToTaskDashboard,
+      },
+      borderTone: 'neutral',
+    });
+    return { ok: true, documentId: result.documentId };
+  } catch (error: unknown) {
+    const message = getErrorMessage(error) || input.messages.failed;
+    showGlobalNotification('error', message);
+    return { ok: false, reason: 'generate_failed', error: message };
+  }
+}

--- a/src/features/notes/NotesCrepeEditor.tsx
+++ b/src/features/notes/NotesCrepeEditor.tsx
@@ -446,6 +446,8 @@ export const NotesCrepeEditor: React.FC<NotesCrepeEditorProps> = ({
   const mobileCommands = buildMobileEditorCommands(editorApi, {
     // P0-4：图片上传归档到当前笔记资产目录
     noteId: isDstuMode ? dstuNoteId : contextActive?.id,
+    // 底栏「生成卡片」入口：牌组名取当前笔记标题
+    noteTitle: isDstuMode ? initialTitle : contextActive?.title,
     // 底栏「查找」入口：打开编辑器内联查找替换条
     openFind: () => setIsFindReplaceOpen(true),
   });

--- a/src/features/notes/NotesCrepeEditor.tsx
+++ b/src/features/notes/NotesCrepeEditor.tsx
@@ -446,7 +446,8 @@ export const NotesCrepeEditor: React.FC<NotesCrepeEditorProps> = ({
   const mobileCommands = buildMobileEditorCommands(editorApi, {
     // P0-4：图片上传归档到当前笔记资产目录
     noteId: isDstuMode ? dstuNoteId : contextActive?.id,
-    // 底栏「生成卡片」入口：牌组名取当前笔记标题
+    // 底栏「生成卡片」入口：笔记宿主开启，牌组名取当前笔记标题
+    enableGenerateCards: true,
     noteTitle: isDstuMode ? initialTitle : contextActive?.title,
     // 底栏「查找」入口：打开编辑器内联查找替换条
     openFind: () => setIsFindReplaceOpen(true),

--- a/src/features/notes/__tests__/generateCardsFromNote.test.ts
+++ b/src/features/notes/__tests__/generateCardsFromNote.test.ts
@@ -1,0 +1,84 @@
+/**
+ * 笔记「生成卡片」接线层：正文取全文、牌组名取笔记标题，
+ * 制卡本身必须落到共享入口 generateCardsFromText（不另起链路）。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CrepeEditorApi } from '@/components/crepe/types';
+import { generateCardsFromText } from '@/features/anki/generateCardsFromText';
+import { generateCardsFromNote, readNoteMarkdown } from '../generateCardsFromNote';
+import { buildMobileEditorCommands } from '../mobileEditorCommands';
+
+vi.mock('@/features/anki/generateCardsFromText', () => ({
+  MIN_CONTENT_LENGTH_FOR_CARDS: 10,
+  generateCardsFromText: vi.fn(async () => ({ ok: true as const })),
+}));
+
+function makeEditor(overrides: Partial<CrepeEditorApi> = {}): CrepeEditorApi {
+  return {
+    getMarkdown: vi.fn(() => '# 细胞呼吸\n线粒体是有氧呼吸的主要场所。'),
+    getCrepe: vi.fn(() => null),
+    focus: vi.fn(),
+    ...overrides,
+  } as unknown as CrepeEditorApi;
+}
+
+describe('generateCardsFromNote', () => {
+  beforeEach(() => {
+    vi.mocked(generateCardsFromText).mockClear();
+  });
+
+  it('把笔记正文与标题交给共享制卡入口', async () => {
+    const editor = makeEditor();
+
+    await generateCardsFromNote({
+      editor,
+      noteTitle: '生物 · 第三章',
+      translate: (_key, defaultValue) => defaultValue,
+    });
+
+    expect(generateCardsFromText).toHaveBeenCalledTimes(1);
+    const payload = vi.mocked(generateCardsFromText).mock.calls[0][0];
+    expect(payload.content).toBe('# 细胞呼吸\n线粒体是有氧呼吸的主要场所。');
+    expect(payload.deckName).toBe('生物 · 第三章');
+    expect(payload.messages.tooShort).toBeTruthy();
+    expect(payload.messages.openTaskDashboard).toBeTruthy();
+  });
+
+  it('无标题时回退到通用牌组名', async () => {
+    await generateCardsFromNote({
+      editor: makeEditor(),
+      noteTitle: '   ',
+      translate: (_key, defaultValue) => defaultValue,
+    });
+
+    expect(vi.mocked(generateCardsFromText).mock.calls[0][0].deckName).toBe('笔记制卡');
+  });
+
+  it('readNoteMarkdown 优先取完整文档，并对未就绪编辑器返回空串', () => {
+    const windowed = makeEditor({
+      getMarkdown: vi.fn(() => '可见前缀'),
+      getFullMarkdown: vi.fn(() => '可见前缀 + 窗口外正文'),
+    });
+    expect(readNoteMarkdown(windowed)).toBe('可见前缀 + 窗口外正文');
+    expect(readNoteMarkdown(null)).toBe('');
+    expect(
+      readNoteMarkdown(makeEditor({
+        getMarkdown: vi.fn(() => {
+          throw new Error('editor destroyed');
+        }),
+      })),
+    ).toBe('');
+  });
+
+  it('移动端命令桥的 generateCards 走同一个共享入口', async () => {
+    const commands = buildMobileEditorCommands(makeEditor(), { noteTitle: '化学笔记' });
+
+    expect(commands.generateCards).toBeTypeOf('function');
+    commands.generateCards?.();
+    await vi.waitFor(() => {
+      expect(generateCardsFromText).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(generateCardsFromText).mock.calls[0][0].deckName).toBe('化学笔记');
+  });
+});

--- a/src/features/notes/__tests__/generateCardsFromNote.test.ts
+++ b/src/features/notes/__tests__/generateCardsFromNote.test.ts
@@ -72,7 +72,10 @@ describe('generateCardsFromNote', () => {
   });
 
   it('移动端命令桥的 generateCards 走同一个共享入口', async () => {
-    const commands = buildMobileEditorCommands(makeEditor(), { noteTitle: '化学笔记' });
+    const commands = buildMobileEditorCommands(makeEditor(), {
+      enableGenerateCards: true,
+      noteTitle: '化学笔记',
+    });
 
     expect(commands.generateCards).toBeTypeOf('function');
     commands.generateCards?.();
@@ -80,5 +83,60 @@ describe('generateCardsFromNote', () => {
       expect(generateCardsFromText).toHaveBeenCalledTimes(1);
     });
     expect(vi.mocked(generateCardsFromText).mock.calls[0][0].deckName).toBe('化学笔记');
+  });
+
+  it('宿主未开启 enableGenerateCards 时不注入制卡命令（底栏不渲染按钮）', () => {
+    const commands = buildMobileEditorCommands(makeEditor(), { noteTitle: '化学笔记' });
+    expect(commands.generateCards).toBeUndefined();
+    expect(buildMobileEditorCommands(makeEditor()).generateCards).toBeUndefined();
+  });
+
+  it('制卡任务在途时忽略重复点击（触屏双击只发一个任务）', async () => {
+    let resolveTask: (value: { ok: true }) => void = () => {};
+    vi.mocked(generateCardsFromText).mockImplementationOnce(
+      () => new Promise((resolve) => { resolveTask = resolve; }),
+    );
+
+    const commands = buildMobileEditorCommands(makeEditor(), { enableGenerateCards: true });
+    commands.generateCards?.();
+    commands.generateCards?.();
+
+    await vi.waitFor(() => {
+      expect(generateCardsFromText).toHaveBeenCalledTimes(1);
+    });
+
+    resolveTask({ ok: true });
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+
+    // 任务结束后守卫解除，可以再次制卡
+    commands.generateCards?.();
+    expect(generateCardsFromText).toHaveBeenCalledTimes(2);
+  });
+
+  it('in-flight 守卫按编辑器实例隔离，另一篇笔记不受影响', async () => {
+    vi.mocked(generateCardsFromText).mockImplementationOnce(() => new Promise(() => {}));
+
+    const first = buildMobileEditorCommands(makeEditor(), { enableGenerateCards: true });
+    const second = buildMobileEditorCommands(makeEditor(), { enableGenerateCards: true });
+    first.generateCards?.();
+    first.generateCards?.();
+    second.generateCards?.();
+
+    await vi.waitFor(() => {
+      expect(generateCardsFromText).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('宿主重渲染重建命令对象后守卫仍然生效', async () => {
+    vi.mocked(generateCardsFromText).mockImplementationOnce(() => new Promise(() => {}));
+
+    const editor = makeEditor();
+    buildMobileEditorCommands(editor, { enableGenerateCards: true }).generateCards?.();
+    await vi.waitFor(() => {
+      expect(generateCardsFromText).toHaveBeenCalledTimes(1);
+    });
+
+    buildMobileEditorCommands(editor, { enableGenerateCards: true }).generateCards?.();
+    expect(generateCardsFromText).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/notes/components/MobileEditorToolbar.tsx
+++ b/src/features/notes/components/MobileEditorToolbar.tsx
@@ -35,6 +35,7 @@ import {
   DotsThreeOutline,
   MagnifyingGlass,
   SquaresFour,
+  Cards,
   ArrowCounterClockwise,
   ArrowClockwise,
 } from '@phosphor-icons/react';
@@ -73,6 +74,11 @@ export type MobileEditorToolbarCommands = {
    * 触屏无 hover 块句柄，此入口为块操作的移动端替代；未注入时按钮不渲染。
    */
   openBlockActions?: () => void;
+  /**
+   * 可选：把当前笔记正文送进共享制卡入口（generateCardsFromText）。
+   * 未注入时按钮不渲染，保持旧宿主的工具条形态不变。
+   */
+  generateCards?: () => void;
 };
 
 /** 可选激活态；宿主可按选区 marks/节点透传，未传则不亮 */
@@ -305,8 +311,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
         },
       ],
     },
-    // 工具入口：块操作（触屏替代 hover 块句柄）/ 查找，均按宿主是否接线渲染
-    ...(commands.openFind || commands.openBlockActions
+    // 工具入口：块操作（触屏替代 hover 块句柄）/ 查找 / 生成卡片，均按宿主是否接线渲染
+    ...(commands.openFind || commands.openBlockActions || commands.generateCards
       ? [{
           id: 'tools',
           items: [
@@ -326,6 +332,15 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
                   defaultLabel: '查找',
                   icon: <MagnifyingGlass size={ICON_SIZE} weight={ICON_WEIGHT} aria-hidden />,
                   onAction: () => commands.openFind?.(),
+                }]
+              : []),
+            ...(commands.generateCards
+              ? [{
+                  id: 'generateCards',
+                  labelKey: 'notes:mobileToolbar.generateCards',
+                  defaultLabel: '生成卡片',
+                  icon: <Cards size={ICON_SIZE} weight={ICON_WEIGHT} aria-hidden />,
+                  onAction: () => commands.generateCards?.(),
                 }]
               : []),
           ],

--- a/src/features/notes/components/NotesEditorToolbar.tsx
+++ b/src/features/notes/components/NotesEditorToolbar.tsx
@@ -33,8 +33,10 @@ import {
   ChatCenteredText,
   CaretCircleDown,
   BracketsSquare,
+  Cards,
 } from '@phosphor-icons/react';
 import { useNotesOptional } from '../NotesContext';
+import { generateCardsFromNote } from '../generateCardsFromNote';
 import { CommonTooltip } from '@/components/shared/CommonTooltip';
 import { isMacOS } from '@/utils/platform';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/shad/Popover';
@@ -112,6 +114,7 @@ export const NotesEditorToolbar: React.FC<NotesEditorToolbarProps> = ({
   const isDisabled = !editor || readOnly;
   const mac = isMacOS();
   const [overflowOpen, setOverflowOpen] = useState(false);
+  const [generatingCards, setGeneratingCards] = useState(false);
 
   // 内联区横向滚动：仅在真实溢出时展示渐隐 mask 提示
   const inlineRef = useRef<HTMLDivElement | null>(null);
@@ -219,6 +222,22 @@ export const NotesEditorToolbar: React.FC<NotesEditorToolbarProps> = ({
     runWithCtx(insertEmptyToggle);
   }, [runWithCtx]);
 
+  /**
+   * 生成卡片：把当前笔记全文送进共享制卡入口（与错题本 / 作文批改同一条 CardForge 通道）。
+   * 只读笔记同样可以制卡，因此不受 readOnly 影响，仅在编辑器缺失或任务提交中禁用。
+   */
+  const handleGenerateCards = useCallback(() => {
+    if (!editor || generatingCards) return;
+    setGeneratingCards(true);
+    void generateCardsFromNote({
+      editor,
+      noteTitle: notesContext?.active?.title,
+      translate: tr,
+    }).finally(() => {
+      setGeneratingCards(false);
+    });
+  }, [editor, generatingCards, notesContext?.active?.title, tr]);
+
   /** 插入 `[[` 触发 wikilink 自动补全浮层（与手动输入同一路径） */
   const handleWikilink = useCallback(() => {
     if (!editor) return;
@@ -262,6 +281,7 @@ export const NotesEditorToolbar: React.FC<NotesEditorToolbarProps> = ({
   const actionByLabel = new Map(formatActions.map((item) => [item.label, item]));
 
   const toolbarLabel = tr('notes:toolbar.label', '格式化');
+  const generateCardsLabel = tr('notes:toolbar.generateCards', '生成卡片');
 
   /** role="menu" 方向键 roving tabindex */
   const handleMenuKeyDown = useCallback((event: React.KeyboardEvent) => {
@@ -331,6 +351,22 @@ export const NotesEditorToolbar: React.FC<NotesEditorToolbarProps> = ({
         ))}
         <span className="notes-editor-toolbar-divider" aria-hidden="true" />
       </div>
+      {/* 生成卡片：常驻主操作，内联区在窄屏收起后仍可点到；触屏保证 44px 命中区 */}
+      <CommonTooltip content={generateCardsLabel}>
+        <DsButton
+          variant="ghost"
+          size="icon"
+          iconOnly
+          disabled={!editor || generatingCards}
+          aria-label={generateCardsLabel}
+          aria-busy={generatingCards || undefined}
+          className="notes-editor-generate-cards flex-none ui-press hover:!bg-[var(--interactive-hover)] active:!bg-[var(--interactive-selected)] [@media(pointer:coarse)]:min-h-11 [@media(pointer:coarse)]:min-w-11"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={handleGenerateCards}
+        >
+          <Cards className="h-4 w-4" />
+        </DsButton>
+      </CommonTooltip>
       <Popover open={overflowOpen} onOpenChange={setOverflowOpen}>
         <CommonTooltip content={toolbarLabel}>
           <PopoverTrigger asChild>

--- a/src/features/notes/components/__tests__/MobileEditorToolbar.test.tsx
+++ b/src/features/notes/components/__tests__/MobileEditorToolbar.test.tsx
@@ -1,6 +1,9 @@
 /**
  * MobileEditorToolbar — 按钮回调触发 + visible 受控 + visualViewport bottom
  */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -239,6 +242,27 @@ describe('MobileEditorToolbar', () => {
     const btn = document.querySelector('.mobile-editor-toolbar__btn');
     expect(btn).toBeTruthy();
     expect(btn?.className).toContain('mobile-editor-toolbar__btn');
+  });
+
+  it('生成卡片按钮同样落在 44px 命中区规则里', () => {
+    const commands: MobileEditorToolbarCommands = {
+      ...mockCommands(),
+      generateCards: vi.fn(),
+    };
+    render(<MobileEditorToolbar commands={commands} visible />);
+
+    // jsdom 不加载 CSS：按钮侧锁 class，尺寸侧锁 class 对应的样式声明
+    expect(byAction('generateCards').className).toContain('mobile-editor-toolbar__btn');
+
+    const css = readFileSync(
+      resolve(process.cwd(), 'src/features/notes/components/MobileEditorToolbar.css'),
+      'utf-8',
+    );
+    const rule = css
+      .split('.mobile-editor-toolbar__btn {')[1]
+      ?.split('}')[0] ?? '';
+    expect(rule).toMatch(/min-width:\s*44px/);
+    expect(rule).toMatch(/min-height:\s*44px/);
   });
 
   it('mousedown 默认 preventDefault，避免抢走编辑器焦点', () => {

--- a/src/features/notes/components/__tests__/MobileEditorToolbar.test.tsx
+++ b/src/features/notes/components/__tests__/MobileEditorToolbar.test.tsx
@@ -171,6 +171,7 @@ describe('MobileEditorToolbar', () => {
     expect(byAction('table')).toBeNull();
     expect(byAction('codeblock')).toBeNull();
     expect(byAction('find')).toBeNull();
+    expect(byAction('generateCards')).toBeNull();
   });
 
   it('openFind 注入后展示查找入口并触发回调', () => {
@@ -185,6 +186,20 @@ describe('MobileEditorToolbar', () => {
     expect(find.getAttribute('aria-label')).toBe('查找');
     fireEvent.click(find);
     expect(commands.openFind).toHaveBeenCalledTimes(1);
+  });
+
+  it('generateCards 注入后展示制卡入口并触发回调', () => {
+    const commands: MobileEditorToolbarCommands = {
+      ...mockCommands(),
+      generateCards: vi.fn(),
+    };
+    render(<MobileEditorToolbar commands={commands} visible />);
+
+    const generate = byAction('generateCards');
+    expect(generate).toBeTruthy();
+    expect(generate.getAttribute('aria-label')).toBe('生成卡片');
+    fireEvent.click(generate);
+    expect(commands.generateCards).toHaveBeenCalledTimes(1);
   });
 
   it('toggleStrikethrough 未注入时点击删除线不抛错', () => {

--- a/src/features/notes/components/__tests__/NotesEditorToolbar.test.tsx
+++ b/src/features/notes/components/__tests__/NotesEditorToolbar.test.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CrepeEditorApi } from '@/components/crepe/types';
+import { generateCardsFromText } from '@/features/anki/generateCardsFromText';
 import { NotesEditorToolbar } from '../NotesEditorToolbar';
+
+vi.mock('@/features/anki/generateCardsFromText', () => ({
+  MIN_CONTENT_LENGTH_FOR_CARDS: 10,
+  generateCardsFromText: vi.fn(async () => ({ ok: true as const })),
+}));
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: vi.fn() },
@@ -36,11 +42,16 @@ function makeEditor(overrides: Partial<CrepeEditorApi> = {}): CrepeEditorApi {
     insertAtCursor: vi.fn(),
     focus: vi.fn(),
     getCrepe: vi.fn(() => null),
+    getMarkdown: vi.fn(() => '# 光合作用\n叶绿体把光能转成化学能。'),
     ...overrides,
   } as unknown as CrepeEditorApi;
 }
 
 describe('NotesEditorToolbar', () => {
+  beforeEach(() => {
+    vi.mocked(generateCardsFromText).mockClear();
+  });
+
   it('keeps every formatting command keyboard reachable in one quiet menu', () => {
     const editor = makeEditor();
 
@@ -124,5 +135,43 @@ describe('NotesEditorToolbar', () => {
 
     fireEvent.keyDown(menu, { key: 'Home' });
     expect(items[0]).toHaveAttribute('tabindex', '0');
+  });
+
+  it('exposes a generate-cards action that feeds the note body to the shared card pipeline', async () => {
+    const editor = makeEditor();
+    render(<NotesEditorToolbar editor={editor} />);
+
+    const trigger = screen.getByRole('button', { name: 'generateCards' });
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(generateCardsFromText).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(generateCardsFromText).mock.calls[0][0]).toMatchObject({
+      content: '# 光合作用\n叶绿体把光能转成化学能。',
+    });
+  });
+
+  it('prefers the full document over the loaded window when generating cards', async () => {
+    const editor = makeEditor({
+      getMarkdown: vi.fn(() => 'visible prefix only'),
+      getFullMarkdown: vi.fn(() => 'visible prefix only\nplus the windowed tail'),
+    });
+    render(<NotesEditorToolbar editor={editor} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'generateCards' }));
+
+    await waitFor(() => {
+      expect(generateCardsFromText).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(generateCardsFromText).mock.calls[0][0].content).toBe(
+      'visible prefix only\nplus the windowed tail',
+    );
+  });
+
+  it('keeps the generate-cards action disabled without an editor', () => {
+    render(<NotesEditorToolbar editor={null} />);
+
+    expect(screen.getByRole('button', { name: 'generateCards' })).toBeDisabled();
   });
 });

--- a/src/features/notes/generateCardsFromNote.ts
+++ b/src/features/notes/generateCardsFromNote.ts
@@ -1,0 +1,67 @@
+/**
+ * 笔记正文 → 制卡任务的接线层。
+ *
+ * 只负责「取正文 / 取牌组名 / 取文案」，制卡链路本身复用
+ * src/features/anki/generateCardsFromText.ts（与错题本、作文批改同一条 CardForge 通道），
+ * 桌面工具栏与移动端底栏共用这里，避免两端各写一遍。
+ */
+
+import i18next from 'i18next';
+
+import type { CrepeEditorApi } from '@/components/crepe/types';
+import {
+  generateCardsFromText,
+  type GenerateCardsFromTextResult,
+} from '@/features/anki/generateCardsFromText';
+
+/** 与 NotesEditorToolbar 的 tr 同形：key + 兜底文案 */
+export type NoteCardsTranslate = (key: string, defaultValue: string) => string;
+
+export interface GenerateCardsFromNoteInput {
+  editor?: CrepeEditorApi | null;
+  /** 当前笔记标题；用作牌组名，缺省时回退到通用牌组 */
+  noteTitle?: string | null;
+  translate?: NoteCardsTranslate;
+}
+
+/** 未初始化的 i18next 会返回 undefined，这里统一回退到调用方兜底文案 */
+function defaultTranslate(key: string, defaultValue: string): string {
+  try {
+    const value = i18next.t(key, { defaultValue });
+    return typeof value === 'string' && value.length > 0 ? value : defaultValue;
+  } catch {
+    return defaultValue;
+  }
+}
+
+/** 窗口化加载的长笔记里 getMarkdown() 只是可见前缀，制卡要拿全文 */
+export function readNoteMarkdown(editor?: CrepeEditorApi | null): string {
+  if (!editor) return '';
+  try {
+    return editor.getFullMarkdown?.() ?? editor.getMarkdown() ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export async function generateCardsFromNote(
+  input: GenerateCardsFromNoteInput,
+): Promise<GenerateCardsFromTextResult> {
+  const tr = input.translate ?? defaultTranslate;
+  const title = input.noteTitle?.trim();
+
+  return generateCardsFromText({
+    content: readNoteMarkdown(input.editor),
+    deckName: title && title.length > 0 ? title : tr('notes:generateCards.deckName', '笔记制卡'),
+    requirements: tr(
+      'notes:generateCards.requirements',
+      '基于这篇笔记的要点出卡，保留原文的术语与表述，跳过纯格式化内容。',
+    ),
+    messages: {
+      tooShort: tr('notes:generateCards.tooShort', '笔记内容太短，先写点内容再生成卡片'),
+      started: tr('notes:generateCards.started', '已开始根据笔记生成卡片'),
+      failed: tr('notes:generateCards.failed', '生成卡片失败'),
+      openTaskDashboard: tr('notes:generateCards.openTaskDashboard', '查看任务'),
+    },
+  });
+}

--- a/src/features/notes/mobileEditorCommands.ts
+++ b/src/features/notes/mobileEditorCommands.ts
@@ -160,15 +160,53 @@ export async function insertImageFromDevice(
 }
 
 /**
+ * 移动端制卡的 in-flight 守卫。
+ *
+ * 命令对象在宿主每次渲染时重建，闭包变量守不住双击；按编辑器实例记在模块级，
+ * 与桌面 NotesEditorToolbar 的 generatingCards state 等效（触屏双击只发一个任务）。
+ */
+const cardsInFlightEditors = new WeakSet<object>();
+/** 编辑器尚未就绪时也要防抖，此时没有可作键的实例 */
+let cardsInFlightWithoutEditor = false;
+
+function isGeneratingCards(editor: CrepeEditorApi | null | undefined): boolean {
+  return editor ? cardsInFlightEditors.has(editor) : cardsInFlightWithoutEditor;
+}
+
+function setGeneratingCards(editor: CrepeEditorApi | null | undefined, running: boolean): void {
+  if (!editor) {
+    cardsInFlightWithoutEditor = running;
+    return;
+  }
+  if (running) cardsInFlightEditors.add(editor);
+  else cardsInFlightEditors.delete(editor);
+}
+
+/** 制卡入口：任务在途时忽略重复点击，完成/失败后恢复 */
+export function generateCardsFromEditor(
+  editor: CrepeEditorApi | null | undefined,
+  noteTitle?: string,
+): void {
+  if (isGeneratingCards(editor)) return;
+  setGeneratingCards(editor, true);
+  void generateCardsFromNote({ editor, noteTitle }).finally(() => {
+    setGeneratingCards(editor, false);
+  });
+}
+
+/**
  * 宿主侧扩展（不依赖编辑器实例的命令）。
  * - openFind：打开编辑器内查找替换面板（NotesCrepeEditor 传 setIsFindReplaceOpen(true)）；
  * - noteId：图片上传归档到该笔记的资产目录（P0-4；缺省时 uploader 回退 blob URL）。
  * - noteTitle：制卡时作为牌组名；缺省时 generateCardsFromNote 回退到通用牌组。
+ * - enableGenerateCards：笔记宿主显式开启制卡入口；其他宿主（复用工具条但内容不是
+ *   笔记正文）不传，底栏就不会多出一个「生成卡片」按钮。
  */
 export interface MobileEditorCommandExtras {
   openFind?: () => void;
   noteId?: string;
   noteTitle?: string;
+  enableGenerateCards?: boolean;
 }
 
 export function buildMobileEditorCommands(
@@ -196,10 +234,13 @@ export function buildMobileEditorCommands(
     insertTable: () => editor?.insertTable(),
     // 📱 触屏无 hover 块句柄：当前块操作菜单入口（Turn into / 复制 / 删除等）
     openBlockActions: () => editor?.openBlockMenuAtSelection?.(),
-    // 生成卡片：走与桌面工具栏同一个共享制卡入口，不新起链路
-    generateCards: () => {
-      void generateCardsFromNote({ editor, noteTitle: extras?.noteTitle });
-    },
+    // 生成卡片：走与桌面工具栏同一个共享制卡入口，不新起链路；
+    // 仅笔记宿主显式开启（enableGenerateCards）后暴露，未开启时按钮不渲染
+    ...(extras?.enableGenerateCards
+      ? {
+          generateCards: () => generateCardsFromEditor(editor, extras.noteTitle),
+        }
+      : {}),
     // 查找入口：仅宿主接线后暴露，保持未接线宿主的按钮隐藏行为
     ...(extras?.openFind ? { openFind: extras.openFind } : {}),
   };

--- a/src/features/notes/mobileEditorCommands.ts
+++ b/src/features/notes/mobileEditorCommands.ts
@@ -15,6 +15,7 @@ import {
   pickImageWithTauriDialog,
 } from '@/components/crepe/features/imageUpload';
 import { showGlobalNotification } from '@/components/UnifiedNotification';
+import { generateCardsFromNote } from './generateCardsFromNote';
 import type { MobileEditorToolbarCommands } from './components/MobileEditorToolbar';
 
 type ViewAction = (view: EditorView) => void;
@@ -162,10 +163,12 @@ export async function insertImageFromDevice(
  * 宿主侧扩展（不依赖编辑器实例的命令）。
  * - openFind：打开编辑器内查找替换面板（NotesCrepeEditor 传 setIsFindReplaceOpen(true)）；
  * - noteId：图片上传归档到该笔记的资产目录（P0-4；缺省时 uploader 回退 blob URL）。
+ * - noteTitle：制卡时作为牌组名；缺省时 generateCardsFromNote 回退到通用牌组。
  */
 export interface MobileEditorCommandExtras {
   openFind?: () => void;
   noteId?: string;
+  noteTitle?: string;
 }
 
 export function buildMobileEditorCommands(
@@ -193,6 +196,10 @@ export function buildMobileEditorCommands(
     insertTable: () => editor?.insertTable(),
     // 📱 触屏无 hover 块句柄：当前块操作菜单入口（Turn into / 复制 / 删除等）
     openBlockActions: () => editor?.openBlockMenuAtSelection?.(),
+    // 生成卡片：走与桌面工具栏同一个共享制卡入口，不新起链路
+    generateCards: () => {
+      void generateCardsFromNote({ editor, noteTitle: extras?.noteTitle });
+    },
     // 查找入口：仅宿主接线后暴露，保持未接线宿主的按钮隐藏行为
     ...(extras?.openFind ? { openFind: extras.openFind } : {}),
   };

--- a/src/locales/en-US/notes.json
+++ b/src/locales/en-US/notes.json
@@ -352,6 +352,7 @@
     "quote": "Quote",
     "horizontalRule": "Horizontal Rule",
     "codeBlock": "Code Block",
+    "generateCards": "Generate cards",
     "link": "Link",
     "image": "Image",
     "table": "Table",
@@ -1298,7 +1299,16 @@
     "taskList": "Task list",
     "image": "Image",
     "undo": "Undo",
-    "redo": "Redo"
+    "redo": "Redo",
+    "generateCards": "Generate cards"
+  },
+  "generateCards": {
+    "deckName": "Note cards",
+    "requirements": "Build cards from the key points of this note, keep the original terminology and wording, and skip purely formatting content.",
+    "tooShort": "This note is too short — add some content before generating cards",
+    "started": "Started generating cards from this note",
+    "failed": "Failed to generate cards",
+    "openTaskDashboard": "View tasks"
   },
   "menu": {
     "page_actions": "Page Actions",

--- a/src/locales/zh-CN/notes.json
+++ b/src/locales/zh-CN/notes.json
@@ -325,6 +325,7 @@
     "quote": "引用",
     "horizontalRule": "分隔线",
     "codeBlock": "代码块",
+    "generateCards": "生成卡片",
     "link": "链接",
     "image": "图片",
     "table": "表格",
@@ -1287,7 +1288,16 @@
     "taskList": "任务列表",
     "image": "图片",
     "undo": "撤销",
-    "redo": "重做"
+    "redo": "重做",
+    "generateCards": "生成卡片"
+  },
+  "generateCards": {
+    "deckName": "笔记制卡",
+    "requirements": "基于这篇笔记的要点出卡，保留原文的术语与表述，跳过纯格式化内容。",
+    "tooShort": "笔记内容太短，先写点内容再生成卡片",
+    "started": "已开始根据笔记生成卡片",
+    "failed": "生成卡片失败",
+    "openTaskDashboard": "查看任务"
   },
   "versions": {
     "title": "版本历史",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

笔记编辑器可以一键把当前笔记交给已有 CardForge 制卡链路，与聊天划词、错题本、作文批改共用 `generateCardsFromText`，不新造 pipeline。

### Changes
- 共享 `src/features/anki/generateCardsFromText.ts` + `generateCardsFromNote` 接线层
- 桌面工具栏常驻「生成卡片」，带 in-flight 守卫
- 移动底栏入口由宿主显式开启（`enableGenerateCards`），同样有 in-flight 防双击
- 正文优先 `getFullMarkdown`，避免窗口化截断
- i18n 中英同步；vitest 覆盖共享函数与两个工具栏

### How to test
- 打开足够长的笔记，点「生成卡片」，应出现制卡开始 toast，并可跳到任务看板
- 正文过短应拒绝
- 窄屏按钮 44px；连点不应发出两个任务
- 未开启 `enableGenerateCards` 的宿主不出现该按钮

### 重叠说明
共享函数与 #160 同源。本 PR 只加笔记入口。

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92ea5725-a196-4c8d-97b6-cf85cfe2ecb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92ea5725-a196-4c8d-97b6-cf85cfe2ecb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

