### PR TITLE
fix(llm): 流错误保留数字 code 与上游原文

### DIFF
--- a/src-tauri/src/llm_manager/model2_pipeline.rs
+++ b/src-tauri/src/llm_manager/model2_pipeline.rs
@@ -993,6 +993,121 @@ mod tests {
     }
 
     #[test]
+    fn provider_failure_keeps_upstream_message_for_numeric_codes() {
+        // OpenRouter/中转站风格：code 是数字，旧实现的 as_str() 失配后丢掉原文
+        let message = provider_stream_failure_message(
+            &json!({
+                "type": "provider_error",
+                "reason": "stream_error",
+                "details": {
+                    "code": 429,
+                    "message": "Provider returned error: rate limit exceeded for gpt-5"
+                }
+            }),
+            false,
+            false,
+        );
+        assert!(message.contains("模型回复未完整结束"));
+        assert!(message.contains("rate limit exceeded for gpt-5"));
+    }
+
+    #[test]
+    fn provider_failure_falls_back_to_nested_and_top_level_messages() {
+        let nested = provider_stream_failure_message(
+            &json!({
+                "type": "provider_error",
+                "reason": "response.failed",
+                "details": { "error": { "message": "insufficient_quota: 余额不足" } }
+            }),
+            true,
+            false,
+        );
+        assert!(nested.contains("insufficient_quota: 余额不足"));
+
+        let top_level = provider_stream_failure_message(
+            &json!({
+                "type": "provider_error",
+                "message": "upstream gateway closed the connection"
+            }),
+            false,
+            false,
+        );
+        assert!(top_level.contains("upstream gateway closed the connection"));
+
+        let plain_details = provider_stream_failure_message(
+            &json!({
+                "type": "provider_error",
+                "reason": "stream_error",
+                "details": "Bad gateway"
+            }),
+            false,
+            false,
+        );
+        assert!(plain_details.contains("Bad gateway"));
+    }
+
+    #[test]
+    fn provider_failure_classifies_known_reasons_and_truncates_detail() {
+        let cancelled = provider_stream_failure_message(
+            &json!({
+                "type": "provider_error",
+                "reason": "response.cancelled",
+                "details": { "code": 499 }
+            }),
+            true,
+            true,
+        );
+        assert!(cancelled.contains("OpenAI Codex"));
+        assert!(cancelled.contains("上游取消"));
+
+        let filtered = provider_stream_failure_message(
+            &json!({
+                "type": "content_blocked",
+                "reason": "safety",
+                "stop_details": { "category": "self_harm" }
+            }),
+            false,
+            false,
+        );
+        assert!(filtered.contains("内容安全策略中止"));
+
+        // 上游把整段 HTML 塞进 message 时，只保留截断后的片段
+        let long_detail = format!("<html>{}</html>", "x".repeat(500));
+        let truncated = provider_stream_failure_message(
+            &json!({
+                "type": "provider_error",
+                "reason": "max_tokens",
+                "details": { "message": long_detail }
+            }),
+            false,
+            false,
+        );
+        assert!(truncated.contains("输出上限"));
+        assert!(truncated.contains("上游返回：<html>"));
+        assert!(truncated.ends_with("..."));
+        let detail_part = truncated
+            .rsplit("上游返回：")
+            .next()
+            .expect("appended detail must exist");
+        assert!(detail_part.chars().count() <= PROVIDER_STREAM_ERROR_DETAIL_MAX_CHARS + 3);
+    }
+
+    #[test]
+    fn provider_failure_without_upstream_message_keeps_plain_classification() {
+        let message = provider_stream_failure_message(
+            &json!({
+                "type": "provider_error",
+                "reason": "response.incomplete",
+                "details": { "reason": "max_output_tokens" }
+            }),
+            true,
+            false,
+        );
+        assert!(message.contains("输出上限"));
+        assert!(!message.contains("上游返回"));
+    }
+
+    #[test]
     fn test_sanitize_request_body_for_audit_redacts_user_profile() {
         let body = json!({
             "messages": [

--- a/src-tauri/src/llm_manager/model2_pipeline.rs
+++ b/src-tauri/src/llm_manager/model2_pipeline.rs
@@ -269,16 +269,73 @@ fn ensure_model_accepts_message_modalities(
     Ok(())
 }
 
+const PROVIDER_STREAM_ERROR_DETAIL_MAX_CHARS: usize = 200;
+
+/// 上游把 reason/code/message 写成字符串、数字或布尔的情况都存在，统一取标量文本。
+fn provider_stream_scalar_text(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::String(text) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        Value::Number(number) => Some(number.to_string()),
+        Value::Bool(flag) => Some(flag.to_string()),
+        _ => None,
+    }
+}
+
+fn provider_stream_error_detail(value: &Value) -> Option<String> {
+    let raw = provider_stream_scalar_text(value.pointer("/details/message"))
+        .or_else(|| provider_stream_scalar_text(value.pointer("/details/error/message")))
+        .or_else(|| provider_stream_scalar_text(value.get("details")))
+        .or_else(|| provider_stream_scalar_text(value.get("message")))
+        .or_else(|| provider_stream_scalar_text(value.pointer("/error/message")))?;
+
+    let collapsed = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() {
+        return None;
+    }
+    if collapsed.chars().count() > PROVIDER_STREAM_ERROR_DETAIL_MAX_CHARS {
+        let head: String = collapsed
+            .chars()
+            .take(PROVIDER_STREAM_ERROR_DETAIL_MAX_CHARS)
+            .collect();
+        Some(format!("{head}..."))
+    } else {
+        Some(collapsed)
+    }
+}
+
+fn provider_stream_failure_classification(prefix: &str, reason: &str) -> Option<String> {
+    match reason {
+        "max_output_tokens" | "max_tokens" => Some(format!(
+            "{prefix}（达到模型输出上限）；已保留已生成内容，可重试或发送“继续”"
+        )),
+        "response.cancelled" | "response.canceled" | "cancelled" | "canceled" => {
+            Some(format!("{prefix}（上游取消）；已保留已生成内容，可重试"))
+        }
+        "content_filter" | "safety" => {
+            Some(format!("{prefix}（内容安全策略中止）；已保留已生成内容"))
+        }
+        _ if reason.starts_with("response.incomplete") => {
+            Some(format!("{prefix}；已保留已生成内容，可重试或发送“继续”"))
+        }
+        _ => None,
+    }
+}
+
 fn provider_stream_failure_message(
     value: &Value,
     requires_explicit_completion: bool,
     is_codex: bool,
 ) -> String {
-    let terminal_reason = value.get("reason").and_then(Value::as_str);
-    let detail_reason = value
-        .pointer("/details/reason")
-        .and_then(Value::as_str)
-        .or_else(|| value.pointer("/details/code").and_then(Value::as_str));
+    let terminal_reason = provider_stream_scalar_text(value.get("reason"));
+    let detail_reason = provider_stream_scalar_text(value.pointer("/details/reason"))
+        .or_else(|| provider_stream_scalar_text(value.pointer("/details/code")));
     let prefix = if is_codex {
         "OpenAI Codex 回复未完整结束"
     } else if requires_explicit_completion {
@@ -287,20 +344,20 @@ fn provider_stream_failure_message(
         "模型回复未完整结束"
     };
 
-    match detail_reason.or(terminal_reason) {
-        Some("max_output_tokens" | "max_tokens") => {
-            format!("{prefix}（达到模型输出上限）；已保留已生成内容，可重试或发送“继续”")
-        }
-        Some("response.cancelled" | "response.canceled" | "cancelled" | "canceled") => {
-            format!("{prefix}（上游取消）；已保留已生成内容，可重试")
-        }
-        Some("content_filter" | "safety") => {
-            format!("{prefix}（内容安全策略中止）；已保留已生成内容")
-        }
-        Some(reason) if reason.starts_with("response.incomplete") => {
-            format!("{prefix}；已保留已生成内容，可重试或发送“继续”")
-        }
-        _ => format!("{prefix}；已保留已生成内容，可重试"),
+    // 数字状态码（如 details.code=499）无法分类，此时仍要回退到顶层 reason 的已知分类。
+    let classified = detail_reason
+        .as_deref()
+        .and_then(|reason| provider_stream_failure_classification(prefix, reason))
+        .or_else(|| {
+            terminal_reason
+                .as_deref()
+                .and_then(|reason| provider_stream_failure_classification(prefix, reason))
+        })
+        .unwrap_or_else(|| format!("{prefix}；已保留已生成内容，可重试"));
+
+    match provider_stream_error_detail(value) {
+        Some(detail) => format!("{classified}；上游返回：{detail}"),
+        None => classified,
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主干的 `provider_stream_failure_message` 只做原因分类，丢掉 OpenRouter/中转站数字 `code` 和上游 `message`。本 PR 从 #158 厨房水槽抽出实现 + 契约测试：标量文本、嵌套 `error.message`、200 字截断，并追加 `上游返回：…`。

与 #180（前端把终态错误传到 preparing 块）互补。不改 FTP / nightly / 前端。

### Changes
- `provider_stream_scalar_text` / `provider_stream_error_detail` / `provider_stream_failure_classification`
- 数字 status code 无法分类时回退顶层 `reason`
- 测试：429 数字 code、嵌套原文、纯字符串 details、安全拦截、超长 HTML 截断

### How to test
- `cargo test --manifest-path src-tauri/Cargo.toml provider_failure -- --nocapture`

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [x] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。#158 合入前应丢掉与本 PR 重复的 pipeline 改动。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

