### PR TITLE
fix(capability): mythos-5 前端补齐

### DIFF
--- a/src/utils/__tests__/apiCapabilityEngine.test.ts
+++ b/src/utils/__tests__/apiCapabilityEngine.test.ts
@@ -62,6 +62,25 @@ describe('apiCapabilityEngine vision inference', () => {
     expect(caps.functionCalling).toBe(true);
     expect(caps.reasoning).toBe(true);
     expect(caps.contextWindow).toBe(32768);
+    expect(caps.contextWindowSource).toBe('registry');
+  });
+
+  it('reports context window source for registry hits, rule hits and defaults', () => {
+    const qwen = inferApiCapabilities({ id: 'qwen3.5-32b', providerScope: 'siliconflow' });
+    expect(qwen.contextWindow).toBe(32_768);
+    expect(qwen.contextWindowSource).toBe('registry');
+
+    const glm = inferApiCapabilities({ id: 'glm-4.5v' });
+    expect(glm.contextWindow).toBe(64_000);
+    expect(glm.contextWindowSource).toBe('registry');
+
+    const ruleHit = inferApiCapabilities({ id: 'claude-fable-5' });
+    expect(ruleHit.contextWindow).toBe(1_000_000);
+    expect(ruleHit.contextWindowSource).toBe('rule');
+
+    const miss = inferApiCapabilities({ id: 'mystery-model-x' });
+    expect(miss.contextWindow).toBe(100_000);
+    expect(miss.contextWindowSource).toBe('default');
   });
 
   it('keeps generic open-source Qwen3.5 records when provider scope is absent', () => {
@@ -158,6 +177,21 @@ describe('apiCapabilityEngine 2026-07 model refresh', () => {
     expect(caps.vision).toBe(true);
     expect(caps.functionCalling).toBe(true);
     expect(caps.supportsThinkingTokens).toBe(true);
+  });
+
+  it('treats Claude Mythos 5 as a multimodal adaptive-thinking model with 1M context', () => {
+    const caps = inferApiCapabilities({ id: 'claude-mythos-5' });
+    expect(caps.vision).toBe(true);
+    expect(caps.functionCalling).toBe(true);
+    expect(caps.supportsThinkingTokens).toBe(true);
+    expect(caps.contextWindow).toBe(1_000_000);
+  });
+
+  it('keeps Claude Mythos 5 snapshot ids vision + thinking capable', () => {
+    const caps = inferApiCapabilities({ id: 'claude-mythos-5-20260615' });
+    expect(caps.vision).toBe(true);
+    expect(caps.supportsThinkingTokens).toBe(true);
+    expect(caps.contextWindow).toBe(1_000_000);
   });
 
   it('treats Claude Sonnet 5 and Opus 4.8 as vision + thinking capable', () => {

--- a/src/utils/__tests__/apiCapabilityEngine.test.ts
+++ b/src/utils/__tests__/apiCapabilityEngine.test.ts
@@ -62,25 +62,6 @@ describe('apiCapabilityEngine vision inference', () => {
     expect(caps.functionCalling).toBe(true);
     expect(caps.reasoning).toBe(true);
     expect(caps.contextWindow).toBe(32768);
-    expect(caps.contextWindowSource).toBe('registry');
-  });
-
-  it('reports context window source for registry hits, rule hits and defaults', () => {
-    const qwen = inferApiCapabilities({ id: 'qwen3.5-32b', providerScope: 'siliconflow' });
-    expect(qwen.contextWindow).toBe(32_768);
-    expect(qwen.contextWindowSource).toBe('registry');
-
-    const glm = inferApiCapabilities({ id: 'glm-4.5v' });
-    expect(glm.contextWindow).toBe(64_000);
-    expect(glm.contextWindowSource).toBe('registry');
-
-    const ruleHit = inferApiCapabilities({ id: 'claude-fable-5' });
-    expect(ruleHit.contextWindow).toBe(1_000_000);
-    expect(ruleHit.contextWindowSource).toBe('rule');
-
-    const miss = inferApiCapabilities({ id: 'mystery-model-x' });
-    expect(miss.contextWindow).toBe(100_000);
-    expect(miss.contextWindowSource).toBe('default');
   });
 
   it('keeps generic open-source Qwen3.5 records when provider scope is absent', () => {

--- a/src/utils/apiCapabilityEngine.ts
+++ b/src/utils/apiCapabilityEngine.ts
@@ -110,9 +110,10 @@ const VISION_ALLOWED_PATTERNS: (string | RegExp)[] = [
   // Claude 4.6 系列
   'claude-opus-4-6',
   'claude-opus-4.6',
-  // Claude 2026 系列：opus-4-7/4-8 已被 'claude-opus-4' 前缀覆盖；Sonnet 5 / Fable 5 需显式列出
+  // Claude 2026 系列：opus-4-7/4-8 已被 'claude-opus-4' 前缀覆盖；Sonnet 5 / Fable 5 / Mythos 5 需显式列出
   'claude-sonnet-5',
   'claude-fable-5',
+  'claude-mythos-5',
   'claude-haiku-5',
   'vision',
   // 智谱仅 V 系列支持视觉，避免把 glm-4.7/4.6/5 等纯文本模型误判为多模态
@@ -273,6 +274,7 @@ const CLAUDE_THINKING_PATTERNS = [
   // 注意：这些模型需 adaptive thinking + output_config.effort（type:"enabled" 会 400，见 r4 P0-#1）
   'claude-sonnet-5',
   'claude-fable-5',
+  'claude-mythos-5',
   'claude-haiku-5',
 ];
 
@@ -338,8 +340,8 @@ const DEFAULT_CONTEXT_WINDOW = 100_000;
 const CONTEXT_WINDOW_RULES: Array<{ pattern: RegExp; window: number }> = [
   // GPT-5.6：1.05M tokens
   { pattern: /gpt-5\.6/i, window: 1_050_000 },
-  // Claude 2026 主线与 Kimi K3：1M tokens
-  { pattern: /claude-(?:fable-5|sonnet-5|opus-4[-.](?:7|8))/i, window: 1_000_000 },
+  // Claude 2026 主线与 Kimi K3：1M tokens（Mythos 5 与 Fable 5 同代，按主线对齐）
+  { pattern: /claude-(?:fable-5|mythos-5|sonnet-5|opus-4[-.](?:7|8))/i, window: 1_000_000 },
   { pattern: /kimi-k3/i, window: 1_000_000 },
   // MiniMax M2.7 与 Doubao Evolving：1M tokens
   { pattern: /minimax-m2\.7|doubao-seed-evolving/i, window: 1_000_000 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

前端能力引擎补齐 `claude-mythos-5`：视觉、adaptive thinking、以及与同代 Fable 5 对齐的 1M 上下文规则。后端 `anthropic.rs` 已支持该代际；此前 UI 会把它当纯文本非思考模型。

没有编造独立官方上下文数字，只并入既有 Claude 2026 主线规则。未改 `inferModelContextWindow` 命中判断、gpt-5.6 max、K3、CI、sync。

### Changes
- `VISION_ALLOWED_PATTERNS` / `CLAUDE_THINKING_PATTERNS` 增加 `claude-mythos-5`
- `CONTEXT_WINDOW_RULES` 的 Claude 2026 主线纳入 `mythos-5`
- 测试覆盖裸 id 与 snapshot id

### How to test
- `npx vitest run src/utils/__tests__/apiCapabilityEngine.test.ts`

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

