### PR TITLE
test(workbench): 固定 StatusBar Windows UA 断言

### DIFF
--- a/src/features/workbench/components/__tests__/StatusBar.test.tsx
+++ b/src/features/workbench/components/__tests__/StatusBar.test.tsx
@@ -450,10 +450,22 @@ describe('StatusBar 学习中心 SB3', () => {
   });
 
   it('Windows 下 menubar 标记 chrome inset', () => {
-    render(<StatusBar />);
-    const bar = screen.getByTestId('wb-menubar');
-    // jsdom UA 多为 Windows / 默认 platform 为 windows
-    expect(bar.getAttribute('data-chrome-inset')).toBe('windows');
+    const originalUserAgent = navigator.userAgent;
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+      configurable: true,
+    });
+
+    try {
+      render(<StatusBar />);
+      const bar = screen.getByTestId('wb-menubar');
+      expect(bar.getAttribute('data-chrome-inset')).toBe('windows');
+    } finally {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: originalUserAgent,
+        configurable: true,
+      });
+    }
   });
 
   it('macOS 下状态栏与原生交通灯共面，并由空白区接管拖拽和双击缩放', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

CI 里 jsdom 的 `navigator.userAgent` 不再默认像 Windows，`StatusBar` 的「Windows 下 menubar 标记 chrome inset」用例会拿到 `null`。本 PR 只在该用例里钉住 Windows UA，测完还原。

从 #158 厨房水槽抽出；#161 是 workbench 产品正主，本切片只动测试。

### Changes
- `src/features/workbench/components/__tests__/StatusBar.test.tsx` 一处

### How to test
- `npx vitest run src/features/workbench/components/__tests__/StatusBar.test.tsx`

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。不要把这段塞进 #185（泄漏隔离）或 #161（壳层产品改动）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

