### PR TITLE
fix(test): 稳定 i18n mock 身份，解除 Vitest 分片自激挂起

### DIFF
--- a/src/__tests__/i18n.source.test.ts
+++ b/src/__tests__/i18n.source.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('../i18n.ts', import.meta.url), 'utf8');
+// jsdom 环境下 import.meta.url 不是 file: scheme，new URL 相对定位会抛
+// "The URL must be of scheme file"；与其他 source 契约测试一致改用 cwd 解析。
+const source = readFileSync(resolve(process.cwd(), 'src/i18n.ts'), 'utf8');
 
 describe('i18n lazy-loading source contract', () => {
   it('refreshes React bindings when resource bundles are added', () => {

--- a/src/features/chat/plugins/blocks/components/__tests__/ToolOutputView.test.tsx
+++ b/src/features/chat/plugins/blocks/components/__tests__/ToolOutputView.test.tsx
@@ -8,15 +8,19 @@ vi.mock('@/components/custom-scroll-area', () => ({
   CustomScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string, options?: Record<string, unknown>) => {
-      if (options?.ns === 'mcp' && key === 'tools.web_search') return '网络搜索';
-      if (options?.ns === 'mcp' && key === 'labels.skill') return '技能';
-      return (options?.defaultValue as string | undefined) ?? '';
-    },
-  }),
-}));
+// 保留模块其余导出（initReactI18next 等）：src/i18n.ts 在模块加载时消费它们，
+// 只导出 useTranslation 会让本文件在收集阶段崩溃。t 需跨渲染身份稳定。
+vi.mock('react-i18next', async (importOriginal) => {
+  const t = (key: string, options?: Record<string, unknown>) => {
+    if (options?.ns === 'mcp' && key === 'tools.web_search') return '网络搜索';
+    if (options?.ns === 'mcp' && key === 'labels.skill') return '技能';
+    return (options?.defaultValue as string | undefined) ?? '';
+  };
+  return {
+    ...(await importOriginal<typeof import('react-i18next')>()),
+    useTranslation: () => ({ t }),
+  };
+});
 
 describe('ToolOutputView load_skills summary', () => {
   it('uses skill provenance so third-party bare names cannot hit builtin labels', () => {

--- a/src/features/notes/__tests__/NoteTagsEditor.test.tsx
+++ b/src/features/notes/__tests__/NoteTagsEditor.test.tsx
@@ -28,11 +28,14 @@ vi.mock('@/components/UnifiedNotification', () => ({
 }));
 
 // Mock i18next
-vi.mock('react-i18next', () => ({
-    useTranslation: () => ({
-        t: (key: string) => key,
-    }),
-}));
+// t 必须跨渲染身份稳定：NoteTagsEditor 的 loadAvailableTags 依赖 [initialTags, t]，
+// 若每次渲染返回新 t 闭包，弹层打开后加载 effect 会无限重跑（挂起 + 堆增长）。
+vi.mock('react-i18next', () => {
+    const t = (key: string) => key;
+    return {
+        useTranslation: () => ({ t }),
+    };
+});
 
 interface MockPopoverProps {
     children?: React.ReactNode;

--- a/src/features/notes/reference-selector/__tests__/ReferenceSelector.test.tsx
+++ b/src/features/notes/reference-selector/__tests__/ReferenceSelector.test.tsx
@@ -20,11 +20,15 @@ vi.mock('../api', () => ({
     listExamSessions: vi.fn(),
 }));
 
-vi.mock('react-i18next', () => ({
-    useTranslation: () => ({
-        t: (key: string) => key,
-    }),
-}));
+// 保留模块其余导出（initReactI18next 等）：src/i18n.ts 在模块加载时消费它们，
+// 只导出 useTranslation 会让本文件在收集阶段崩溃。t 需跨渲染身份稳定。
+vi.mock('react-i18next', async (importOriginal) => {
+    const t = (key: string) => key;
+    return {
+        ...(await importOriginal<typeof import('react-i18next')>()),
+        useTranslation: () => ({ t }),
+    };
+});
 
 vi.mock('@tauri-apps/api/core', () => ({
     convertFileSrc: (path: string) => `asset://mock${path}`,

--- a/src/features/workbench/apps/notes/__tests__/NotesBacklinksPanel.test.tsx
+++ b/src/features/workbench/apps/notes/__tests__/NotesBacklinksPanel.test.tsx
@@ -194,9 +194,11 @@ describe('NotesBacklinksPanel', () => {
     expect(screen.getByText('Gamma alias')).toBeInTheDocument();
     expect(screen.getByText('[[missing]]')).toBeInTheDocument();
     expect(screen.getByText('反向链接')).toBeInTheDocument();
-    expect(within(screen.getByRole('region', { name: /出链/ }))
-      .getByRole('button', { name: '打开 Beta' })).toHaveTextContent('Beta');
-    expect(screen.queryByText('Alpha alias')).toBeNull();
+    const outgoing = screen.getByRole('region', { name: /出链/ });
+    expect(within(outgoing).getByRole('button', { name: '打开 Beta' })).toHaveTextContent('Beta');
+    // 'Alpha alias' 是 Beta→Alpha 入链使用的别名：入链区域的上下文片段会渲染它
+    // （见下方 shows inbound context snippets 用例），但不应泄漏进出链区域。
+    expect(within(outgoing).queryByText('Alpha alias')).toBeNull();
   });
 
   it('prefers the backend note_links graph and skips the candidate search scan', async () => {

--- a/tests/ct/mocks/react-i18next.tsx
+++ b/tests/ct/mocks/react-i18next.tsx
@@ -75,15 +75,28 @@ export const i18n = {
   t,
 };
 
-export const useTranslation = (ns?: string | string[]) => ({
-  t: (key: string, options?: any) => {
-    // Preserve i18next string-default signature: t(key, 'fallback')
-    if (typeof options === 'string') return t(key, options);
+// 真实 react-i18next 在语言不变时返回身份稳定的 `t`。这里按 namespace 缓存
+// 返回值，避免每次渲染生成新的 `t` 闭包：否则依赖 `t` 的 useEffect 会在
+// 每次渲染后重跑并 setState，形成微任务自激死循环（测试挂起 + 堆增长）。
+const useTranslationCache = new Map<string, { t: typeof t; i18n: typeof i18n }>();
+
+export const useTranslation = (ns?: string | string[]) => {
+  const cacheKey = Array.isArray(ns) ? ns.join('\u0000') : ns ?? '';
+  let cached = useTranslationCache.get(cacheKey);
+  if (!cached) {
     const defaultNs = Array.isArray(ns) ? ns[0] : ns;
-    return t(key, defaultNs ? { ...options, ns: options?.ns ?? defaultNs } : options);
-  },
-  i18n,
-});
+    cached = {
+      t: (key: string, options?: any) => {
+        // Preserve i18next string-default signature: t(key, 'fallback')
+        if (typeof options === 'string') return t(key, options);
+        return t(key, defaultNs ? { ...options, ns: options?.ns ?? defaultNs } : options);
+      },
+      i18n,
+    };
+    useTranslationCache.set(cacheKey, cached);
+  }
+  return cached;
+};
 
 export const initReactI18next = {
   type: '3rdParty' as const,

--- a/tests/vitest/chat-v2/skills/activeSkillToolAccess.test.ts
+++ b/tests/vitest/chat-v2/skills/activeSkillToolAccess.test.ts
@@ -1,10 +1,25 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('i18next', () => ({
-  default: {
-    t: (_key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? _key,
-  },
-}));
+// 完整覆盖 i18next 表面：产品模块图谱中 src/i18n.ts 会在模块加载时执行
+// `i18n.use(...).init(...)` 与 `i18n.on('languageChanged', ...)`，只 mock `t`
+// 会让本文件在收集阶段就崩溃（default.use is not a function）。
+vi.mock('i18next', () => {
+  const t = (_key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? _key;
+  const i18nMock = {
+    t,
+    isInitialized: true,
+    language: 'zh-CN',
+    use: () => i18nMock,
+    init: () => Promise.resolve(t),
+    on: () => i18nMock,
+    off: () => i18nMock,
+    addResourceBundle: () => i18nMock,
+    hasResourceBundle: () => true,
+    loadNamespaces: () => Promise.resolve(),
+    changeLanguage: () => Promise.resolve(t),
+  };
+  return { default: i18nMock };
+});
 
 import { createSkillActions } from '@/features/chat/core/store/skillActions';
 import type { ChatStoreState, GetState, SetState } from '@/features/chat/core/store/types';

--- a/tests/vitest/data-governance/DataGovernanceDashboard.backup-config.test.tsx
+++ b/tests/vitest/data-governance/DataGovernanceDashboard.backup-config.test.tsx
@@ -6,7 +6,7 @@
  * 2. 自动备份开关切换
  * 3. 备份间隔选择
  * 4. 最大备份数设置
- * 5. 精简备份模式切换
+ * 5. 精简备份模式已移除的守护（自动备份始终全量）
  * 6. 配置保存失败处理
  * 7. 配置加载失败处理
  * 8. 加载状态显示
@@ -17,7 +17,7 @@
  */
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within, act } from '@testing-library/react';
 
 // ============================================================================
 // Mocks
@@ -66,7 +66,8 @@ vi.mock('react-i18next', async (importOriginal) => ({
   useTranslation: () => ({ t: mockTranslate }),
 }));
 
-vi.mock('@/utils/cloudStorageApi', () => ({
+vi.mock('@/utils/cloudStorageApi', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/cloudStorageApi')>()),
   loadStoredCloudStorageConfigSafe: () => null,
   loadStoredCloudStorageConfigWithCredentials: vi.fn().mockResolvedValue(null),
 }));
@@ -146,7 +147,7 @@ const enabledAutoBackupConfig = {
 /** 导航到备份 Tab 的辅助函数 */
 async function navigateToBackupTab() {
   const backupTab = await screen.findByRole('button', {
-    name: /备份|data:governance\.tab_backup/i,
+    name: /^(?:备份|data:governance\.tab_backup)$/i,
   });
   fireEvent.click(backupTab);
   await waitFor(() => {
@@ -164,6 +165,19 @@ async function expandSettingsPanel() {
       fireEvent.click(settingsBtn);
     });
   }
+}
+
+/** 配置加载完成的哨兵：自动备份标签仅在 backupConfig 就绪后渲染 */
+const autoBackupLabel = /^(?:自动备份|data:governance\.auto_backup)$/i;
+
+/**
+ * 定位自动备份开关：按标签所在行作用域查找，
+ * 避免依赖全局 switch 顺序（导出区还有 includeAssets 开关）。
+ */
+function getAutoBackupSwitch() {
+  const row = screen.getByText(autoBackupLabel).closest('div.justify-between');
+  if (!row) throw new Error('auto backup row not found');
+  return within(row as HTMLElement).getByRole('switch');
 }
 
 // ============================================================================
@@ -217,11 +231,9 @@ describe('DataGovernanceDashboard backup settings panel rendering', () => {
       expect(mockGetBackupConfig).toHaveBeenCalledTimes(1);
     });
 
-    // 配置加载后，精简备份模式开关应可见（唯一文本，无歧义）
+    // 配置加载后，自动备份开关标签应可见
     await waitFor(() => {
-      expect(
-        screen.getByText(/精简备份模式|data:governance\.slim_backup$/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(autoBackupLabel)).toBeInTheDocument();
     });
   });
 
@@ -253,9 +265,7 @@ describe('DataGovernanceDashboard backup settings panel rendering', () => {
 
     // 加载完成后，配置项应可见
     await waitFor(() => {
-      expect(
-        screen.getByText(/精简备份模式|data:governance\.slim_backup$/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(autoBackupLabel)).toBeInTheDocument();
     });
   });
 });
@@ -290,17 +300,13 @@ describe('DataGovernanceDashboard auto backup toggle', () => {
     await navigateToBackupTab();
     await expandSettingsPanel();
 
-    // 等待配置加载（通过精简备份模式文本确认）
+    // 等待配置加载
     await waitFor(() => {
-      expect(
-        screen.getByText(/精简备份模式|data:governance\.slim_backup$/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(autoBackupLabel)).toBeInTheDocument();
     });
 
-    // 找到自动备份开关（Switch 组件的 role 是 switch）
-    const switches = screen.getAllByRole('switch');
-    // 第一个 switch 是自动备份开关
-    const autoBackupSwitch = switches[0];
+    // 按标签行定位自动备份开关（导出区还有 includeAssets 开关，不能按顺序取）
+    const autoBackupSwitch = getAutoBackupSwitch();
     expect(autoBackupSwitch).not.toBeChecked();
 
     // 切换开关
@@ -341,11 +347,9 @@ describe('DataGovernanceDashboard auto backup toggle', () => {
     await navigateToBackupTab();
     await expandSettingsPanel();
 
-    // 等待配置加载（通过精简备份模式文本确认）
+    // 等待配置加载
     await waitFor(() => {
-      expect(
-        screen.getByText(/精简备份模式|data:governance\.slim_backup$/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(autoBackupLabel)).toBeInTheDocument();
     });
 
     // 自动备份关闭时，间隔选择器不应该显示
@@ -502,7 +506,7 @@ describe('DataGovernanceDashboard slim backup mode', () => {
     });
   });
 
-  it('toggles slim backup mode and saves config', async () => {
+  it('no longer renders a slim backup toggle (auto backups are always full snapshots)', async () => {
     mockGetBackupConfig.mockResolvedValue(defaultBackupConfig);
     mockSetBackupConfig.mockResolvedValue(undefined);
 
@@ -510,33 +514,16 @@ describe('DataGovernanceDashboard slim backup mode', () => {
     await navigateToBackupTab();
     await expandSettingsPanel();
 
-    // 等待配置加载（通过精简备份模式文本确认）
+    // 等待配置加载
     await waitFor(() => {
-      expect(
-        screen.getByText(/精简备份模式|data:governance\.slim_backup$/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(autoBackupLabel)).toBeInTheDocument();
     });
 
-    // 在设置面板中找到 switch 元素
-    // 当 autoBackupEnabled 为 false 时，有 auto_backup 和 slim_backup 两个 switch
-    // 还可能有分层备份区域的 includeAssets switch，所以使用最后一个 in settings panel
-    const switches = screen.getAllByRole('switch');
-    // slim_backup 是设置面板中最后一个 switch（第二个）
-    const slimSwitch = switches[1];
-    expect(slimSwitch).not.toBeChecked();
-
-    await act(async () => {
-      fireEvent.click(slimSwitch);
-    });
-
-    // setBackupConfig 应被调用，且 slimBackup 为 true
-    await waitFor(() => {
-      expect(mockSetBackupConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          slimBackup: true,
-        }),
-      );
-    });
+    // 精简备份开关已从产品中移除（自动备份始终创建完整快照），
+    // 设置面板不应再出现 slim_backup 相关文案或第二个设置开关。
+    expect(
+      screen.queryByText(/精简备份模式|data:governance\.slim_backup/i),
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -585,9 +572,7 @@ describe('DataGovernanceDashboard backup config error handling', () => {
 
     await waitFor(() => {
       expect(mockGetBackupConfig).toHaveBeenCalledTimes(2);
-      expect(
-        screen.getByText(/精简备份模式|data:governance\.slim_backup$/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(autoBackupLabel)).toBeInTheDocument();
     });
   });
 
@@ -599,19 +584,14 @@ describe('DataGovernanceDashboard backup config error handling', () => {
     await navigateToBackupTab();
     await expandSettingsPanel();
 
-    // 等待配置加载（通过精简备份模式文本确认）
+    // 等待配置加载
     await waitFor(() => {
-      expect(
-        screen.getByText(/精简备份模式|data:governance\.slim_backup$/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(autoBackupLabel)).toBeInTheDocument();
     });
 
     // 切换自动备份开关触发保存
-    const switches = screen.getAllByRole('switch');
-    const autoBackupSwitch = switches[0];
-
     await act(async () => {
-      fireEvent.click(autoBackupSwitch);
+      fireEvent.click(getAutoBackupSwitch());
     });
 
     // setBackupConfig 应被调用
@@ -620,9 +600,7 @@ describe('DataGovernanceDashboard backup config error handling', () => {
     });
 
     // 组件不应崩溃，面板应保持显示
-    expect(
-      screen.getByText(/精简备份模式|data:governance\.slim_backup$/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(autoBackupLabel)).toBeInTheDocument();
   });
 
   it('does not call getBackupConfig again if already loaded', async () => {

--- a/tests/vitest/data-governance/DataGovernanceDashboard.backup-operations.test.tsx
+++ b/tests/vitest/data-governance/DataGovernanceDashboard.backup-operations.test.tsx
@@ -125,7 +125,7 @@ const sampleBackupList = [
 /** 导航到备份 Tab 的辅助函数 */
 async function navigateToBackupTab() {
   const backupTab = await screen.findByRole('button', {
-    name: /备份|data:governance\.tab_backup/i,
+    name: /^(?:备份|data:governance\.tab_backup)$/i,
   });
   fireEvent.click(backupTab);
   await waitFor(() => {
@@ -156,13 +156,13 @@ describe('DataGovernanceDashboard tiered backup selector', () => {
     await navigateToBackupTab();
 
     const tieredToggle = screen.getByRole('checkbox', {
-      name: /data:governance\.use_tiered_backup/i,
+      name: /使用分层备份|data:governance\.use_tiered_backup/i,
     });
     fireEvent.click(tieredToggle);
 
-    expect(screen.getByText(/settings:data_governance\.backup_tiers\.core_label/i)).toBeInTheDocument();
-    expect(screen.getByText(/settings:data_governance\.backup_tiers\.important_label/i)).toBeInTheDocument();
-    expect(screen.getByText(/settings:data_governance\.backup_tiers\.rebuildable_label/i)).toBeInTheDocument();
+    expect(screen.getByText(/核心数据|settings:data_governance\.backup_tiers\.core_label/i)).toBeInTheDocument();
+    expect(screen.getByText(/重要数据|settings:data_governance\.backup_tiers\.important_label/i)).toBeInTheDocument();
+    expect(screen.getByText(/可重建数据|settings:data_governance\.backup_tiers\.rebuildable_label/i)).toBeInTheDocument();
 
     const exportBtn = screen.getByRole('button', {
       name: /导出备份|data:governance\.export_backup/i,
@@ -182,7 +182,7 @@ describe('DataGovernanceDashboard tiered backup selector', () => {
     await navigateToBackupTab();
 
     fireEvent.click(screen.getByRole('checkbox', {
-      name: /data:governance\.use_tiered_backup/i,
+      name: /使用分层备份|data:governance\.use_tiered_backup/i,
     }));
 
     const exportBtn = screen.getByRole('button', {
@@ -216,15 +216,15 @@ describe('DataGovernanceDashboard tiered backup selector', () => {
     await navigateToBackupTab();
 
     fireEvent.click(screen.getByRole('checkbox', {
-      name: /data:governance\.use_tiered_backup/i,
+      name: /使用分层备份|data:governance\.use_tiered_backup/i,
     }));
 
     // 找到各层级的可点击区域（通过层级标签文本）
     const importantTier = screen.getByText(
-      /settings:data_governance\.backup_tiers\.important_label/i,
+      /重要数据|settings:data_governance\.backup_tiers\.important_label/i,
     );
     const rebuildableTier = screen.getByText(
-      /settings:data_governance\.backup_tiers\.rebuildable_label/i,
+      /可重建数据|settings:data_governance\.backup_tiers\.rebuildable_label/i,
     );
 
     // 点击 important 和 rebuildable 层级的包裹 div
@@ -262,18 +262,18 @@ describe('DataGovernanceDashboard tiered backup selector', () => {
     await navigateToBackupTab();
 
     fireEvent.click(screen.getByRole('checkbox', {
-      name: /data:governance\.use_tiered_backup/i,
+      name: /使用分层备份|data:governance\.use_tiered_backup/i,
     }));
 
     // 取消 core 层级选择
     const coreTier = screen.getByText(
-      /settings:data_governance\.backup_tiers\.core_label/i,
+      /核心数据|settings:data_governance\.backup_tiers\.core_label/i,
     );
     fireEvent.click(coreTier.closest('[class*="cursor-pointer"]')!);
 
     // 选择 important 层级
     const importantTier = screen.getByText(
-      /settings:data_governance\.backup_tiers\.important_label/i,
+      /重要数据|settings:data_governance\.backup_tiers\.important_label/i,
     );
     fireEvent.click(importantTier.closest('[class*="cursor-pointer"]')!);
 
@@ -298,12 +298,12 @@ describe('DataGovernanceDashboard tiered backup selector', () => {
     await navigateToBackupTab();
 
     fireEvent.click(screen.getByRole('checkbox', {
-      name: /data:governance\.use_tiered_backup/i,
+      name: /使用分层备份|data:governance\.use_tiered_backup/i,
     }));
 
     // 取消 core 层级选择（默认唯一选中项）
     const coreTier = screen.getByText(
-      /settings:data_governance\.backup_tiers\.core_label/i,
+      /核心数据|settings:data_governance\.backup_tiers\.core_label/i,
     );
     fireEvent.click(coreTier.closest('[class*="cursor-pointer"]')!);
 
@@ -517,7 +517,7 @@ describe('DataGovernanceDashboard backup progress display', () => {
     await navigateToBackupTab();
 
     fireEvent.click(screen.getByRole('checkbox', {
-      name: /data:governance\.use_tiered_backup/i,
+      name: /使用分层备份|data:governance\.use_tiered_backup/i,
     }));
 
     const createTieredBtn = screen.getByRole('button', { name: exportBackupButtonName });
@@ -602,7 +602,7 @@ describe('DataGovernanceDashboard backup failure handling', () => {
     await navigateToBackupTab();
 
     fireEvent.click(screen.getByRole('checkbox', {
-      name: /data:governance\.use_tiered_backup/i,
+      name: /使用分层备份|data:governance\.use_tiered_backup/i,
     }));
 
     const createTieredBtn = screen.getByRole('button', { name: exportBackupButtonName });
@@ -827,7 +827,7 @@ describe('DataGovernanceDashboard backup buttons disabled while running', () => 
     expect(fullBackupBtn).toBeDisabled();
     expect(
       screen.getByRole('checkbox', {
-        name: /data:governance\.use_tiered_backup/i,
+        name: /使用分层备份|data:governance\.use_tiered_backup/i,
       }),
     ).toBeDisabled();
 

--- a/tests/vitest/data-governance/DataGovernanceDashboard.backup-restore-ui.test.tsx
+++ b/tests/vitest/data-governance/DataGovernanceDashboard.backup-restore-ui.test.tsx
@@ -324,7 +324,7 @@ describe('DataGovernanceDashboard backup/restore interactions (Issue #15)', () =
     render(<DataGovernanceDashboard embedded />);
 
     // 找到备份标签并点击
-    const backupTab = await screen.findByRole('button', { name: /备份|data:governance\.tab_backup/i });
+    const backupTab = await screen.findByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i });
     fireEvent.click(backupTab);
 
     await waitFor(() => {
@@ -337,7 +337,7 @@ describe('DataGovernanceDashboard backup/restore interactions (Issue #15)', () =
 
     render(<DataGovernanceDashboard embedded />);
 
-    const backupTab = await screen.findByRole('button', { name: /备份|data:governance\.tab_backup/i });
+    const backupTab = await screen.findByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i });
     fireEvent.click(backupTab);
 
     await waitFor(() => {
@@ -352,7 +352,7 @@ describe('DataGovernanceDashboard backup/restore interactions (Issue #15)', () =
 
     render(<DataGovernanceDashboard embedded />);
 
-    const backupTab = await screen.findByRole('button', { name: /备份|data:governance\.tab_backup/i });
+    const backupTab = await screen.findByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i });
     fireEvent.click(backupTab);
 
     await waitFor(() => {
@@ -503,7 +503,7 @@ describe('DataGovernanceDashboard backup operations (Issue #15)', () => {
     render(<DataGovernanceDashboard embedded />);
 
     // 导航到备份 Tab
-    const backupTab = await screen.findByRole('button', { name: /备份|data:governance\.tab_backup/i });
+    const backupTab = await screen.findByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i });
     fireEvent.click(backupTab);
 
     await waitFor(() => {
@@ -543,7 +543,7 @@ describe('DataGovernanceDashboard backup operations (Issue #15)', () => {
     render(<DataGovernanceDashboard embedded />);
 
     // 导航到备份 Tab
-    const backupTab = await screen.findByRole('button', { name: /备份|data:governance\.tab_backup/i });
+    const backupTab = await screen.findByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i });
     fireEvent.click(backupTab);
 
     await waitFor(() => {
@@ -593,7 +593,7 @@ describe('DataGovernanceDashboard backup operations (Issue #15)', () => {
     render(<DataGovernanceDashboard embedded />);
 
     // 导航到备份 Tab
-    const backupTab = await screen.findByRole('button', { name: /备份|data:governance\.tab_backup/i });
+    const backupTab = await screen.findByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i });
     fireEvent.click(backupTab);
 
     await waitFor(() => {
@@ -622,7 +622,7 @@ describe('DataGovernanceDashboard backup operations (Issue #15)', () => {
 
     render(<DataGovernanceDashboard embedded />);
 
-    const backupTab = await screen.findByRole('button', { name: /备份|data:governance\.tab_backup/i });
+    const backupTab = await screen.findByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i });
     fireEvent.click(backupTab);
 
     await waitFor(() => {
@@ -650,7 +650,7 @@ describe('DataGovernanceDashboard backup operations (Issue #15)', () => {
 
     render(<DataGovernanceDashboard embedded />);
 
-    const backupTab = await screen.findByRole('button', { name: /备份|data:governance\.tab_backup/i });
+    const backupTab = await screen.findByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i });
     fireEvent.click(backupTab);
 
     await waitFor(() => {

--- a/tests/vitest/data-governance/DataGovernanceDashboard.edge-cases.test.tsx
+++ b/tests/vitest/data-governance/DataGovernanceDashboard.edge-cases.test.tsx
@@ -190,7 +190,7 @@ describe('Edge case: empty databases list', () => {
 
     // Tab 按钮仍然可用
     expect(
-      screen.getByRole('button', { name: /备份|data:governance\.tab_backup/i }),
+      screen.getByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i }),
     ).toBeInTheDocument();
   });
 
@@ -231,7 +231,7 @@ describe('Edge case: large backup list (100 items)', () => {
 
     // 导航到备份 Tab
     const backupTab = await screen.findByRole('button', {
-      name: /备份|data:governance\.tab_backup/i,
+      name: /^(?:备份|data:governance\.tab_backup)$/i,
     });
     fireEvent.click(backupTab);
 
@@ -261,7 +261,7 @@ describe('Edge case: large backup list (100 items)', () => {
     render(<DataGovernanceDashboard embedded />);
 
     const backupTab = await screen.findByRole('button', {
-      name: /备份|data:governance\.tab_backup/i,
+      name: /^(?:备份|data:governance\.tab_backup)$/i,
     });
     fireEvent.click(backupTab);
 
@@ -313,7 +313,7 @@ describe('Edge case: concurrent operation conflict', () => {
 
     // 导航到备份 Tab
     const backupTab = await screen.findByRole('button', {
-      name: /备份|data:governance\.tab_backup/i,
+      name: /^(?:备份|data:governance\.tab_backup)$/i,
     });
     fireEvent.click(backupTab);
 
@@ -356,7 +356,7 @@ describe('Edge case: concurrent operation conflict', () => {
     render(<DataGovernanceDashboard embedded />);
 
     const backupTab = await screen.findByRole('button', {
-      name: /备份|data:governance\.tab_backup/i,
+      name: /^(?:备份|data:governance\.tab_backup)$/i,
     });
     fireEvent.click(backupTab);
 
@@ -460,7 +460,7 @@ describe('Edge case: empty audit logs', () => {
 
     // 切换到审计 Tab
     const auditTab = await screen.findByRole('button', {
-      name: /审计|data:governance\.tab_audit/i,
+      name: /^(?:审计|data:governance\.tab_audit)$/i,
     });
     fireEvent.click(auditTab);
 
@@ -476,7 +476,7 @@ describe('Edge case: empty audit logs', () => {
     render(<DataGovernanceDashboard embedded />);
 
     const auditTab = await screen.findByRole('button', {
-      name: /审计|data:governance\.tab_audit/i,
+      name: /^(?:审计|data:governance\.tab_audit)$/i,
     });
     fireEvent.click(auditTab);
 
@@ -516,7 +516,7 @@ describe('Edge case: maintenance mode UI state', () => {
     render(<DataGovernanceDashboard embedded />);
 
     const backupTab = await screen.findByRole('button', {
-      name: /备份|data:governance\.tab_backup/i,
+      name: /^(?:备份|data:governance\.tab_backup)$/i,
     });
     fireEvent.click(backupTab);
 
@@ -557,7 +557,7 @@ describe('Edge case: maintenance mode UI state', () => {
     expect(container.firstChild).not.toBeNull();
     // 刷新按钮和 Tab 导航应存在
     expect(screen.getByRole('button', { name: /刷新|common:actions\.refresh/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /概览|data:governance\.tab_overview/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^(?:概览|data:governance\.tab_overview)$/i })).toBeInTheDocument();
     // 维护模式状态应保持
     expect(useSystemStatusStore.getState().maintenanceMode).toBe(true);
   });
@@ -573,7 +573,7 @@ describe('Edge case: maintenance mode UI state', () => {
     render(<DataGovernanceDashboard embedded />);
 
     const backupTab = await screen.findByRole('button', {
-      name: /备份|data:governance\.tab_backup/i,
+      name: /^(?:备份|data:governance\.tab_backup)$/i,
     });
     fireEvent.click(backupTab);
 
@@ -647,7 +647,7 @@ describe('Edge case: unmount cleanup', () => {
 
     // 导航到备份 Tab
     const backupTab = await screen.findByRole('button', {
-      name: /备份|data:governance\.tab_backup/i,
+      name: /^(?:备份|data:governance\.tab_backup)$/i,
     });
     fireEvent.click(backupTab);
 
@@ -724,7 +724,7 @@ describe('Edge case: tab switching data loading', () => {
 
     // 切换到备份 Tab
     const backupTab = screen.getByRole('button', {
-      name: /备份|data:governance\.tab_backup/i,
+      name: /^(?:备份|data:governance\.tab_backup)$/i,
     });
     fireEvent.click(backupTab);
 
@@ -748,7 +748,7 @@ describe('Edge case: tab switching data loading', () => {
 
     // 切换到同步 Tab
     const syncTab = screen.getByRole('button', {
-      name: /同步|data:governance\.tab_sync/i,
+      name: /^(?:同步|data:governance\.tab_sync)$/i,
     });
     fireEvent.click(syncTab);
 
@@ -772,7 +772,7 @@ describe('Edge case: tab switching data loading', () => {
 
     // 切换到备份 Tab
     const backupTab = screen.getByRole('button', {
-      name: /备份|data:governance\.tab_backup/i,
+      name: /^(?:备份|data:governance\.tab_backup)$/i,
     });
     fireEvent.click(backupTab);
 
@@ -782,7 +782,7 @@ describe('Edge case: tab switching data loading', () => {
 
     // 切换回概览 Tab
     const overviewTab = screen.getByRole('button', {
-      name: /概览|data:governance\.tab_overview/i,
+      name: /^(?:概览|data:governance\.tab_overview)$/i,
     });
     fireEvent.click(overviewTab);
 

--- a/tests/vitest/data-governance/DataGovernanceDashboard.error-states.test.tsx
+++ b/tests/vitest/data-governance/DataGovernanceDashboard.error-states.test.tsx
@@ -81,7 +81,7 @@ describe('DataGovernanceDashboard multiple API failures (Issue #15)', () => {
     // 刷新按钮应存在且可操作
     expect(screen.getByRole('button', { name: /刷新|common:actions\.refresh/i })).toBeInTheDocument();
     // Tab 导航应存在
-    expect(screen.getByRole('button', { name: /概览|data:governance\.tab_overview/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^(?:概览|data:governance\.tab_overview)$/i })).toBeInTheDocument();
   });
 
   it('does not crash when migration status returns null', async () => {
@@ -101,7 +101,7 @@ describe('DataGovernanceDashboard multiple API failures (Issue #15)', () => {
     expect(container.firstChild).not.toBeNull();
     // 即使数据为 null，核心导航仍应可用
     expect(screen.getByRole('button', { name: /刷新|common:actions\.refresh/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /备份|data:governance\.tab_backup/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i })).toBeInTheDocument();
   });
 
   it('does not crash when APIs return partial/empty data shapes', async () => {
@@ -135,7 +135,7 @@ describe('DataGovernanceDashboard multiple API failures (Issue #15)', () => {
     // 断言组件成功渲染，核心 UI 元素存在
     expect(container.firstChild).not.toBeNull();
     expect(screen.getByRole('button', { name: /刷新|common:actions\.refresh/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /概览|data:governance\.tab_overview/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^(?:概览|data:governance\.tab_overview)$/i })).toBeInTheDocument();
   });
 
   it('crashes with ErrorBoundary when APIs return completely invalid types (documents defensive gap)', async () => {
@@ -233,7 +233,7 @@ describe('DataGovernanceDashboard tab state isolation (Issue #15)', () => {
     });
 
     // 切换到备份标签
-    const backupTab = screen.getByRole('button', { name: /备份|data:governance\.tab_backup/i });
+    const backupTab = screen.getByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i });
     fireEvent.click(backupTab);
 
     await waitFor(() => {
@@ -241,7 +241,7 @@ describe('DataGovernanceDashboard tab state isolation (Issue #15)', () => {
     });
 
     // 切换回概览标签
-    const overviewTab = screen.getByRole('button', { name: /概览|data:governance\.tab_overview/i });
+    const overviewTab = screen.getByRole('button', { name: /^(?:概览|data:governance\.tab_overview)$/i });
     fireEvent.click(overviewTab);
 
     // 再切换回备份标签 - 不应该重新加载（或至少不应该崩溃）
@@ -260,8 +260,8 @@ describe('DataGovernanceDashboard tab state isolation (Issue #15)', () => {
       expect(mockDataGovernanceApi.runHealthCheck).toHaveBeenCalled();
     });
 
-    const backupTab = screen.getByRole('button', { name: /备份|data:governance\.tab_backup/i });
-    const overviewTab = screen.getByRole('button', { name: /概览|data:governance\.tab_overview/i });
+    const backupTab = screen.getByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i });
+    const overviewTab = screen.getByRole('button', { name: /^(?:概览|data:governance\.tab_overview)$/i });
 
     // 快速切换 5 次
     for (let i = 0; i < 5; i++) {
@@ -326,6 +326,6 @@ describe('DataGovernanceDashboard standalone mode (Issue #15)', () => {
     expect(container.firstChild).not.toBeNull();
     // 非嵌入模式也应渲染刷新按钮和 Tab 导航
     expect(screen.getByRole('button', { name: /刷新|common:actions\.refresh/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /概览|data:governance\.tab_overview/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^(?:概览|data:governance\.tab_overview)$/i })).toBeInTheDocument();
   });
 });

--- a/tests/vitest/data-governance/DataGovernanceDashboard.restore-operations.test.tsx
+++ b/tests/vitest/data-governance/DataGovernanceDashboard.restore-operations.test.tsx
@@ -184,7 +184,7 @@ beforeEach(() => {
 /** 导航到备份 Tab 的辅助函数 */
 async function navigateToBackupTab() {
   const backupTab = await screen.findByRole('button', {
-    name: /备份|data:governance\.tab_backup/i,
+    name: /^(?:备份|data:governance\.tab_backup)$/i,
   });
   fireEvent.click(backupTab);
   await waitFor(() => {

--- a/tests/vitest/data-governance/DataGovernanceDashboard.scoped-loading.test.tsx
+++ b/tests/vitest/data-governance/DataGovernanceDashboard.scoped-loading.test.tsx
@@ -107,14 +107,14 @@ describe('DataGovernanceDashboard scoped loading', () => {
 
     render(<DataGovernanceDashboard embedded />);
 
-    const backupTab = screen.getByRole('button', { name: /备份|data:governance\.tab_backup/i });
+    const backupTab = screen.getByRole('button', { name: /^(?:备份|data:governance\.tab_backup)$/i });
     fireEvent.click(backupTab);
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /刷新|common:actions\.refresh/i })).toBeEnabled();
     });
 
-    const overviewTab = screen.getByRole('button', { name: /概览|data:governance\.tab_overview/i });
+    const overviewTab = screen.getByRole('button', { name: /^(?:概览|data:governance\.tab_overview)$/i });
     fireEvent.click(overviewTab);
 
     const runHealthCheckButton = await screen.findByRole('button', {

--- a/tests/vitest/data-governance/DataGovernanceDashboard.sync-operations.test.tsx
+++ b/tests/vitest/data-governance/DataGovernanceDashboard.sync-operations.test.tsx
@@ -73,7 +73,8 @@ const mockDataGovernanceApi = vi.hoisted(() => ({
 const mockLoadStoredCloudStorageConfigSafe = vi.hoisted(() => vi.fn());
 const mockLoadStoredCloudStorageConfigWithCredentials = vi.hoisted(() => vi.fn());
 
-vi.mock('@/utils/cloudStorageApi', () => ({
+vi.mock('@/utils/cloudStorageApi', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/cloudStorageApi')>()),
   loadStoredCloudStorageConfigSafe: mockLoadStoredCloudStorageConfigSafe,
   loadStoredCloudStorageConfigWithCredentials: mockLoadStoredCloudStorageConfigWithCredentials,
 }));
@@ -244,7 +245,7 @@ function setupDefaultMocks(opts?: { cloudConfigured?: boolean }) {
 /** 导航到同步 Tab 的辅助函数 */
 async function navigateToSyncTab() {
   const syncTab = await screen.findByRole('button', {
-    name: /同步|data:governance\.tab_sync/i,
+    name: /^(?:同步|data:governance\.tab_sync)$/i,
   });
   fireEvent.click(syncTab);
   await waitFor(() => {

--- a/tests/vitest/data-governance/maintenance-mode.test.tsx
+++ b/tests/vitest/data-governance/maintenance-mode.test.tsx
@@ -71,7 +71,8 @@ vi.mock('react-i18next', async (importOriginal) => ({
   useTranslation: () => ({ t: mockTranslate }),
 }));
 
-vi.mock('@/utils/cloudStorageApi', () => ({
+vi.mock('@/utils/cloudStorageApi', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/cloudStorageApi')>()),
   loadStoredCloudStorageConfigSafe: () => null,
   loadStoredCloudStorageConfigWithCredentials: vi.fn().mockResolvedValue(null),
 }));
@@ -177,7 +178,7 @@ function MaintenanceBannerTestHarness() {
 /** 导航到备份 Tab 的辅助函数 */
 async function navigateToBackupTab() {
   const backupTab = await screen.findByRole('button', {
-    name: /备份|data:governance\.tab_backup/i,
+    name: /^(?:备份|data:governance\.tab_backup)$/i,
   });
   fireEvent.click(backupTab);
   await waitFor(() => {

--- a/tests/vitest/harness/react-i18next-mock-stability.test.tsx
+++ b/tests/vitest/harness/react-i18next-mock-stability.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * 测试 harness 契约：react-i18next mock 的 `t` 必须跨渲染身份稳定。
+ *
+ * 背景：真实 react-i18next 在语言不变时返回稳定的 `t`。若 mock 每次渲染
+ * 返回新的 `t` 闭包，所有依赖 `t` 的 useEffect（如 DataGovernanceDashboard
+ * 的事件订阅、NotesBacklinksPanel 的加载 effect）会在每次渲染后重跑并
+ * setState，形成微任务自激死循环——测试文件无限挂起、堆持续增长，
+ * 连 vitest 的 testTimeout 都无法触发。本测试锁定该契约，防止回归。
+ */
+import React, { useEffect, useRef } from 'react';
+import { describe, expect, it } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { useTranslation } from 'react-i18next';
+
+describe('react-i18next test mock stability contract', () => {
+  it('returns an identity-stable t for the same namespace across calls', () => {
+    const a = useTranslation('workbench');
+    const b = useTranslation('workbench');
+    expect(a.t).toBe(b.t);
+    expect(useTranslation(['data', 'common']).t).toBe(useTranslation(['data', 'common']).t);
+    // 不同 namespace 各自独立，但同样稳定
+    expect(useTranslation('data').t).toBe(useTranslation('data').t);
+  });
+
+  it('does not re-fire t-dependent effects on unrelated re-renders', () => {
+    const effectRuns: number[] = [];
+
+    const Probe: React.FC<{ tick: number }> = ({ tick }) => {
+      const { t } = useTranslation('common');
+      const runsRef = useRef(0);
+      useEffect(() => {
+        runsRef.current += 1;
+        effectRuns.push(runsRef.current);
+      }, [t]);
+      return <span>{t('actions.refresh')}{tick}</span>;
+    };
+
+    const { rerender } = render(<Probe tick={1} />);
+    act(() => {
+      rerender(<Probe tick={2} />);
+      rerender(<Probe tick={3} />);
+    });
+
+    // t 身份稳定 → effect 只在挂载时运行一次
+    expect(effectRuns).toEqual([1]);
+  });
+
+  it('still resolves translations with the default namespace', () => {
+    const { t } = useTranslation('data');
+    expect(t('governance.tab_backup')).toBe('备份');
+    expect(t('data:governance.tab_overview')).toBe('概览');
+  });
+});

--- a/tests/vitest/mindmap/blankedTextInteraction.test.tsx
+++ b/tests/vitest/mindmap/blankedTextInteraction.test.tsx
@@ -3,9 +3,15 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { BlankedText } from '@/features/mindmap/components/shared/BlankedText';
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}));
+// 保留模块其余导出（initReactI18next 等）：src/i18n.ts 在模块加载时消费它们，
+// 只导出 useTranslation 会让本文件在收集阶段崩溃。t 需跨渲染身份稳定。
+vi.mock('react-i18next', async (importOriginal) => {
+  const t = (key: string) => key;
+  return {
+    ...(await importOriginal<typeof import('react-i18next')>()),
+    useTranslation: () => ({ t }),
+  };
+});
 
 describe('BlankedText recite interaction', () => {
   afterEach(() => {

--- a/tests/vitest/question-bank-editor-ai-markdown.test.tsx
+++ b/tests/vitest/question-bank-editor-ai-markdown.test.tsx
@@ -12,20 +12,28 @@ vi.mock('@/hooks/useBreakpoint', () => ({
   useIsTablet: () => false,
 }));
 
-vi.mock('@/hooks/useQbankAiGrading', () => ({
-  useQbankAiGrading: () => ({
-    state: {
-      isGrading: false,
-      feedback: '',
-      verdict: null,
-      score: null,
-      error: null,
-    },
-    resetState: vi.fn(),
-    startGrading: vi.fn(),
-    cancelGrading: vi.fn(),
-  }),
-}));
+// 回调必须跨渲染身份稳定：QuestionBankEditor 的切题重置 effect 依赖
+// resetState（resetAiGrading），若每次渲染返回新 vi.fn()，effect 会在每次
+// 渲染后重跑并 setState(new Set())，形成无限渲染循环（测试挂起 + 堆增长）。
+vi.mock('@/hooks/useQbankAiGrading', () => {
+  const resetState = vi.fn();
+  const startGrading = vi.fn();
+  const cancelGrading = vi.fn();
+  return {
+    useQbankAiGrading: () => ({
+      state: {
+        isGrading: false,
+        feedback: '',
+        verdict: null,
+        score: null,
+        error: null,
+      },
+      resetState,
+      startGrading,
+      cancelGrading,
+    }),
+  };
+});
 
 describe('QuestionBankEditor AI markdown rendering', () => {
   it('renders cached ai_feedback as markdown after submit', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主干 Vitest 分片 OOM/挂起的测试侧根因：全局 `react-i18next` mock 每次 `useTranslation()` 都返回新的 `t` 闭包，依赖 `t` 的 `useEffect` 自激 setState，占满微任务队列后超时器无法触发，堆无界增长。

这与 #166 产品侧 `tRef` 互补：本 PR **不改** `DataGovernanceDashboard.tsx`，只修测试 harness 与局部 mock。也不改 #168 的 `ci.yml` 堆上限。

### CI 观察（2026-08-23）
四个分片都**跑完了**，不再 OOM。仍红是因为主干既有断言漂移（源码契约、InputBar 推理文案、ToolApproval、StatusBar Windows UA 等）。那些失败不属于本切片，不要为了把 gate 刷绿把全仓测试断言塞进本 PR。

### Changes
- `tests/ct/mocks/react-i18next.tsx`：按 namespace 缓存稳定 `t`
- 新增 harness 契约测试，锁定「无关重渲染不重跑 t 依赖 effect」
- 解除挂起后对齐 data-governance 断言漂移（Tab 锚定、云存储 mock `importOriginal`）
- `NoteTagsEditor` / 题库 AI markdown 的局部 mock 身份稳定化
- 补全若干收集期崩溃的不完整 i18n mock

### How to test
```bash
npm run version:generate
npx vitest run --logHeapUsage \
  tests/vitest/data-governance/ \
  src/features/workbench/apps/notes/__tests__/NotesBacklinksPanel.test.tsx
```

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。与 #166（产品 tRef）、#168（ci heap）互补。合入后各草稿的 Vitest 仍可能因主干断言漂移失败，但不应再被自激循环打死。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

