### PR TITLE
fix(capability): 注册表小上下文直通

### DIFF
--- a/src/utils/__tests__/apiCapabilityEngine.test.ts
+++ b/src/utils/__tests__/apiCapabilityEngine.test.ts
@@ -74,8 +74,14 @@ describe('apiCapabilityEngine vision inference', () => {
     expect(glm.contextWindow).toBe(64_000);
     expect(glm.contextWindowSource).toBe('registry');
 
-    const ruleHit = inferApiCapabilities({ id: 'claude-fable-5' });
-    expect(ruleHit.contextWindow).toBe(1_000_000);
+    // claude-fable-5 在注册表中有确认记录（max_context_tokens=1M），注册表优先于规则
+    const registryHit = inferApiCapabilities({ id: 'claude-fable-5' });
+    expect(registryHit.contextWindow).toBe(1_000_000);
+    expect(registryHit.contextWindowSource).toBe('registry');
+
+    // codestral 不在注册表中，仅由 CONTEXT_WINDOW_RULES 命中
+    const ruleHit = inferApiCapabilities({ id: 'codestral-2508' });
+    expect(ruleHit.contextWindow).toBe(256_000);
     expect(ruleHit.contextWindowSource).toBe('rule');
 
     const miss = inferApiCapabilities({ id: 'mystery-model-x' });

--- a/src/utils/__tests__/apiCapabilityEngine.test.ts
+++ b/src/utils/__tests__/apiCapabilityEngine.test.ts
@@ -62,6 +62,25 @@ describe('apiCapabilityEngine vision inference', () => {
     expect(caps.functionCalling).toBe(true);
     expect(caps.reasoning).toBe(true);
     expect(caps.contextWindow).toBe(32768);
+    expect(caps.contextWindowSource).toBe('registry');
+  });
+
+  it('reports context window source for registry hits, rule hits and defaults', () => {
+    const qwen = inferApiCapabilities({ id: 'qwen3.5-32b', providerScope: 'siliconflow' });
+    expect(qwen.contextWindow).toBe(32_768);
+    expect(qwen.contextWindowSource).toBe('registry');
+
+    const glm = inferApiCapabilities({ id: 'glm-4.5v' });
+    expect(glm.contextWindow).toBe(64_000);
+    expect(glm.contextWindowSource).toBe('registry');
+
+    const ruleHit = inferApiCapabilities({ id: 'claude-fable-5' });
+    expect(ruleHit.contextWindow).toBe(1_000_000);
+    expect(ruleHit.contextWindowSource).toBe('rule');
+
+    const miss = inferApiCapabilities({ id: 'mystery-model-x' });
+    expect(miss.contextWindow).toBe(100_000);
+    expect(miss.contextWindowSource).toBe('default');
   });
 
   it('keeps generic open-source Qwen3.5 records when provider scope is absent', () => {

--- a/src/utils/__tests__/modelCapabilities.test.ts
+++ b/src/utils/__tests__/modelCapabilities.test.ts
@@ -57,6 +57,42 @@ describe('modelCapabilities DeepSeek version defaults', () => {
   });
 });
 
+describe('inferModelContextWindow registry small-context passthrough', () => {
+  it('keeps registry-confirmed qwen3.5-32b at 32768 instead of lifting to >=100K', () => {
+    const descriptor = { id: 'qwen3.5-32b', providerScope: 'siliconflow' };
+
+    expect(inferModelContextWindow(descriptor)).toBe(32_768);
+    // P0 回归：命中注册表后不得再走 maxOutputTokens 启发式（旧逻辑会抬到 >=100K）
+    expect(inferModelContextWindow(descriptor, 8_192)).toBe(32_768);
+    expect(inferModelContextWindow(descriptor, 65_536)).toBe(32_768);
+  });
+
+  it('keeps SiliconFlow provider-prefixed Qwen3.5-32B ids at 32768', () => {
+    expect(
+      inferModelContextWindow({ id: 'Qwen/Qwen3.5-32B', providerScope: 'siliconflow' }, 8_192)
+    ).toBe(32_768);
+  });
+
+  it('keeps registry-confirmed glm-4.5v at 64000 instead of lifting to >=100K', () => {
+    expect(inferModelContextWindow('glm-4.5v')).toBe(64_000);
+    expect(inferModelContextWindow('glm-4.5v', 8_192)).toBe(64_000);
+    expect(inferModelContextWindow({ id: 'glm-4.5v' }, 96_000)).toBe(64_000);
+  });
+
+  it('keeps rule hits above the fallback unchanged', () => {
+    expect(inferModelContextWindow('claude-fable-5', 8_192)).toBe(1_000_000);
+    expect(inferModelContextWindow('gemini-2.5-pro')).toBe(1_000_000);
+  });
+
+  it('still applies the maxOutputTokens heuristic only for unmatched models', () => {
+    // 未命中且无 maxOutputTokens：返回 DEFAULT_FALLBACK_CONTEXT_WINDOW (100_000)
+    expect(inferModelContextWindow('mystery-model-x')).toBe(100_000);
+    // 未命中 + maxOutputTokens：max(100_000, 4 * maxOutputTokens)
+    expect(inferModelContextWindow('mystery-model-x', 8_192)).toBe(100_000);
+    expect(inferModelContextWindow('mystery-model-x', 50_000)).toBe(200_000);
+  });
+});
+
 describe('modelCapabilities OpenAI GPT-5 defaults', () => {
   it('uses OpenAI GPT-5.5 defaults with reasoning effort and verbosity', () => {
     expect(getModelDefaultParameters('gpt-5.5', { providerScope: 'openai' })).toMatchObject({

--- a/src/utils/apiCapabilityEngine.ts
+++ b/src/utils/apiCapabilityEngine.ts
@@ -21,6 +21,14 @@ export interface ApiModelDescriptor {
   providerScope?: string;
 }
 
+/**
+ * 上下文窗口的推断来源：
+ * - 'registry'：模型注册表（model-capability-registry.json）确认的 max_context_tokens
+ * - 'rule'：CONTEXT_WINDOW_RULES 或内置硬规则（如 DeepSeek V4）命中
+ * - 'default'：未命中任何规则，返回 DEFAULT_CONTEXT_WINDOW 兜底值
+ */
+export type ContextWindowSource = 'registry' | 'rule' | 'default';
+
 export interface InferredApiCapabilities {
   reasoning: boolean;
   vision: boolean;
@@ -33,8 +41,10 @@ export interface InferredApiCapabilities {
   supportsReasoningEffort: boolean;
   supportsThinkingTokens: boolean;
   supportsHybridReasoning: boolean;
-  /** 推断的上下文窗口大小（tokens），基于模型 ID/名称的启发式匹配 */
+  /** 推断的上下文窗口大小（tokens），基于注册表记录或模型 ID/名称的启发式匹配 */
   contextWindow: number;
+  /** contextWindow 的来源；'default' 表示未命中任何注册表记录或规则 */
+  contextWindowSource: ContextWindowSource;
 }
 
 const toLower = (value: string | undefined | null): string => (value ?? '').toLowerCase();
@@ -444,15 +454,15 @@ const CONTEXT_WINDOW_RULES: Array<{ pattern: RegExp; window: number }> = [
  * 使用 first-match-wins 策略，具体模式优先于通用模式。
  *
  * @param fingerprint - 小写的 "id name" 拼接字符串
- * @returns 推断的上下文窗口大小（tokens）
+ * @returns 命中规则时返回窗口大小（tokens），未命中返回 null
  */
-function inferContextWindow(fingerprint: string): number {
+function inferContextWindow(fingerprint: string): number | null {
   for (const rule of CONTEXT_WINDOW_RULES) {
     if (rule.pattern.test(fingerprint)) {
       return rule.window;
     }
   }
-  return DEFAULT_CONTEXT_WINDOW;
+  return null;
 }
 
 const matchesPatternList = (value: string, patterns: (string | RegExp)[]): boolean => {
@@ -686,15 +696,32 @@ export function inferApiCapabilities(descriptor: ApiModelDescriptor): InferredAp
     !imageModel &&
     (DEEPSEEK_HYBRID_REGEXES.some(regex => regex.test(id)) || isMimoHybridReasoning || isRegistryHybridReasoning);
 
-  // 上下文窗口推断：使用 id + name 拼接作为指纹，提高匹配率
-  const inferredWindow = inferContextWindow(`${id} ${name}`);
-  const shouldUseDeepSeekV4Context = isDeepSeekV4 || isDeepSeekV4EffortCapable;
-  const contextWindow =
-    shouldUseDeepSeekV4Context
-      ? 1_000_000
-      : modelCapabilities && typeof modelCapabilities.max_context_tokens === 'number' && modelCapabilities.max_context_tokens > 0
+  // 上下文窗口推断：注册表确认值 > 规则命中 > 默认兜底。
+  // 命中来源通过 contextWindowSource 回传，调用方（如 inferModelContextWindow）
+  // 据此判断"是否命中"，而不是用数值大小去猜——注册表确认的小上下文
+  // （如 qwen3.5-32b=32768、glm-4.5v=64000）同样是有效命中。
+  const ruleWindow = inferContextWindow(`${id} ${name}`);
+  const registryWindow =
+    modelCapabilities && typeof modelCapabilities.max_context_tokens === 'number' && modelCapabilities.max_context_tokens > 0
       ? modelCapabilities.max_context_tokens
-      : inferredWindow;
+      : null;
+  const shouldUseDeepSeekV4Context = isDeepSeekV4 || isDeepSeekV4EffortCapable;
+
+  let contextWindow: number;
+  let contextWindowSource: ContextWindowSource;
+  if (shouldUseDeepSeekV4Context) {
+    contextWindow = 1_000_000;
+    contextWindowSource = 'rule';
+  } else if (registryWindow !== null) {
+    contextWindow = registryWindow;
+    contextWindowSource = 'registry';
+  } else if (ruleWindow !== null) {
+    contextWindow = ruleWindow;
+    contextWindowSource = 'rule';
+  } else {
+    contextWindow = DEFAULT_CONTEXT_WINDOW;
+    contextWindowSource = 'default';
+  }
 
   return {
     reasoning,
@@ -709,5 +736,6 @@ export function inferApiCapabilities(descriptor: ApiModelDescriptor): InferredAp
     supportsThinkingTokens,
     supportsHybridReasoning,
     contextWindow,
+    contextWindowSource,
   };
 }

--- a/src/utils/modelCapabilities.ts
+++ b/src/utils/modelCapabilities.ts
@@ -333,8 +333,9 @@ function clampNumber(value: number, min: number, max: number): number {
 /**
  * 基于模型标识推断上下文窗口。
  *
- * 统一委托给 apiCapabilityEngine.inferApiCapabilities() 中的 CONTEXT_WINDOW_RULES，
- * 避免维护两套正则。当推断引擎无法匹配时，尝试根据 maxOutputTokens 启发式推导。
+ * 统一委托给 apiCapabilityEngine.inferApiCapabilities()（注册表 + CONTEXT_WINDOW_RULES），
+ * 避免维护两套正则。仅当推断引擎未命中（contextWindowSource === 'default'）时，
+ * 才根据 maxOutputTokens 启发式推导。
  *
  * 注意：这是推断默认值；用户可在 ApiConfig.contextWindow 或 Chat V2 高级面板中手动覆盖。
  */
@@ -349,12 +350,15 @@ export function inferModelContextWindow(
   // 统一调用 apiCapabilityEngine 推断
   const caps: InferredApiCapabilities = inferApiCapabilities({ id: modelId, name: modelName, providerScope });
 
-  // 如果推断引擎命中了规则，直接使用其值
-  if (caps.contextWindow > DEFAULT_FALLBACK_CONTEXT_WINDOW) {
+  // 注册表/规则命中即直通生效——包括 ≤100K 的小上下文（如 qwen3.5-32b=32768、
+  // glm-4.5v=64000）。不能用数值大小判断是否命中：那会把注册表确认的小窗口
+  // 误判为未命中，再被下方启发式抬到 ≥100K，长对话超出真实窗口后必然 400。
+  if (caps.contextWindowSource !== 'default') {
     return caps.contextWindow;
   }
 
-  // 推断引擎未命中（返回默认 32K）时，尝试根据 maxOutputTokens 启发式推导
+  // 推断引擎未命中（返回默认 100K，即 DEFAULT_FALLBACK_CONTEXT_WINDOW）时，
+  // 尝试根据 maxOutputTokens 启发式推导
   if (typeof maxOutputTokens === 'number' && Number.isFinite(maxOutputTokens) && maxOutputTokens > 0) {
     return clampNumber(
       Math.max(DEFAULT_FALLBACK_CONTEXT_WINDOW, Math.floor(maxOutputTokens * 4)),
@@ -363,7 +367,7 @@ export function inferModelContextWindow(
     );
   }
 
-  return caps.contextWindow; // DEFAULT_FALLBACK_CONTEXT_WINDOW (32_768)
+  return caps.contextWindow; // DEFAULT_FALLBACK_CONTEXT_WINDOW (100_000)
 }
 
 export interface InputContextBudgetOptions {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`inferModelContextWindow` 原先用 `contextWindow > 100_000` 判断引擎是否命中，于是注册表确认的小窗口（如 qwen3.5-32b=32768、glm-4.5v=64000）被当成未命中，再被启发式抬到 ≥100K，长对话必然 400。

改为由 `inferApiCapabilities` 回传 `contextWindowSource: 'registry' | 'rule' | 'default'`，命中即直通，不再用数值大小猜。未改 mythos-5（#170）、gpt-5.6 max、K3、CI、sync。

### Changes
- `apiCapabilityEngine.ts`：增加命中标志；规则未命中返回 null
- `modelCapabilities.ts`：`contextWindowSource !== 'default'` 即直通
- 回归：qwen3.5-32b / glm-4.5v 不被 `maxOutputTokens` 抬升

### How to test
- `npx vitest run src/utils/__tests__/modelCapabilities.test.ts src/utils/__tests__/apiCapabilityEngine.test.ts`

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

