### PR TITLE
chore(registry): 补录 2026-08 已核验的 Haiku 4.5 / Gemini lite / MiniMax-M2

### DIFF
--- a/scripts/model-capability-registry.json
+++ b/scripts/model-capability-registry.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-07-20",
-  "purpose": "持续维护模型能力、参数形态和适配注意事项，用于修正 chat-v2 适配器与模型能力推断实现。2026-07-20 刷新：新增 GPT-5.6、Kimi K3、Grok 4.5、Mistral Medium 3.5/Small 4、MiniMax M2.7，并修正 Claude 5、Doubao Evolving 等上下文能力。",
+  "updated_at": "2026-08-23",
+  "purpose": "持续维护模型能力、参数形态和适配注意事项，用于修正 chat-v2 适配器与模型能力推断实现。2026-08-23 增补：新增 claude-haiku-4-5、gemini-3.1-flash-lite、gemini-3.5-flash-lite、MiniMax-M2（均核验官方文档并附 source_url/verified_at）；claude-haiku-5 因官方未发布对应模型 ID 暂不收录。",
   "records": [
     {
       "vendor": "OpenAI",
@@ -808,6 +808,36 @@
           ]
         },
         {
+          "model_id": "claude-haiku-4-5",
+          "provider_model_id": "claude-haiku-4-5-20251001",
+          "release_date": "2025-10-15",
+          "status": "confirmed",
+          "source_url": "https://platform.claude.com/docs/en/about-claude/models/overview",
+          "verified_at": "2026-08-23",
+          "capabilities": {
+            "text": true,
+            "vision": true,
+            "audio": false,
+            "video": false,
+            "function_calling": true,
+            "reasoning": true,
+            "coding_agent": true,
+            "max_context_tokens": 200000,
+            "max_output_tokens": 64000
+          },
+          "param_format": {
+            "family": "anthropic_messages_native",
+            "required_fields": ["model", "messages", "max_tokens"],
+            "optional_fields": ["system", "tools", "tool_choice", "temperature", "top_p", "top_k", "thinking", "stream", "stream_options", "stop_sequences"],
+            "notes": "Haiku 产线现役型号；Claude API 别名 claude-haiku-4-5 指向日期版 claude-haiku-4-5-20251001（Bedrock：anthropic.claude-haiku-4-5-20251001-v1:0）。"
+          },
+          "quirks": [
+            "截至 2026-08-23，Anthropic 官方模型总览未发布 claude-haiku-5 的模型 ID，Haiku 产线最新官方型号即 4.5；前端 claude-haiku-5 规则暂无官方 registry 对应。",
+            "具备 context awareness（API 自动注入剩余 token budget 标签），客户端无需也不应自行发送相关标签。",
+            "输入支持文本与图像；不支持音频/视频输入（Bedrock 模型卡 2026-08-23 核验）。"
+          ]
+        },
+        {
           "model_id": "claude-opus-4-1",
           "release_date": "2025-06",
           "status": "confirmed",
@@ -887,6 +917,34 @@
           "quirks": [
             "适配器需优先识别 customtools 变体，避免将其误识别为普通 Pro Preview。"
           ]
+        },
+        {
+          "model_id": "gemini-3.1-flash-lite",
+          "release_date": "2026-05-07",
+          "status": "confirmed",
+          "source_url": "https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite",
+          "verified_at": "2026-08-23",
+          "capabilities": {
+            "text": true,
+            "vision": true,
+            "audio": true,
+            "video": true,
+            "function_calling": true,
+            "reasoning": true,
+            "coding_agent": false,
+            "max_context_tokens": 1048576,
+            "max_output_tokens": 65536
+          },
+          "param_format": {
+            "family": "google_gemini_api_native",
+            "required_fields": ["contents"],
+            "optional_fields": ["generationConfig", "generationConfig.topK", "generationConfig.topP", "generationConfig.maxOutputTokens", "generationConfig.temperature", "generationConfig.stopSequences", "generationConfig.responseSchema", "generationConfig.responseMimeType", "generationConfig.presencePenalty", "generationConfig.frequencyPenalty", "generationConfig.candidateCount", "tools", "toolConfig", "thinkingConfig"],
+            "notes": "低延迟低成本多模态型号（Stable，GA 2026-05-07）；输入支持文本/图像/视频/音频/PDF，输出仅文本；Thinking Supported。"
+          },
+          "quirks": [
+            "Gemini 3 系列用 thinking_level 控制推理深度，与旧 thinking_budget 参数互斥（同请求并用返回 400）。",
+            "官方模型页 token 上限为 1,048,576 输入 / 65,536 输出（开发指南简写 1M/64k 指同一数值）。"
+          ]
         }
       ]
     },
@@ -917,6 +975,33 @@
           },
           "quirks": [
             "是否启用 near-zero thinking 层在不同客户端可能有开关差异。"
+          ]
+        },
+        {
+          "model_id": "gemini-3.5-flash-lite",
+          "release_date": "2026-07-21",
+          "status": "confirmed",
+          "source_url": "https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash-lite",
+          "verified_at": "2026-08-23",
+          "capabilities": {
+            "text": true,
+            "vision": true,
+            "audio": true,
+            "video": true,
+            "function_calling": true,
+            "reasoning": true,
+            "coding_agent": false,
+            "max_context_tokens": 1048576,
+            "max_output_tokens": 65536
+          },
+          "param_format": {
+            "family": "google_gemini_api_native",
+            "required_fields": ["contents"],
+            "optional_fields": ["generationConfig", "generationConfig.topK", "generationConfig.topP", "generationConfig.maxOutputTokens", "generationConfig.temperature", "generationConfig.stopSequences", "generationConfig.responseSchema", "generationConfig.responseMimeType", "generationConfig.presencePenalty", "generationConfig.frequencyPenalty", "generationConfig.candidateCount", "tools", "toolConfig", "thinkingConfig"],
+            "notes": "Gemini 3.x Flash-Lite 最新稳定版（Stable，GA 2026-07-21）；输入支持文本/图像/视频/音频/PDF，输出仅文本；Thinking Supported。"
+          },
+          "quirks": [
+            "官方模型页 token 上限为 1,048,576 输入 / 65,536 输出。"
           ]
         }
       ]
@@ -2541,7 +2626,7 @@
     },
     {
       "vendor": "MiniMax",
-      "series": "M3/M2.7",
+      "series": "M3/M2.7/M2",
       "models": [
         {
           "model_id": "minimax-m3",
@@ -2617,6 +2702,35 @@
           },
           "quirks": [
             "官方已归类为 Legacy Models，仍可调用"
+          ]
+        },
+        {
+          "model_id": "MiniMax-M2",
+          "release_date": "2025-10-27",
+          "status": "confirmed",
+          "source_url": "https://platform.minimax.io/docs/api-reference/api-overview",
+          "verified_at": "2026-08-23",
+          "capabilities": {
+            "text": true,
+            "vision": false,
+            "audio": false,
+            "video": false,
+            "function_calling": true,
+            "reasoning": true,
+            "coding_agent": true,
+            "max_context_tokens": 204800,
+            "max_output_tokens": null
+          },
+          "param_format": {
+            "family": "minimax_openai_compat",
+            "required_fields": ["model", "messages"],
+            "optional_fields": ["reasoning_split", "max_completion_tokens", "temperature", "top_p", "tools", "tool_choice", "stream"],
+            "notes": "面向 Agent 与代码的文本模型；OpenAI 兼容接口 max_completion_tokens 对非 M3 型号推荐 65536、上限 204800；另提供 Anthropic 兼容端点。"
+          },
+          "quirks": [
+            "官方 ID 为大小写敏感写法 MiniMax-M2（区别于 minimax-m2.7 等小写记录）。",
+            "M2.x 不使用 M3 的 adaptive/disabled thinking 开关。",
+            "2025-10-27 发布并开源权重（Hugging Face MiniMaxAI/MiniMax-M2）；M2.x 系列 top_p 默认 0.9。"
           ]
         }
       ]

--- a/src/utils/__tests__/apiCapabilityEngine.test.ts
+++ b/src/utils/__tests__/apiCapabilityEngine.test.ts
@@ -77,6 +77,52 @@ describe('apiCapabilityEngine vision inference', () => {
   });
 });
 
+describe('modelCapabilityRegistry 2026-08 supplement lookups', () => {
+  it('resolves claude-haiku-4-5 with the official 200K context window', () => {
+    const record = findModelRecordById('claude-haiku-4-5');
+    expect(record?.model_id).toBe('claude-haiku-4-5');
+    expect(record?.capabilities.max_context_tokens).toBe(200000);
+    expect(record?.capabilities.max_output_tokens).toBe(64000);
+    expect(record?.capabilities.vision).toBe(true);
+    expect(record?.capabilities.reasoning).toBe(true);
+  });
+
+  it('resolves the dated claude-haiku-4-5-20251001 id via provider_model_id', () => {
+    const record = findModelRecordById('claude-haiku-4-5-20251001');
+    expect(record?.model_id).toBe('claude-haiku-4-5');
+    expect(record?.provider_model_id).toBe('claude-haiku-4-5-20251001');
+  });
+
+  it('keeps claude-haiku-5 unresolved because Anthropic has not published that model id', () => {
+    expect(findModelRecordById('claude-haiku-5')).toBeUndefined();
+  });
+
+  it('resolves gemini-3.1-flash-lite with official token limits', () => {
+    const record = findModelRecordById('gemini-3.1-flash-lite');
+    expect(record?.model_id).toBe('gemini-3.1-flash-lite');
+    expect(record?.capabilities.max_context_tokens).toBe(1048576);
+    expect(record?.capabilities.max_output_tokens).toBe(65536);
+    expect(record?.capabilities.reasoning).toBe(true);
+    expect(record?.capabilities.function_calling).toBe(true);
+  });
+
+  it('resolves gemini-3.5-flash-lite as the latest stable 3.x Flash-Lite', () => {
+    const record = findModelRecordById('gemini-3.5-flash-lite');
+    expect(record?.model_id).toBe('gemini-3.5-flash-lite');
+    expect(record?.capabilities.max_context_tokens).toBe(1048576);
+    expect(record?.capabilities.max_output_tokens).toBe(65536);
+  });
+
+  it('resolves MiniMax-M2 case-insensitively with the official 204800 context window', () => {
+    for (const input of ['MiniMax-M2', 'minimax-m2']) {
+      const record = findModelRecordById(input);
+      expect(record?.model_id).toBe('MiniMax-M2');
+      expect(record?.capabilities.max_context_tokens).toBe(204800);
+      expect(record?.capabilities.reasoning).toBe(true);
+    }
+  });
+});
+
 describe('apiCapabilityEngine DeepSeek version inference', () => {
   it('treats official DeepSeek V4 as hybrid reasoning with V4 effort and 1M context', () => {
     const caps = inferApiCapabilities({ id: 'deepseek-v4-pro', providerScope: 'deepseek' });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

给 `scripts/model-capability-registry.json` 补 2026-08 能核到官方文档的缺口。前端已有 `claude-haiku-5` 规则，但官方总览仍无该 ID——**不编造**，只收录 `claude-haiku-4-5`。

不改 `apiCapabilityEngine.ts`（#170）、`contextWindowSource`（#171）、`deepseekReasoningControls.ts`（#178/#179）。

### Changes
新增 4 条（均含 `source_url`，`verified_at: 2026-08-23`）：
- `claude-haiku-4-5` / `claude-haiku-4-5-20251001` — 200K/64K — [Claude models overview](https://platform.claude.com/docs/en/about-claude/models/overview)
- `gemini-3.1-flash-lite` — 1,048,576 / 65,536 — [Gemini 3.1 Flash-Lite](https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite)
- `gemini-3.5-flash-lite` — 1,048,576 / 65,536 — [Gemini 3.5 Flash-Lite](https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash-lite)
- `MiniMax-M2` — 204,800 — [MiniMax API overview](https://platform.minimax.io/docs/api-reference/api-overview)

刻意留空：`claude-haiku-5`（官方无此 ID）。lookup 测试断言 `findModelRecordById('claude-haiku-5')` 为 undefined。

### How to test
- `npx vitest run src/utils/__tests__/apiCapabilityEngine.test.ts`

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。与 #170/#171/#178/#179 无生产代码重叠。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

