### PR TITLE
fix(reasoning): gpt-5.6 保留 max 档

### DIFF
--- a/src-tauri/src/llm_manager/adapters/generic_openai.rs
+++ b/src-tauri/src/llm_manager/adapters/generic_openai.rs
@@ -25,7 +25,7 @@ use serde_json::{json, Map, Value};
 /// 处理标准 OpenAI Chat Completions API 格式的推理参数：
 /// - `reasoning_effort`: "none" | "minimal" | "low" | "medium" | "high" | "xhigh"（顶级参数）
 /// - `verbosity`: "low" | "medium" | "high"（顶级参数）
-/// - 供应商侧的 enabled/disabled/adaptive/max 会归一到标准 effort
+/// - 供应商侧的 enabled/disabled/adaptive/max 会归一到标准 effort（GPT-5.6 原生支持 max，保留透传）
 /// - toggle-only 配置会归一为 medium/none，避免向反代发送供应商原生字段
 pub struct GenericOpenAIAdapter;
 
@@ -88,6 +88,26 @@ impl GenericOpenAIAdapter {
             "xhigh" | "max" => Some("xhigh"),
             _ => None,
         }
+    }
+
+    /// GPT-5.6 家族（gpt-5.6 / gpt-5.6-sol|terra|luna，含 `vendor/` 前缀形态）。
+    /// 尾部必须是版本边界，避免误伤未来的 gpt-5.60 之类 id。
+    fn is_gpt56_model(config: &ApiConfig) -> bool {
+        let model = config.model.trim().to_lowercase();
+        model
+            .rsplit('/')
+            .next()
+            .and_then(|segment| segment.strip_prefix("gpt-5.6"))
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with(['.', '-', '_']))
+    }
+
+    /// GPT-5.6 原生支持高于 xhigh 的 max 档，必须透传；
+    /// 其他模型仍将 max 归一为标准 xhigh。
+    fn normalize_effort_for_model(config: &ApiConfig, effort: &str) -> Option<&'static str> {
+        if effort.trim().eq_ignore_ascii_case("max") && Self::is_gpt56_model(config) {
+            return Some("max");
+        }
+        Self::normalize_standard_effort(effort)
     }
 
     fn effort_from_budget(budget: i32) -> &'static str {
@@ -276,7 +296,7 @@ impl RequestAdapter for GenericOpenAIAdapter {
                     body.remove("reasoning_effort");
                     body.remove("reasoning");
                     early_return = true;
-                } else if let Some(normalized) = Self::normalize_standard_effort(effort) {
+                } else if let Some(normalized) = Self::normalize_effort_for_model(config, effort) {
                     if normalized == "none" {
                         // 显式关闭语义必须透传 none；Responses 适配器会保留嵌套格式。
                         Self::insert_reasoning_effort(body, config, "none");
@@ -463,6 +483,94 @@ mod tests {
             };
             let mut body = Map::new();
             adapter.apply_reasoning_config(&mut body, &config, None);
+            assert_eq!(
+                body.get("reasoning_effort"),
+                Some(&json!(expected)),
+                "input={input}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_gpt56_preserves_max_reasoning_effort() {
+        let adapter = GenericOpenAIAdapter;
+
+        for model in ["gpt-5.6", "gpt-5.6-sol", "openai/gpt-5.6", "GPT-5.6-Terra"] {
+            let config = ApiConfig {
+                model: model.to_string(),
+                reasoning_effort: Some("max".to_string()),
+                ..Default::default()
+            };
+            let mut body = Map::new();
+            body.insert("temperature".to_string(), json!(0.7));
+
+            adapter.apply_reasoning_config(&mut body, &config, None);
+
+            assert_eq!(
+                body.get("reasoning_effort"),
+                Some(&json!("max")),
+                "model={model}"
+            );
+            // max 仍是启用推理的档位，采样参数照常移除
+            assert!(!body.contains_key("temperature"), "model={model}");
+        }
+    }
+
+    #[test]
+    fn test_gpt56_openrouter_nested_dialect_preserves_max() {
+        let adapter = GenericOpenAIAdapter;
+        let config = ApiConfig {
+            provider_type: Some("openrouter".to_string()),
+            base_url: "https://openrouter.ai/api/v1".to_string(),
+            model: "openai/gpt-5.6".to_string(),
+            reasoning_effort: Some("max".to_string()),
+            ..Default::default()
+        };
+        let mut body = Map::new();
+
+        adapter.apply_reasoning_config(&mut body, &config, None);
+
+        assert_eq!(body["reasoning"]["effort"], json!("max"));
+        assert!(!body.contains_key("reasoning_effort"));
+    }
+
+    #[test]
+    fn test_non_gpt56_models_still_normalize_max_to_xhigh() {
+        let adapter = GenericOpenAIAdapter;
+
+        // gpt-5.60 是版本边界护栏用例，不属于 5.6 家族
+        for model in ["gpt-5.5", "gpt-5.4-mini", "gpt-5.60", "o3"] {
+            let config = ApiConfig {
+                model: model.to_string(),
+                reasoning_effort: Some("max".to_string()),
+                ..Default::default()
+            };
+            let mut body = Map::new();
+
+            adapter.apply_reasoning_config(&mut body, &config, None);
+
+            assert_eq!(
+                body.get("reasoning_effort"),
+                Some(&json!("xhigh")),
+                "model={model}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_gpt56_non_max_efforts_keep_standard_normalization() {
+        let adapter = GenericOpenAIAdapter;
+
+        for (input, expected) in [("xhigh", "xhigh"), ("adaptive", "medium"), ("high", "high")] {
+            let config = ApiConfig {
+                model: "gpt-5.6".to_string(),
+                reasoning_effort: Some(input.to_string()),
+                ..Default::default()
+            };
+            let mut body = Map::new();
+
+            adapter.apply_reasoning_config(&mut body, &config, None);
+
             assert_eq!(
                 body.get("reasoning_effort"),
                 Some(&json!(expected)),

--- a/src/features/settings/components/__tests__/deepseekReasoningControls.test.ts
+++ b/src/features/settings/components/__tests__/deepseekReasoningControls.test.ts
@@ -23,4 +23,12 @@ describe('DeepSeek reasoning control mapping', () => {
     expect(control.kind).toBe('v32-budget-effort');
     expect(control.options.map((option) => option.value)).toEqual(['low', 'medium', 'high', 'xhigh']);
   });
+
+  it('exposes the native max depth for GPT-5.6 settings controls', () => {
+    const control = resolveDeepSeekReasoningControl('gpt-5.6', false);
+
+    expect(control.kind).toBe('openai-effort');
+    expect(control.options.map((option) => option.value)).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+    expect(control.canDisable).toBe(true);
+  });
 });

--- a/src/utils/__tests__/deepseekReasoningControls.test.ts
+++ b/src/utils/__tests__/deepseekReasoningControls.test.ts
@@ -26,6 +26,9 @@ describe('DeepSeek runtime reasoning controls', () => {
     ['gpt-oss-120b', 'openai-compatible', ['low', 'medium', 'high'], false],
     ['gpt-5.1', 'openai', ['low', 'medium', 'high'], true],
     ['gpt-5.5', 'openai_codex', ['low', 'medium', 'high', 'xhigh'], false],
+    ['gpt-5.6', 'openai', ['low', 'medium', 'high', 'xhigh', 'max'], true],
+    ['gpt-5.6-sol', 'openai_codex', ['low', 'medium', 'high', 'xhigh', 'max'], false],
+    ['gpt-5.6-terra', 'openai_codex', ['low', 'medium', 'high', 'xhigh', 'max'], false],
     ['codex-mini-latest', 'openai_codex', ['low', 'medium', 'high'], false],
     ['gpt-5', 'openai_codex', ['minimal', 'low', 'medium', 'high'], false],
   ] as const)('crops OpenAI/Codex effort levels for %s', (model, providerType, values, canDisable) => {
@@ -234,6 +237,26 @@ describe('DeepSeek runtime reasoning controls', () => {
         thinkingBudget: 32768,
       })
     ).toEqual({ enableThinking: true, reasoningEffort: 'xhigh', thinkingBudget: undefined });
+  });
+
+  it('keeps the max runtime depth for GPT-5.6 instead of falling back', () => {
+    expect(
+      resolveDeepSeekRuntimeReasoningSelection({
+        control: resolveDeepSeekRuntimeReasoningControl({ model: 'gpt-5.6', providerType: 'openai' }),
+        enableThinking: true,
+        reasoningEffort: 'max',
+        thinkingBudget: 32768,
+      })
+    ).toEqual({ enableThinking: true, reasoningEffort: 'max', thinkingBudget: undefined });
+
+    // 非 5.6 的 GPT-5 系列不认识 max，仍回退到 medium
+    expect(
+      resolveDeepSeekRuntimeReasoningSelection({
+        control: resolveDeepSeekRuntimeReasoningControl({ model: 'gpt-5.5', providerType: 'openai' }),
+        enableThinking: true,
+        reasoningEffort: 'max',
+      })
+    ).toEqual({ enableThinking: true, reasoningEffort: 'medium', thinkingBudget: undefined });
   });
 
   it('clears versioned runtime depth fields for toggle-only models', () => {

--- a/src/utils/deepseekReasoningControls.ts
+++ b/src/utils/deepseekReasoningControls.ts
@@ -68,6 +68,12 @@ const OPENAI_CODEX_EFFORT_OPTIONS: DeepSeekReasoningOption[] = [
   { value: 'xhigh', labelKey: 'settings:api.modal.reasoning.effort.xhigh', defaultLabel: 'XHigh' },
 ];
 
+/** GPT-5.6 在 xhigh 之上原生支持 max 档，不能复用 codex 档位表。 */
+const GPT56_EFFORT_OPTIONS: DeepSeekReasoningOption[] = [
+  ...OPENAI_CODEX_EFFORT_OPTIONS,
+  { value: 'max', labelKey: 'settings:api.modal.deepseek.depth.max', defaultLabel: 'Max' },
+];
+
 const LOW_HIGH_EFFORT_OPTIONS: DeepSeekReasoningOption[] = [
   { value: 'low', labelKey: 'settings:api.modal.reasoning.effort.low', defaultLabel: 'Low' },
   { value: 'high', labelKey: 'settings:api.modal.reasoning.effort.high', defaultLabel: 'High' },
@@ -332,6 +338,13 @@ function resolveOpenAiEffortControl(
       kind: 'openai-effort',
       options: MINIMAL_LOW_MEDIUM_HIGH_EFFORT_OPTIONS,
       canDisable: false,
+    });
+  }
+  if (/gpt-5\.6(?:[.\-_/]|$)/.test(modelId)) {
+    return finalize({
+      kind: 'openai-effort',
+      options: GPT56_EFFORT_OPTIONS,
+      canDisable: true,
     });
   }
   if (/gpt-5\.[45](?:[.\-_/]|$)/.test(modelId)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

GPT-5.6 的 `reasoning_effort` 官方含 max，但前端兜底只有 low/medium/high/xhigh，后端 `normalize_standard_effort` 还会把 max 收成 xhigh。本 PR 给 5.6 专属档位并在适配器里保留 max。

未改 #170 mythos、#171 小上下文、K3（另开）、CI、sync。注意与 K3 切片都改了 `deepseekReasoningControls.ts`，合入时需 rebase。

### Changes
- `deepseekReasoningControls.ts`：gpt-5.6 选项含 max
- `generic_openai.rs`：5.6 不把 max 归一成 xhigh
- 前后端测试

### How to test
- `npx vitest run src/utils/__tests__/deepseekReasoningControls.test.ts`
- 对应 Rust adapter 测试

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

