### PR TITLE
fix(sync): WebDAV 列举编码归一化与 S3 端点识别

### DIFF
--- a/src-tauri/src/cloud_storage/s3.rs
+++ b/src-tauri/src/cloud_storage/s3.rs
@@ -28,6 +28,79 @@ pub struct S3Storage {
 }
 
 impl S3Storage {
+    /// [#57] 归一化用户填写的 S3 endpoint。
+    ///
+    /// 腾讯云 COS / 阿里云 OSS / 缤纷云 S4 等控制台展示给用户的是
+    /// **带 bucket 前缀的访问域名**（如 `https://mybucket.cos.ap-beijing.myqcloud.com`、
+    /// `https://mybucket.oss-cn-hangzhou.aliyuncs.com`、`https://mybucket.s3.bitiful.net`）。
+    /// 用户把它原样粘贴进 endpoint 并单独填写 bucket 后，SDK 的
+    /// virtual-hosted-style 寻址会再拼一次 bucket，产生
+    /// `mybucket.mybucket.cos…` 这样的域名，DNS 解析/TLS 证书直接失败，
+    /// 表现为"S3 存储无法被识别"。
+    ///
+    /// 归一化规则（全部是纯字符串变换，不发网络请求）：
+    /// 1. 去除首尾空白与尾部 `/`；
+    /// 2. 缺少 scheme 时补 `https://`（控制台复制的域名通常不带 scheme）；
+    /// 3. host 以 `{bucket}.` 开头、且剥离后剩余部分仍是至少三段的服务域名
+    ///    （如 `cos.ap-beijing.myqcloud.com`）时剥离该前缀，交由 SDK 重新拼接
+    ///    （IP/localhost 不做剥离，两段域名保守跳过以免误伤真实端点）；
+    /// 4. path 以 `/{bucket}` 结尾时剥离（path-style 形式的控制台地址）。
+    ///
+    /// 未触发第 3/4 条时原样返回（仅做 trim/补 scheme），确保已能工作的配置
+    /// 的 endpoint 字符串与 instance_binding_hint 完全不变。
+    fn normalize_endpoint(endpoint: &str, bucket: &str) -> String {
+        let trimmed = endpoint.trim().trim_end_matches('/');
+        let with_scheme = if trimmed.contains("://") {
+            trimmed.to_string()
+        } else {
+            format!("https://{trimmed}")
+        };
+
+        let bucket = bucket.trim();
+        if bucket.is_empty() {
+            return with_scheme;
+        }
+        let Ok(mut url) = url::Url::parse(&with_scheme) else {
+            return with_scheme;
+        };
+
+        let mut changed = false;
+
+        // 剥离 host 前缀 "{bucket}."（仅域名；IP/localhost 不适用 virtual-host 寻址）
+        if let Some(url::Host::Domain(host)) = url.host() {
+            let host = host.to_string();
+            if let Some(rest) = host.strip_prefix(&format!("{bucket}.")) {
+                let rest = rest.to_string();
+                if rest.matches('.').count() >= 2 && url.set_host(Some(&rest)).is_ok() {
+                    tracing::info!(
+                        "[CloudStorage::S3] endpoint 中检测到 bucket 前缀域名，已归一化为服务端点: {} -> {}",
+                        host,
+                        rest
+                    );
+                    changed = true;
+                }
+            }
+        }
+
+        // 剥离 path 尾部 "/{bucket}"
+        let path = url.path().trim_end_matches('/').to_string();
+        if let Some(rest) = path.strip_suffix(&format!("/{bucket}")) {
+            url.set_path(if rest.is_empty() { "/" } else { rest });
+            tracing::info!(
+                "[CloudStorage::S3] endpoint 路径中检测到 bucket 后缀，已归一化: {} -> {}",
+                path,
+                url.path()
+            );
+            changed = true;
+        }
+
+        if changed {
+            url.to_string().trim_end_matches('/').to_string()
+        } else {
+            with_scheme
+        }
+    }
+
     /// 创建 S3 存储实例
     pub async fn new(config: S3Config, root: String) -> Result<Self> {
         if config.endpoint.trim().is_empty() {
@@ -36,6 +109,8 @@ impl S3Storage {
         if config.bucket.trim().is_empty() {
             return Err(AppError::validation("S3 bucket 不能为空"));
         }
+
+        let endpoint = Self::normalize_endpoint(&config.endpoint, &config.bucket);
 
         // 构建凭证提供者
         let credentials = aws_sdk_s3::config::Credentials::new(
@@ -48,7 +123,7 @@ impl S3Storage {
 
         let mut s3_config_builder = aws_sdk_s3::Config::builder()
             .credentials_provider(credentials)
-            .endpoint_url(&config.endpoint)
+            .endpoint_url(&endpoint)
             .timeout_config(
                 // [P0-6/F10] 显式超时：避免 TCP 半开/对端无响应时整个同步流程无限挂起。
                 // connect 30s 建连上限；operation_attempt 120s 单次尝试上限（大对象走
@@ -88,7 +163,7 @@ impl S3Storage {
 
         Ok(Self {
             client,
-            endpoint: config.endpoint.trim().trim_end_matches('/').to_string(),
+            endpoint,
             bucket: config.bucket,
             root: root.trim_matches('/').to_string(),
         })
@@ -565,5 +640,124 @@ impl CloudStorage for S3Storage {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// [#57 回归] 腾讯云 COS / 阿里云 OSS / 缤纷云 S4 控制台展示的是带
+    /// bucket 前缀的访问域名；原样粘贴 + 单独填写 bucket 会让 SDK 的
+    /// virtual-hosted-style 寻址拼出 `bucket.bucket.…` 域名，DNS/TLS 直接失败。
+    #[test]
+    fn normalize_endpoint_strips_bucket_prefixed_host() {
+        // 腾讯云 COS：bucket 命名带 APPID 后缀
+        assert_eq!(
+            S3Storage::normalize_endpoint(
+                "https://mybucket-1250000000.cos.ap-beijing.myqcloud.com",
+                "mybucket-1250000000"
+            ),
+            "https://cos.ap-beijing.myqcloud.com"
+        );
+        // 阿里云 OSS
+        assert_eq!(
+            S3Storage::normalize_endpoint(
+                "https://mybucket.oss-cn-hangzhou.aliyuncs.com/",
+                "mybucket"
+            ),
+            "https://oss-cn-hangzhou.aliyuncs.com"
+        );
+        // 缤纷云 S4
+        assert_eq!(
+            S3Storage::normalize_endpoint("https://mybucket.s3.bitiful.net", "mybucket"),
+            "https://s3.bitiful.net"
+        );
+        // AWS 官方 virtual-host 域名同样归一化回服务端点
+        assert_eq!(
+            S3Storage::normalize_endpoint(
+                "https://mybucket.s3.us-east-1.amazonaws.com",
+                "mybucket"
+            ),
+            "https://s3.us-east-1.amazonaws.com"
+        );
+    }
+
+    #[test]
+    fn normalize_endpoint_adds_https_scheme_and_trims() {
+        // 控制台复制的域名通常不带 scheme
+        assert_eq!(
+            S3Storage::normalize_endpoint("  cos.ap-beijing.myqcloud.com  ", "mybucket"),
+            "https://cos.ap-beijing.myqcloud.com"
+        );
+        // 带 scheme + 尾部斜杠 + 空白：只做清理，不改动其余部分
+        assert_eq!(
+            S3Storage::normalize_endpoint(" https://s3.example.com/ ", "b"),
+            "https://s3.example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_endpoint_strips_bucket_path_suffix() {
+        // path-style 形式的控制台地址
+        assert_eq!(
+            S3Storage::normalize_endpoint(
+                "https://cos.ap-beijing.myqcloud.com/mybucket",
+                "mybucket"
+            ),
+            "https://cos.ap-beijing.myqcloud.com"
+        );
+        // 保留 bucket 之外的基础路径
+        assert_eq!(
+            S3Storage::normalize_endpoint("https://gw.example.com/s3/mybucket", "mybucket"),
+            "https://gw.example.com/s3"
+        );
+    }
+
+    #[test]
+    fn normalize_endpoint_keeps_canonical_endpoints_untouched() {
+        // 正常服务端点：host 不以 bucket 开头，原样保留
+        assert_eq!(
+            S3Storage::normalize_endpoint("https://cos.ap-beijing.myqcloud.com", "mybucket"),
+            "https://cos.ap-beijing.myqcloud.com"
+        );
+        // Cloudflare R2 账户端点不受影响
+        assert_eq!(
+            S3Storage::normalize_endpoint(
+                "https://0123456789abcdef.r2.cloudflarestorage.com",
+                "mybucket"
+            ),
+            "https://0123456789abcdef.r2.cloudflarestorage.com"
+        );
+        // 未触发归一化时字符串完全不变（大小写等原样），
+        // 保证 instance_binding_hint 对既有可用配置保持稳定
+        assert_eq!(
+            S3Storage::normalize_endpoint("https://MinIO.Example.com:9000", "mybucket"),
+            "https://MinIO.Example.com:9000"
+        );
+    }
+
+    #[test]
+    fn normalize_endpoint_conservative_cases() {
+        // IP / localhost 不适用 virtual-host 寻址，不剥离
+        assert_eq!(
+            S3Storage::normalize_endpoint("http://127.0.0.1:9000", "127"),
+            "http://127.0.0.1:9000"
+        );
+        assert_eq!(
+            S3Storage::normalize_endpoint("http://localhost:9000", "localhost"),
+            "http://localhost:9000"
+        );
+        // 剥离后只剩两段域名：保守跳过，避免误伤真实端点
+        // （如 bucket 恰好叫 "s3"、端点是 s3.bitiful.net 的情况）
+        assert_eq!(
+            S3Storage::normalize_endpoint("https://s3.bitiful.net", "s3"),
+            "https://s3.bitiful.net"
+        );
+        // bucket 为空时只做 trim/补 scheme
+        assert_eq!(
+            S3Storage::normalize_endpoint("https://s3.example.com", ""),
+            "https://s3.example.com"
+        );
     }
 }

--- a/src-tauri/src/cloud_storage/webdav.rs
+++ b/src-tauri/src/cloud_storage/webdav.rs
@@ -425,11 +425,7 @@ impl WebDavStorage {
         // 再把 href 路径与 base 路径统一解码成人类可读形式后比较。
         let raw_path = match Url::parse(href) {
             Ok(url) => url.path().to_string(),
-            Err(_) => href
-                .split(['?', '#'])
-                .next()
-                .unwrap_or(href)
-                .to_string(),
+            Err(_) => href.split(['?', '#']).next().unwrap_or(href).to_string(),
         };
         let href_path = Self::decode_path(&raw_path);
 
@@ -1112,10 +1108,8 @@ mod tests {
         )
         .expect("create storage");
 
-        let key = storage.extract_relative_key(
-            "/My%20Dav/sync%20root/objects/a%20b.txt",
-            "objects",
-        );
+        let key =
+            storage.extract_relative_key("/My%20Dav/sync%20root/objects/a%20b.txt", "objects");
         assert_eq!(key, "objects/a b.txt");
         // 解码后的 key 经 build_url 逐段推入时会被重新百分号编码
         assert_eq!(

--- a/src-tauri/src/cloud_storage/webdav.rs
+++ b/src-tauri/src/cloud_storage/webdav.rs
@@ -102,12 +102,15 @@ impl WebDavStorage {
     /// 构建完整 URL
     fn build_path_url(&self, path: &str) -> Result<Url> {
         let mut url = self.base_url.clone();
+        // [#57] base_url.path() 是百分号编码形式，而 path_segments_mut().push
+        // 会把 '%' 再转义一次——端点路径含编码字符（中文/空格）时所有请求 URL
+        // 被双重编码。先解码 base 片段，交由 push 统一做单次编码。
         let base_segments = url
             .path()
             .trim_matches('/')
             .split('/')
             .filter(|segment| !segment.is_empty())
-            .map(ToOwned::to_owned)
+            .map(Self::decode_path)
             .collect::<Vec<_>>();
         let remote_segments = path
             .trim_matches('/')
@@ -404,14 +407,35 @@ impl WebDavStorage {
         Ok(files)
     }
 
-    fn extract_relative_key(&self, href: &str, prefix: &str) -> String {
-        // URL 解码
-        let decoded = urlencoding::decode(href).unwrap_or_else(|_| href.into());
-        let href_path = Url::parse(&decoded)
-            .map(|url| url.path().to_string())
-            .unwrap_or_else(|_| decoded.to_string());
+    /// 对百分号编码的路径解码；解码失败（非法 UTF-8 等）时原样返回。
+    fn decode_path(path: &str) -> String {
+        urlencoding::decode(path)
+            .map(|decoded| decoded.into_owned())
+            .unwrap_or_else(|_| path.to_string())
+    }
 
-        let base_path = self.base_url.path().trim_end_matches('/');
+    fn extract_relative_key(&self, href: &str, prefix: &str) -> String {
+        // [#57] href 与 base_url.path() 必须在同一编码空间里比较。
+        // 旧实现先解码 href 再 Url::parse：绝对 URL 形式的 href 会被重新编码，
+        // 而 base_url.path() 始终是百分号编码形式——端点路径含非 ASCII/空格时
+        // （如坚果云中文同步文件夹 https://dav.jianguoyun.com/dav/我的坚果云/）
+        // strip_prefix 永不命中，列举结果被静默清空：上传（PUT）正常、
+        // 下载/双向同步看不到任何云端文件。
+        // 修复：先提取原始路径（绝对 URL 取 path，相对 href 去掉 query/fragment），
+        // 再把 href 路径与 base 路径统一解码成人类可读形式后比较。
+        let raw_path = match Url::parse(href) {
+            Ok(url) => url.path().to_string(),
+            Err(_) => href
+                .split(['?', '#'])
+                .next()
+                .unwrap_or(href)
+                .to_string(),
+        };
+        let href_path = Self::decode_path(&raw_path);
+
+        let base_path_encoded = self.base_url.path().trim_end_matches('/');
+        let base_path = Self::decode_path(base_path_encoded);
+        let base_path = base_path.trim_end_matches('/');
         let root = self.root.trim_matches('/');
         let root_path = match (base_path.is_empty(), root.is_empty()) {
             (true, true) => String::new(),
@@ -1017,6 +1041,141 @@ mod tests {
             "backups/one.zip"
         );
         assert_eq!(storage.root, "");
+    }
+
+    /// [#57 回归] 坚果云中文同步文件夹：endpoint 路径含非 ASCII 字符时，
+    /// `Url` 内部保存百分号编码形式，而服务器返回的 href 同样是编码形式。
+    /// 两侧必须统一解码后比较，否则所有文件被静默丢弃——
+    /// 上传正常、下载/双向同步永远列举到 0 个文件。
+    #[test]
+    fn extract_relative_key_decodes_non_ascii_endpoint_path() {
+        let storage = WebDavStorage::new(
+            WebDavConfig {
+                endpoint: "https://dav.jianguoyun.com/dav/我的坚果云/".to_string(),
+                username: "user".to_string(),
+                password: "pass".to_string(),
+            },
+            "deep-student-sync".to_string(),
+        )
+        .expect("create storage");
+        // Url 内部把中文路径存成百分号编码
+        assert!(storage.base_url.path().contains('%'));
+
+        // 服务器返回编码的路径形式 href（多数 WebDAV 服务的行为）
+        assert_eq!(
+            storage.extract_relative_key(
+                "/dav/%E6%88%91%E7%9A%84%E5%9D%9A%E6%9E%9C%E4%BA%91/deep-student-sync/data_governance/changes/device-a/000000000001-1723372800-nonce.json.zst",
+                "data_governance/changes"
+            ),
+            "data_governance/changes/device-a/000000000001-1723372800-nonce.json.zst"
+        );
+
+        // 绝对 URL 形式 href（RFC 4918 同样允许）
+        assert_eq!(
+            storage.extract_relative_key(
+                "https://dav.jianguoyun.com/dav/%E6%88%91%E7%9A%84%E5%9D%9A%E6%9E%9C%E4%BA%91/deep-student-sync/manifests/device-a.json",
+                ""
+            ),
+            "manifests/device-a.json"
+        );
+
+        // 服务器直接返回未编码 UTF-8 href（部分自建 WebDAV 的行为）
+        assert_eq!(
+            storage.extract_relative_key(
+                "/dav/我的坚果云/deep-student-sync/backups/20260801.zip",
+                "backups"
+            ),
+            "backups/20260801.zip"
+        );
+
+        // 根目录自身应归一化为空 key
+        assert_eq!(
+            storage.extract_relative_key(
+                "/dav/%E6%88%91%E7%9A%84%E5%9D%9A%E6%9E%9C%E4%BA%91/deep-student-sync/",
+                ""
+            ),
+            ""
+        );
+    }
+
+    /// [#57 回归] endpoint 路径含空格（编码为 %20）时同样不能丢文件，
+    /// 且返回的 key 是解码后的形式，可直接交给 build_url 重新编码请求。
+    #[test]
+    fn extract_relative_key_decodes_space_in_endpoint_path() {
+        let storage = WebDavStorage::new(
+            WebDavConfig {
+                endpoint: "http://localhost:8080/My%20Dav/".to_string(),
+                username: "user".to_string(),
+                password: "pass".to_string(),
+            },
+            "sync root".to_string(),
+        )
+        .expect("create storage");
+
+        let key = storage.extract_relative_key(
+            "/My%20Dav/sync%20root/objects/a%20b.txt",
+            "objects",
+        );
+        assert_eq!(key, "objects/a b.txt");
+        // 解码后的 key 经 build_url 逐段推入时会被重新百分号编码
+        assert_eq!(
+            storage.build_url(&key).unwrap().path(),
+            "/My%20Dav/sync%20root/objects/a%20b.txt"
+        );
+    }
+
+    /// [#57 回归] 端到端：解析坚果云风格（编码 href + Depth:1）的 PROPFIND
+    /// multistatus，非 ASCII endpoint 路径下必须能发现子目录并提取文件 key。
+    #[test]
+    fn parse_propfind_entries_with_encoded_hrefs_lists_files_and_subdirs() {
+        let storage = WebDavStorage::new(
+            WebDavConfig {
+                endpoint: "https://dav.jianguoyun.com/dav/我的坚果云/".to_string(),
+                username: "user".to_string(),
+                password: "pass".to_string(),
+            },
+            "deep-student-sync".to_string(),
+        )
+        .expect("create storage");
+
+        let base = "/dav/%E6%88%91%E7%9A%84%E5%9D%9A%E6%9E%9C%E4%BA%91/deep-student-sync";
+        let xml = format!(
+            r#"<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>{base}/data_governance/changes/</d:href>
+    <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop>
+    <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>{base}/data_governance/changes/device-a/</d:href>
+    <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop>
+    <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>{base}/data_governance/changes/instance.json</d:href>
+    <d:propstat><d:prop>
+      <d:resourcetype/>
+      <d:getcontentlength>42</d:getcontentlength>
+      <d:getlastmodified>Fri, 07 Aug 2026 08:00:00 GMT</d:getlastmodified>
+    </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+</d:multistatus>"#
+        );
+
+        let (files, subdirs, response_count) = storage
+            .parse_propfind_entries(&xml, "data_governance/changes", "data_governance/changes")
+            .expect("parse entries");
+
+        assert_eq!(response_count, 3);
+        assert_eq!(
+            subdirs,
+            vec!["data_governance/changes/device-a".to_string()],
+            "编码 href 下必须仍能发现待递归的子目录"
+        );
+        assert_eq!(files.len(), 1, "编码 href 下文件不能被静默丢弃");
+        assert_eq!(files[0].key, "data_governance/changes/instance.json");
+        assert_eq!(files[0].size, 42);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

推进 #57，且不重复 #169 的 FTP tombstone。

WebDAV：列举时 href/base 编码不一致，含非 ASCII/空格的同步目录会让 `strip_prefix` 永不命中，下载/双向同步看到 0 个文件。改为两侧统一解码后再比较，并修正 `build_path_url` 双重编码。

S3：用户粘贴带 bucket 前缀的访问域名后再填 bucket，SDK 会拼出 `bucket.bucket.…`。新增 `normalize_endpoint` 剥离 host/path 上的重复 bucket；未触发时原样返回。

未改 `ftp.rs` / tombstone manifest。若与 #169 的清单解析叠加，合并时应先合 #169 再 rebase。

### Changes
- `cloud_storage/webdav.rs`：列举路径解码归一化、build_path_url 单次编码
- `cloud_storage/s3.rs`：endpoint 归一化

### How to test
- 坚果云等中文/空格目录：下载与双向应能看到已上传文件
- 腾讯云/阿里云控制台访问域名 + 单独 bucket：应能连上，不再 `bucket.bucket`

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

