### PR TITLE
fix(chat): 流中断时把上游终态错误传到孤儿 preparing 块

### DIFF
--- a/src/features/chat/adapters/TauriAdapter.ts
+++ b/src/features/chat/adapters/TauriAdapter.ts
@@ -2367,8 +2367,9 @@ export class ChatV2TauriAdapter {
           // 流式错误 - 重置状态为 idle
           chunkBuffer.flushSession(this.sessionId);
           // 🔧 P2修复：先重置状态确保 UI 响应，再异步保存
-          this.store.completeStream('error');
+          // 先归一化再收尾，孤儿 preparing 块才能显示后端真实原因而不是通用兜底文案
           const streamError = normalizeStreamTerminalError(payload.error);
+          this.store.completeStream('error', streamError);
           this.store.updateMessageMeta(
             payload.messageId!,
             streamErrorMetaPatch(streamError),
@@ -2876,7 +2877,7 @@ export class ChatV2TauriAdapter {
       const errorMsg = getErrorMessage(error);
       console.error(LOG_PREFIX, 'Execute wake session failed:', errorMsg);
       this.store.updateMessageMeta(assistantMessageId, { terminalError: errorMsg });
-      this.store.completeStream('error');
+      this.store.completeStream('error', normalizeStreamTerminalError(error));
       showGlobalNotification('error', formatUserFacingError(
         error,
         'chatV2:error.sendFailed',
@@ -3603,7 +3604,7 @@ export class ChatV2TauriAdapter {
       console.error(LOG_PREFIX, 'Continue message failed:', errorMsg);
       // 清除流式状态
       // 🔧 修复：同时清除 stale currentStreamingMessageId（completeStream 在 idle 时不清除它）
-      this.store.completeStream('error');
+      this.store.completeStream('error', normalizeStreamTerminalError(error));
       this.store.setCurrentStreamingMessage(null);
       // 🔧 修复：不在此处显示通知，让 store.continueMessage 的 fallback（sendMessage）处理
       // 原代码在此显示 "继续执行失败" 通知，但 store 会 fallback 到 sendMessage('继续')，

--- a/src/features/chat/adapters/__tests__/TauriAdapter.errorChannel.test.ts
+++ b/src/features/chat/adapters/__tests__/TauriAdapter.errorChannel.test.ts
@@ -137,7 +137,10 @@ describe('ChatV2TauriAdapter error channel surfacing', () => {
       error: 'upstream stream setup failed',
     });
 
-    expect(store.completeStream).toHaveBeenCalledWith('error');
+    expect(store.completeStream).toHaveBeenCalledWith(
+      'error',
+      expect.stringMatching(/upstream stream setup failed/i),
+    );
     expect(showGlobalNotification).toHaveBeenCalledWith(
       'error',
       expect.stringMatching(/upstream stream setup failed|Load failed|加载失败/i),

--- a/src/features/chat/adapters/__tests__/TauriAdapter.streamComplete.test.ts
+++ b/src/features/chat/adapters/__tests__/TauriAdapter.streamComplete.test.ts
@@ -223,7 +223,11 @@ describe('ChatV2TauriAdapter stream_complete sequencing', () => {
     await vi.advanceTimersByTimeAsync(100);
 
     expect(store.completeStream).toHaveBeenCalledTimes(1);
-    expect(store.completeStream).toHaveBeenCalledWith(reason);
+    expect(store.completeStream).toHaveBeenCalledWith(
+      reason,
+      // stream_error 额外传入归一化后的终态错误，供孤儿 preparing 块展示
+      ...(reason === 'error' ? [expect.stringMatching(/connection failed/i)] : []),
+    );
     expect(store.completeStream).not.toHaveBeenCalledWith('success');
   });
 

--- a/src/features/chat/core/store/__tests__/streamActions.lifecycle.test.ts
+++ b/src/features/chat/core/store/__tests__/streamActions.lifecycle.test.ts
@@ -145,4 +145,92 @@ describe('completeStream lifecycle cleanup', () => {
       'Stream ended with error before tool execution',
     );
   });
+
+  it('surfaces the normalized terminal error on orphan preparing blocks', () => {
+    const preparing: Block = {
+      id: 'blk_prep',
+      type: 'mcp_tool',
+      status: 'pending',
+      messageId: 'msg_1',
+      toolName: 'load_skills',
+      isPreparing: true,
+    };
+    const msg = {
+      id: 'msg_1',
+      role: 'assistant',
+      blockIds: ['blk_prep'],
+    } as unknown as Message;
+
+    const harness = createHarness({
+      sessionStatus: 'streaming',
+      currentStreamingMessageId: 'msg_1',
+      blocks: new Map([['blk_prep', preparing]]),
+      messageMap: new Map([['msg_1', msg]]),
+    });
+
+    harness.actions.completeStream('error', 'Load failed: upstream 429 rate limit exceeded');
+
+    const block = harness.getState().blocks.get('blk_prep');
+    expect(block?.status).toBe('error');
+    expect(block?.isPreparing).toBe(false);
+    expect(block?.error).toBe('Load failed: upstream 429 rate limit exceeded');
+  });
+
+  it('falls back to the generic error wording when terminalError is blank', () => {
+    const preparing: Block = {
+      id: 'blk_prep',
+      type: 'mcp_tool',
+      status: 'pending',
+      messageId: 'msg_1',
+      toolName: 'load_skills',
+      isPreparing: true,
+    };
+    const msg = {
+      id: 'msg_1',
+      role: 'assistant',
+      blockIds: ['blk_prep'],
+    } as unknown as Message;
+
+    const harness = createHarness({
+      sessionStatus: 'streaming',
+      currentStreamingMessageId: 'msg_1',
+      blocks: new Map([['blk_prep', preparing]]),
+      messageMap: new Map([['msg_1', msg]]),
+    });
+
+    harness.actions.completeStream('error', '   ');
+
+    expect(harness.getState().blocks.get('blk_prep')?.error).toBe(
+      'Stream ended with error before tool execution',
+    );
+  });
+
+  it('ignores terminalError on the cancelled path', () => {
+    const preparing: Block = {
+      id: 'blk_prep',
+      type: 'mcp_tool',
+      status: 'pending',
+      messageId: 'msg_1',
+      toolName: 'load_skills',
+      isPreparing: true,
+    };
+    const msg = {
+      id: 'msg_1',
+      role: 'assistant',
+      blockIds: ['blk_prep'],
+    } as unknown as Message;
+
+    const harness = createHarness({
+      sessionStatus: 'streaming',
+      currentStreamingMessageId: 'msg_1',
+      blocks: new Map([['blk_prep', preparing]]),
+      messageMap: new Map([['msg_1', msg]]),
+    });
+
+    harness.actions.completeStream('cancelled', 'Load failed: upstream 429 rate limit exceeded');
+
+    expect(harness.getState().blocks.get('blk_prep')?.error).toBe(
+      'Stream cancelled before tool execution',
+    );
+  });
 });

--- a/src/features/chat/core/store/streamActions.ts
+++ b/src/features/chat/core/store/streamActions.ts
@@ -9,7 +9,10 @@ export function createStreamActions(
   getState: GetState,
 ) {
   return {
-        completeStream: (reason: 'success' | 'error' | 'cancelled' = 'success'): void => {
+        completeStream: (
+          reason: 'success' | 'error' | 'cancelled' = 'success',
+          terminalError?: string,
+        ): void => {
           const state = getState();
           // 🔧 P0修复：支持 streaming 和 aborting 状态
           // aborting 状态时，后端可能仍然发送 stream_complete/stream_error
@@ -108,6 +111,12 @@ export function createStreamActions(
             // 3. 清理仍停留在 preparing 的孤儿块（pending，不会被上面的 running 检查捕获）。
             // 文案必须跟 reason 一致：success 路径绝不能写 "cancelled"，否则会出现
             // 「加载技能组执行失败 / Stream cancelled…」闪红后再成功的误报。
+            // error 路径优先展示调用方传入的归一化终态错误，通用兜底文案会掩盖后端真实原因。
+            const normalizedTerminalError = terminalError?.trim();
+            const preparingErrorText =
+              reason === 'error'
+                ? normalizedTerminalError || 'Stream ended with error before tool execution'
+                : 'Stream cancelled before tool execution';
             const removedPreparingIds: string[] = [];
             for (const blockId of messageBlockIds) {
               const block = newBlocks.get(blockId);
@@ -127,10 +136,7 @@ export function createStreamActions(
                     ...block,
                     isPreparing: false,
                     status: 'error',
-                    error:
-                      reason === 'error'
-                        ? 'Stream ended with error before tool execution'
-                        : 'Stream cancelled before tool execution',
+                    error: preparingErrorText,
                     endedAt: now,
                   });
                 }

--- a/src/features/chat/core/types/store.ts
+++ b/src/features/chat/core/types/store.ts
@@ -679,8 +679,13 @@ export interface ChatStore {
    * 完成流式生成
    * 将 sessionStatus 重置为 idle，清理流式状态
    * @param reason - 完成原因：'success' 正常完成，'error' 流式错误，'cancelled' 用户取消
+   * @param terminalError - 归一化后的用户可见终态错误文本，仅 reason === 'error' 时生效；
+   *                        用于让孤儿 preparing 块显示后端真实原因，而不是通用兜底文案
    */
-  completeStream(reason?: 'success' | 'error' | 'cancelled'): void;
+  completeStream(
+    reason?: 'success' | 'error' | 'cancelled',
+    terminalError?: string,
+  ): void;
 
   // ========== 对话参数 Actions ==========
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

修复 #157：流在工具执行前失败时，孤儿 `preparing` 块不再只显示通用兜底文案 `Stream ended with error before tool execution`，而是展示适配器已经归一化的上游终态错误。

从 #158 厨房水槽中抽出的前端切片；不改 Rust / FTP / nightly / 夹具。

### Changes
- `completeStream('error', terminalError)` 把归一化错误传到 preparing 块
- `TauriAdapter` 在 stream_error / wake / continue 失败路径先归一化再收尾
- 补 lifecycle 契约测试

### How to test
- 单测：`streamActions.lifecycle`、`TauriAdapter.errorChannel`、`TauriAdapter.streamComplete`
- 手工：人为制造上游 429 / 余额不足，确认气泡不再只写通用英文兜底

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [x] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签；主干 Vitest / archive 基线仍红。此切片只修 #157 文案，不合入 #158 的其余范围。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

