### PR TITLE
fix(sync): FTP 550 tombstone 契约以修复 Cloud Provider Gate

### DIFF
--- a/src-tauri/src/cloud_storage/ftp.rs
+++ b/src-tauri/src/cloud_storage/ftp.rs
@@ -238,6 +238,20 @@ impl FtpStorage {
             || err.contains("不存在")
     }
 
+    /// 父目录缺失时各服务器的 cwd 回复不统一：vsftpd 是 `550 Failed to change
+    /// directory.`，proftpd/pyftpdlib 是 `550 ...: No such file or directory`。删除
+    /// 场景下父目录不可达等价于目标文件已不存在，按成功处理；权限类 550 仍上报错误。
+    fn is_missing_directory_error(error: &AppError) -> bool {
+        if Self::is_not_found_error(error) {
+            return true;
+        }
+        let err = error.to_string().to_lowercase();
+        err.contains("550")
+            && !err.contains("permission denied")
+            && !err.contains("access denied")
+            && !err.contains("access is denied")
+    }
+
     fn parse_list_entry(line: &str) -> Option<FtpListEntry> {
         let parsed = FtpListFile::from_mlsx_line(line)
             .or_else(|_| FtpListFile::try_from(line))
@@ -826,7 +840,13 @@ impl CloudStorage for FtpStorage {
                 let parent_path = &key[..parent];
                 if !parent_path.is_empty() {
                     let full_parent = self.remote_path(parent_path);
-                    client.cwd(&Self::absolute_path(&full_parent)).await?;
+                    if let Err(err) = client.cwd(&Self::absolute_path(&full_parent)).await {
+                        if !Self::is_missing_directory_error(&err) {
+                            return Err(err);
+                        }
+                        let _ = client.quit().await;
+                        return Ok(());
+                    }
                 }
             }
 
@@ -1085,6 +1105,28 @@ mod tests {
         );
 
         assert!(FtpStorage::is_not_found_error(&error));
+    }
+
+    #[test]
+    fn missing_parent_directory_cwd_is_treated_as_absent() {
+        for message in [
+            "FTP CWD 失败：Invalid response: [550] 550 Failed to change directory.",
+            "FTP CWD 失败：Invalid response: [550] 550 /root/data_governance/assets: No such file or directory",
+        ] {
+            let error = AppError::file_system(message);
+            assert!(
+                FtpStorage::is_missing_directory_error(&error),
+                "expected {message} to be treated as a missing directory"
+            );
+        }
+    }
+
+    #[test]
+    fn permission_denied_cwd_is_still_an_error() {
+        let error =
+            AppError::file_system("FTP CWD 失败：Invalid response: [550] 550 Permission denied.");
+
+        assert!(!FtpStorage::is_missing_directory_error(&error));
     }
 
     #[test]

--- a/src-tauri/src/data_governance/sync/mod.rs
+++ b/src-tauri/src/data_governance/sync/mod.rs
@@ -9029,6 +9029,14 @@ impl SyncManager {
         }
     }
 
+    /// 对象是否落在内容寻址前缀（`data_governance/asset_objects/<sha256>`）。
+    ///
+    /// 只有 legacy 前缀 `data_governance/assets/` 下的对象与逻辑 key 一一对应，可以
+    /// 随 tombstone 物理删除。
+    fn is_content_addressed_asset_object(key: &str) -> bool {
+        Self::validate_remote_object_key(key, Self::ASSET_OBJECTS_PREFIX).is_ok()
+    }
+
     /// 文件级 LWW：本地文件是否胜过云端清单条目。
     ///
     /// [P0 收敛性] 设备分量必须中性（双方相同）：旧实现用 "local-file" vs
@@ -10180,6 +10188,29 @@ impl SyncManager {
         &self,
         storage: &dyn CloudStorage,
     ) -> Result<AssetDirsManifest, SyncError> {
+        self.download_assets_manifest_with_tombstone_filter(storage, true)
+            .await
+    }
+
+    /// 保留被 tombstone 覆盖的条目，供删除传播解析物理 object_key。
+    ///
+    /// 过滤版清单会先把 tombstoned 逻辑 key 摘掉，删除传播再去查 `object_key` 必然
+    /// miss，从而回退到 legacy 逻辑路径 `data_governance/assets/{key}`；新布局的对象
+    /// 实际在 `data_governance/asset_objects/{sha256}`，回退路径在 FTP 上会因父目录
+    /// cwd 550 直接硬失败。
+    async fn download_assets_manifest_before_tombstones(
+        &self,
+        storage: &dyn CloudStorage,
+    ) -> Result<AssetDirsManifest, SyncError> {
+        self.download_assets_manifest_with_tombstone_filter(storage, false)
+            .await
+    }
+
+    async fn download_assets_manifest_with_tombstone_filter(
+        &self,
+        storage: &dyn CloudStorage,
+        filter_tombstones: bool,
+    ) -> Result<AssetDirsManifest, SyncError> {
         let mut manifests = Vec::new();
         if let Some(bytes) = storage
             .get(Self::ASSETS_MANIFEST_KEY)
@@ -10253,15 +10284,17 @@ impl SyncManager {
                 }
             }
         }
-        let tombstones = tombstone::download_asset_tombstones(storage, self).await?;
-        for (key, tombstone) in tombstones.entries {
-            let should_remove = merged
-                .entries
-                .get(&key)
-                .map(|entry| !Self::timestamp_after(&entry.updated_at, &tombstone.deleted_at))
-                .unwrap_or(false);
-            if should_remove {
-                merged.entries.remove(&key);
+        if filter_tombstones {
+            let tombstones = tombstone::download_asset_tombstones(storage, self).await?;
+            for (key, tombstone) in tombstones.entries {
+                let should_remove = merged
+                    .entries
+                    .get(&key)
+                    .map(|entry| !Self::timestamp_after(&entry.updated_at, &tombstone.deleted_at))
+                    .unwrap_or(false);
+                if should_remove {
+                    merged.entries.remove(&key);
+                }
             }
         }
         Ok(merged)
@@ -10798,7 +10831,9 @@ impl SyncManager {
         // 1. 拉取 asset tombstone 并删除本地/云端对应文件
         let instance_id = self.ensure_remote_instance_id(storage).await?;
         let state_store = SyncStateStore::open_default()?;
-        let cloud_manifest = self.download_assets_manifest(storage).await?;
+        let cloud_manifest = self
+            .download_assets_manifest_before_tombstones(storage)
+            .await?;
         let (tombstones, tombstone_advances) =
             tombstone::download_asset_tombstones_after(storage, self, |source| {
                 state_store.get_tombstone_watermark(&instance_id, source, "assets")
@@ -10841,9 +10876,20 @@ impl SyncManager {
                         .and_then(|manifest| manifest.object_key.clone())
                         .unwrap_or_else(|| format!("{}/{}", Self::ASSETS_CLOUD_PREFIX, key));
                     Self::validate_asset_object_key(&remote_key)?;
-                    storage.delete(&remote_key).await.map_err(|e| {
-                        SyncError::Network(format!("删除云端资产失败 {}: {}", remote_key, e))
-                    })?;
+                    if Self::is_content_addressed_asset_object(&remote_key) {
+                        // 内容寻址对象按 sha256 去重，可被多个逻辑 key 共享，是独立的
+                        // retention unit：删除传播只负责摘掉逻辑 key，物理回收交给 GC，
+                        // 否则删掉其中一个 key 会连带打断同内容的其他 key。
+                        tracing::info!(
+                            "[sync] 资产 tombstone 保留内容寻址对象，仅摘除清单条目: {} -> {}",
+                            key,
+                            remote_key
+                        );
+                    } else {
+                        storage.delete(&remote_key).await.map_err(|e| {
+                            SyncError::Network(format!("删除云端资产失败 {}: {}", remote_key, e))
+                        })?;
+                    }
                 }
                 // 本地删除
                 if let Some(local) = local_path {

--- a/src-tauri/tests/sync_provider_contract_tests.rs
+++ b/src-tauri/tests/sync_provider_contract_tests.rs
@@ -1611,6 +1611,87 @@ async fn run_asset_directories_file_sync_and_tombstone_contract(storage: Box<dyn
     assert_file_bytes(&target_app_asset, app_payload);
 }
 
+/// 同内容双 key 的删除传播不得打断另一 key。
+///
+/// tombstone 必须在未过滤的清单上解析 `object_key`，否则只能回退到 legacy 逻辑路径
+/// `data_governance/assets/{key}`——该父目录在新布局下根本不存在，FTP 会因 cwd 550
+/// 硬失败。解析成功后，内容寻址对象本身是共享 retention unit，只摘清单条目、不删对象。
+async fn run_asset_shared_object_tombstone_contract(storage: Box<dyn CloudStorage>) {
+    storage
+        .check_connection()
+        .await
+        .expect("provider connection should work");
+
+    let source_active = TempDir::new().expect("create source active dir");
+    let source_app_data = TempDir::new().expect("create source app data dir");
+    let target_active = TempDir::new().expect("create target active dir");
+    let target_app_data = TempDir::new().expect("create target app data dir");
+
+    let shared_payload = deterministic_payload(9 * 1024 + 7);
+    let shared_object_key = format!(
+        "data_governance/asset_objects/{}",
+        sha256_hex(&shared_payload)
+    );
+    let deleted_key = "active/images/shared/deleted.bin";
+    let kept_key = "active/images/shared/kept.bin";
+    let deleted_rel = Path::new("images").join("shared").join("deleted.bin");
+    let kept_rel = Path::new("images").join("shared").join("kept.bin");
+
+    let source_deleted = source_active.path().join(&deleted_rel);
+    let source_kept = source_active.path().join(&kept_rel);
+    std::fs::create_dir_all(source_deleted.parent().expect("shared asset parent"))
+        .expect("create source shared asset dir");
+    std::fs::write(&source_deleted, &shared_payload).expect("write source deleted asset");
+    std::fs::write(&source_kept, &shared_payload).expect("write source kept asset");
+
+    let source_manager = SyncManager::new(format!("device-shared-src-{}", Uuid::new_v4()));
+    let target_manager = SyncManager::new(format!("device-shared-dst-{}", Uuid::new_v4()));
+
+    let upload = source_manager
+        .sync_asset_directories(
+            storage.as_ref(),
+            source_active.path(),
+            source_app_data.path(),
+            SyncDirection::Upload,
+        )
+        .await
+        .expect("upload shared-content assets");
+    assert_eq!(upload.uploaded, 2);
+    assert!(!upload.has_failures(), "asset upload failures: {upload:?}");
+    assert_remote_file_present(storage.as_ref(), &shared_object_key).await;
+
+    std::fs::remove_file(&source_deleted).expect("delete source asset before tombstone");
+    source_manager
+        .mark_asset_deleted(
+            storage.as_ref(),
+            deleted_key,
+            Some(shared_payload.len() as u64),
+        )
+        .await
+        .expect("upload asset tombstone");
+
+    let tombstone_sync = target_manager
+        .sync_asset_directories_with_tombstones(
+            storage.as_ref(),
+            target_active.path(),
+            target_app_data.path(),
+            SyncDirection::Bidirectional,
+        )
+        .await
+        .expect("apply asset tombstone on target");
+    assert!(
+        !tombstone_sync.has_failures(),
+        "shared-object tombstone sync failures: {tombstone_sync:?}"
+    );
+
+    assert_remote_file_present(storage.as_ref(), &shared_object_key).await;
+    assert_file_bytes(&target_active.path().join(&kept_rel), &shared_payload);
+    assert!(
+        !target_active.path().join(&deleted_rel).exists(),
+        "tombstoned key {deleted_key} must not be rehydrated"
+    );
+}
+
 async fn run_asset_remote_same_size_corruption_rejected_contract(storage: Box<dyn CloudStorage>) {
     storage
         .check_connection()
@@ -2016,6 +2097,13 @@ async fn webdav_asset_directories_file_sync_and_tombstone_contract() {
 
 #[tokio::test]
 #[ignore = "requires scripts/dev/docker-compose.sync-test.yml and DS_SYNC_TEST_DOCKER=1"]
+async fn webdav_asset_shared_object_tombstone_contract() {
+    assert!(docker_contract_enabled(), "set DS_SYNC_TEST_DOCKER=1");
+    run_asset_shared_object_tombstone_contract(webdav_storage().await).await;
+}
+
+#[tokio::test]
+#[ignore = "requires scripts/dev/docker-compose.sync-test.yml and DS_SYNC_TEST_DOCKER=1"]
 async fn webdav_asset_remote_same_size_corruption_rejected_contract() {
     assert!(docker_contract_enabled(), "set DS_SYNC_TEST_DOCKER=1");
     run_asset_remote_same_size_corruption_rejected_contract(webdav_storage().await).await;
@@ -2171,6 +2259,14 @@ async fn s3_asset_directories_file_sync_and_tombstone_contract() {
 #[cfg(feature = "cloud_storage_s3")]
 #[tokio::test]
 #[ignore = "requires scripts/dev/docker-compose.sync-test.yml and DS_SYNC_TEST_DOCKER=1"]
+async fn s3_asset_shared_object_tombstone_contract() {
+    assert!(docker_contract_enabled(), "set DS_SYNC_TEST_DOCKER=1");
+    run_asset_shared_object_tombstone_contract(s3_storage().await).await;
+}
+
+#[cfg(feature = "cloud_storage_s3")]
+#[tokio::test]
+#[ignore = "requires scripts/dev/docker-compose.sync-test.yml and DS_SYNC_TEST_DOCKER=1"]
 async fn s3_asset_remote_same_size_corruption_rejected_contract() {
     assert!(docker_contract_enabled(), "set DS_SYNC_TEST_DOCKER=1");
     run_asset_remote_same_size_corruption_rejected_contract(s3_storage().await).await;
@@ -2321,6 +2417,13 @@ async fn ftp_vfs_blob_remote_same_size_corruption_rejected_contract() {
 async fn ftp_asset_directories_file_sync_and_tombstone_contract() {
     assert!(docker_contract_enabled(), "set DS_SYNC_TEST_DOCKER=1");
     run_asset_directories_file_sync_and_tombstone_contract(ftp_storage().await).await;
+}
+
+#[tokio::test]
+#[ignore = "requires scripts/dev/docker-compose.sync-test.yml and DS_SYNC_TEST_DOCKER=1"]
+async fn ftp_asset_shared_object_tombstone_contract() {
+    assert!(docker_contract_enabled(), "set DS_SYNC_TEST_DOCKER=1");
+    run_asset_shared_object_tombstone_contract(ftp_storage().await).await;
 }
 
 #[tokio::test]

--- a/src-tauri/tests/sync_scenarios_tests.rs
+++ b/src-tauri/tests/sync_scenarios_tests.rs
@@ -43,6 +43,9 @@ fn write_content_addressed_blob(blobs_dir: &Path, payload: &[u8]) -> (String, St
 #[derive(Default)]
 struct MockCloudStorageInner {
     files: BTreeMap<String, (Vec<u8>, chrono::DateTime<Utc>)>,
+    /// 记录所有 delete 请求（含删除不存在 key 的请求），用于断言删除传播解析出的
+    /// 物理 key，而不只是断言最终残留状态。
+    delete_requests: Vec<String>,
 }
 
 pub struct MockCloudStorage {
@@ -69,6 +72,10 @@ impl MockCloudStorage {
 
     pub fn keys(&self) -> Vec<String> {
         self.inner.lock().unwrap().files.keys().cloned().collect()
+    }
+
+    pub fn delete_requests(&self) -> Vec<String> {
+        self.inner.lock().unwrap().delete_requests.clone()
     }
 
     fn fail_if_offline(&self) -> CloudResult<()> {
@@ -125,6 +132,7 @@ impl CloudStorage for MockCloudStorage {
     async fn delete(&self, key: &str) -> CloudResult<()> {
         self.fail_if_offline()?;
         let mut inner = self.inner.lock().unwrap();
+        inner.delete_requests.push(key.to_string());
         inner.files.remove(key);
         Ok(())
     }
@@ -2798,5 +2806,94 @@ async fn download_only_asset_tombstone_does_not_rehydrate_in_same_round() {
     assert!(
         !active_b.path().join("images/deleted.txt").exists(),
         "download-only 同一轮不得从陈旧清单复活刚消费的删除"
+    );
+}
+
+/// 同内容双 key 的删除传播：
+///
+/// 1. tombstone 应用必须在「未按 tombstone 过滤」的清单上解析 object_key，否则
+///    条目已被摘掉，只能回退到 legacy 逻辑路径 `data_governance/assets/{key}`，
+///    在 FTP 上会因父目录 cwd 550 直接硬失败。
+/// 2. 解析出的内容寻址对象是共享 retention unit，不得随 tombstone 物理删除，
+///    否则会连带打断同内容的其他逻辑 key。
+#[tokio::test]
+async fn asset_tombstone_resolves_object_key_and_keeps_shared_content_object() {
+    let storage = MockCloudStorage::new();
+    let active_a = TempDir::new().unwrap();
+    let app_a = TempDir::new().unwrap();
+    std::fs::create_dir_all(active_a.path().join("images")).unwrap();
+    let shared_payload = b"shared-asset-content";
+    std::fs::write(active_a.path().join("images/first.png"), shared_payload).unwrap();
+    std::fs::write(active_a.path().join("images/second.png"), shared_payload).unwrap();
+
+    let manager_a = SyncManager::new(format!("shared-object-a-{}", uuid::Uuid::new_v4()));
+    let upload = manager_a
+        .sync_asset_directories(
+            &storage,
+            active_a.path(),
+            app_a.path(),
+            SyncDirection::Upload,
+        )
+        .await
+        .unwrap();
+    assert_eq!(upload.uploaded, 2);
+
+    let shared_object_key = format!(
+        "data_governance/asset_objects/{:x}",
+        Sha256::digest(shared_payload)
+    );
+    assert!(
+        storage.keys().contains(&shared_object_key),
+        "同内容双 key 必须共用一个内容寻址对象"
+    );
+
+    std::fs::remove_file(active_a.path().join("images/first.png")).unwrap();
+    manager_a
+        .mark_asset_deleted(
+            &storage,
+            "active/images/first.png",
+            Some(shared_payload.len() as u64),
+        )
+        .await
+        .unwrap();
+
+    let active_b = TempDir::new().unwrap();
+    let app_b = TempDir::new().unwrap();
+    let manager_b = SyncManager::new(format!("shared-object-b-{}", uuid::Uuid::new_v4()));
+    let outcome = manager_b
+        .sync_asset_directories_with_tombstones(
+            &storage,
+            active_b.path(),
+            app_b.path(),
+            SyncDirection::Bidirectional,
+        )
+        .await
+        .unwrap();
+    assert!(!outcome.has_failures(), "同步不应有失败: {outcome:?}");
+
+    let delete_requests = storage.delete_requests();
+    assert!(
+        !delete_requests
+            .iter()
+            .any(|key| key.starts_with("data_governance/assets/")),
+        "tombstone 不得回退到 legacy 逻辑路径删除: {delete_requests:?}"
+    );
+    assert!(
+        !delete_requests.contains(&shared_object_key),
+        "tombstone 不得物理删除共享的内容寻址对象: {delete_requests:?}"
+    );
+    assert!(
+        storage.keys().contains(&shared_object_key),
+        "另一逻辑 key 的内容对象必须仍在云端"
+    );
+
+    assert_eq!(
+        std::fs::read(active_b.path().join("images/second.png")).unwrap(),
+        shared_payload,
+        "未被删除的同内容 key 必须仍可下载"
+    );
+    assert!(
+        !active_b.path().join("images/first.png").exists(),
+        "被 tombstone 的 key 不得在同一轮复活"
     );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

从 #158 抽出的最小切片：在应用 tombstone 之前解析资产物理 object_key，避免删除传播回退到不存在的 legacy 路径，从而触发 FTP CWD 550，拖红 Cloud Provider Contract Gate。

内容寻址的 `data_governance/asset_objects/` 不物理删除（同内容可被多个逻辑 key 共享）；FTP 删除时父目录 550 / No such file 视为已不存在，权限类 550 仍报错。

**不含** #158 未完成的 `provider_stream_failure_message`、migration-nightly、#168 的 Vitest/夹具改动。

### Changes
- `download_assets_manifest_before_tombstones`：仅 tombstone 应用处使用未过滤清单
- `asset_objects/` 内容寻址对象不做物理删除
- FTP delete 对父目录 550 按不存在成功
- 契约/场景测试：同内容双 key，tombstone 其中一个后另一 key 的对象仍在

### How to test
- `src-tauri/tests/sync_provider_contract_tests.rs`、`sync_scenarios_tests.rs` 相关用例
- CI：Cloud Provider Contract Gate 应变绿（main 上红在 `ftp_asset_directories_file_sync_and_tombstone_contract`）

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

