### PR TITLE
fix(moonshot): K3 推理档位前后端对齐

### DIFF
--- a/src-tauri/src/llm_manager/adapters/moonshot.rs
+++ b/src-tauri/src/llm_manager/adapters/moonshot.rs
@@ -596,7 +596,11 @@ mod tests {
     #[test]
     fn test_k3_forces_reasoning_effort_max() {
         let adapter = MoonshotAdapter;
-        for model in ["kimi-k3", "kimi-k3-0905-preview", "moonshotai/Kimi-K3-Instruct"] {
+        for model in [
+            "kimi-k3",
+            "kimi-k3-0905-preview",
+            "moonshotai/Kimi-K3-Instruct",
+        ] {
             let config = ApiConfig {
                 model: model.to_string(),
                 ..Default::default()

--- a/src-tauri/src/llm_manager/adapters/moonshot.rs
+++ b/src-tauri/src/llm_manager/adapters/moonshot.rs
@@ -378,7 +378,12 @@ mod tests {
         assert!(MoonshotAdapter::is_k25_or_later("kimi-k2.6"));
         assert!(MoonshotAdapter::is_k25_or_later("kimi-k2.7-code"));
         assert!(MoonshotAdapter::is_k25_or_later("kimi-k2.10"));
-        assert!(MoonshotAdapter::is_k25_or_later("kimi-k3"));
+
+        // K3+ 走独立路径（is_k3_or_later），不属于 K2.x 新代际
+        assert!(!MoonshotAdapter::is_k25_or_later("kimi-k3"));
+        assert!(MoonshotAdapter::is_k3_or_later("kimi-k3"));
+        assert!(MoonshotAdapter::is_k3_or_later("kimi-k3-0905-preview"));
+        assert!(!MoonshotAdapter::is_k3_or_later("kimi-k2.7-code"));
 
         // 旧代际不命中
         assert!(!MoonshotAdapter::is_k25_or_later("kimi-k2"));

--- a/src-tauri/src/llm_manager/adapters/moonshot.rs
+++ b/src-tauri/src/llm_manager/adapters/moonshot.rs
@@ -586,6 +586,38 @@ mod tests {
         }
     }
 
+    // ========== K3+ 测试用例 ==========
+
+    #[test]
+    fn test_k3_forces_reasoning_effort_max() {
+        let adapter = MoonshotAdapter;
+        for model in ["kimi-k3", "kimi-k3-0905-preview", "moonshotai/Kimi-K3-Instruct"] {
+            let config = ApiConfig {
+                model: model.to_string(),
+                ..Default::default()
+            };
+            let mut body = Map::new();
+            body.insert("thinking".to_string(), json!({"type": "enabled"}));
+            body.insert("enable_thinking".to_string(), json!(false));
+            body.insert("thinking_budget".to_string(), json!(8192));
+
+            // 即使外部尝试禁用，K3 推理也不可关闭（与前端 canDisable=false 对齐）
+            let handled = adapter.apply_reasoning_config(&mut body, &config, Some(false));
+
+            assert!(handled, "model: {}", model);
+            // 服务端拒绝 K2.x thinking 对象，必须整体移除
+            assert!(!body.contains_key("thinking"), "model: {}", model);
+            assert!(!body.contains_key("enable_thinking"), "model: {}", model);
+            assert!(!body.contains_key("thinking_budget"), "model: {}", model);
+            assert_eq!(
+                body.get("reasoning_effort"),
+                Some(&json!("max")),
+                "model: {}",
+                model
+            );
+        }
+    }
+
     #[test]
     fn test_legacy_k2_not_treated_as_new_gen() {
         let adapter = MoonshotAdapter;

--- a/src/utils/__tests__/deepseekReasoningControls.test.ts
+++ b/src/utils/__tests__/deepseekReasoningControls.test.ts
@@ -173,6 +173,7 @@ describe('DeepSeek runtime reasoning controls', () => {
   it.each([
     'gpt-5.3-codex',
     'gemini-2.5-pro',
+    'kimi-k3',
     'kimi-k2.7-code',
     'kimi-k2-thinking',
     'kimi-thinking-preview',
@@ -200,6 +201,33 @@ describe('DeepSeek runtime reasoning controls', () => {
     'kimi-k2.6',
     'MiniMax-M3',
   ])('keeps modern adaptive thinking models disableable: %s', (model) => {
+    expect(resolveDeepSeekRuntimeReasoningControl({ model }).canDisable).toBe(true);
+  });
+
+  // 后端 moonshot 适配器对 K3+ 固定发送 reasoning_effort=max 且推理不可关闭；
+  // 前端必须 forced（canDisable=false），且不发明后端不接受的档位选项。
+  it.each([
+    'kimi-k3',
+    'kimi-k3-0905-preview',
+    'moonshotai/Kimi-K3-Instruct',
+    'kimi-k3.1',
+  ])('aligns Kimi K3+ with the backend forced reasoning_effort=max contract: %s', (model) => {
+    const control = resolveDeepSeekRuntimeReasoningControl({ model });
+
+    expect(control.kind).toBe('toggle-only');
+    expect(control.options).toEqual([]);
+    expect(control.canDisable).toBe(false);
+    expect(
+      resolveDeepSeekRuntimeReasoningSelection({ control, enableThinking: false })
+    ).toEqual({ enableThinking: true, reasoningEffort: undefined, thinkingBudget: undefined });
+  });
+
+  it.each([
+    'kimi-k2.6',
+    'kimi-k2-0905-preview',
+    'kimi-latest',
+    'moonshot-v1-128k',
+  ])('does not misclassify non-K3 Kimi/Moonshot models as forced K3: %s', (model) => {
     expect(resolveDeepSeekRuntimeReasoningControl({ model }).canDisable).toBe(true);
   });
 

--- a/src/utils/deepseekReasoningControls.ts
+++ b/src/utils/deepseekReasoningControls.ts
@@ -276,6 +276,21 @@ function isLegacyKimiForcedThinkingModelId(modelId: string): boolean {
   );
 }
 
+/**
+ * Kimi K3+：后端 moonshot 适配器固定发送 `reasoning_effort: "max"`，推理不可关闭
+ * （registry quirk：不得发送 K2.x thinking 对象）。前端必须视为 forced（canDisable=false）。
+ *
+ * 版本解析与后端 `MoonshotAdapter::parse_k_version` 对齐：取模型名中首个
+ * `k<major>` 版本号，且 `k` 前必须是开头或非字母数字边界（避免 `grok`、`128k`
+ * 之类误判）。后端适配器仅在 moonshot 供应商下生效，前端没有供应商上下文，
+ * 因此额外要求模型名包含 kimi/moonshot。
+ */
+function isKimiK3OrLaterModelId(modelId: string): boolean {
+  if (!modelId.includes('kimi') && !modelId.includes('moonshot')) return false;
+  const match = modelId.match(/(?:^|[^a-z0-9])k(\d+)/);
+  return !!match && Number(match[1]) >= 3;
+}
+
 function isForcedThinkingModelId(modelId: string): boolean {
   if (
     isGemini3ModelId(modelId) ||
@@ -289,6 +304,7 @@ function isForcedThinkingModelId(modelId: string): boolean {
     /gpt-5(?:\.[0-9]+)?-pro(?:[.\-_/]|$)/.test(modelId)
   ) return true;
   if (
+    isKimiK3OrLaterModelId(modelId) ||
     (modelId.includes('kimi-k2.7') && modelId.includes('code')) ||
     isLegacyKimiForcedThinkingModelId(modelId)
   ) return true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

后端 `moonshot.rs` 对 K3 无条件发送 `reasoning_effort=max`，前端却走可关闭的 toggle。本 PR 让前端 K3 为 forced、`canDisable=false`，并补后端对齐测试。

未改 #170/#171、gpt-5.6 max（另开）、CI、sync。与 gpt-5.6 切片都改了 `deepseekReasoningControls.ts`，合入时需 rebase。

### Changes
- 前端 K3 推理控件 forced
- moonshot 适配器测试
- `deepseekReasoningControls` 测试

### How to test
- `npx vitest run src/utils/__tests__/deepseekReasoningControls.test.ts`

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

