### PR TITLE
fix(test): 加快 scrollbar 契约扫描，避免 5s 超时

### DIFF
--- a/tests/vitest/scrollbarVisualContract.test.ts
+++ b/tests/vitest/scrollbarVisualContract.test.ts
@@ -76,10 +76,16 @@ const virtualQuestionListSource = readFileSync(
   'utf-8',
 );
 
+// 测试夹具与 node 产物不会承载产品样式/组件，扫描它们只会放大 CI 耗时。
+const skippedScanDirectories = new Set(['__tests__', '__mocks__', 'node_modules']);
+
 function collectSourceFiles(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const absolutePath = resolve(directory, entry.name);
-    return entry.isDirectory() ? collectSourceFiles(absolutePath) : absolutePath;
+    if (entry.isDirectory()) {
+      return skippedScanDirectories.has(entry.name) ? [] : collectSourceFiles(absolutePath);
+    }
+    return absolutePath;
   });
 }
 
@@ -103,13 +109,19 @@ const embeddedDocumentScrollbarExemptions = new Set([
   'features/learning-hub/apps/views/epubReaderModel.ts',
 ]);
 
+// 违规判定必然要求源码中连续出现下列标记之一（空白折叠不会拼接非空白字符，
+// 所以规范化后的选择器含 '::-webkit-scrollbar' 蕴含源码原文同样包含它）。
+// 绝大多数文件不含任何标记，先做一次线性预筛即可跳过昂贵的逐块解析。
+const scrollbarRecipeMarker = /::-webkit-scrollbar|scrollbar-width|scrollbar-color/;
+
 function findPrivateVisibleScrollbarRecipes(): string[] {
   const violations = new Set<string>();
 
   for (const { file, source } of scrollbarSourceEntries) {
     if (
       file === 'styles/native-feel/scrollbars.css' ||
-      embeddedDocumentScrollbarExemptions.has(file)
+      embeddedDocumentScrollbarExemptions.has(file) ||
+      !scrollbarRecipeMarker.test(source)
     ) {
       continue;
     }
@@ -288,9 +300,14 @@ describe('repository-wide scrollbar integration contract', () => {
     ).toContain('.scrollbar-none [class~="os-scrollbar"] {');
   });
 
-  it('does not introduce feature-private visible scrollbar recipes', () => {
-    expect(findPrivateVisibleScrollbarRecipes()).toEqual([]);
-  });
+  it(
+    'does not introduce feature-private visible scrollbar recipes',
+    () => {
+      expect(findPrivateVisibleScrollbarRecipes()).toEqual([]);
+    },
+    // 全量扫描 src 在冷缓存的 CI 分片上可能超过默认 5s，显式放宽兜底。
+    30_000,
+  );
 
   it('does not let chat depend on the mindmap custom-scrollbar selector', () => {
     const chatCustomScrollbarUses = scrollbarSourceEntries


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`scrollbarVisualContract` 全 `src` 扫描在 CI 默认 5s 超时。只改该测试：跳过测试夹具目录、无滚动条标记的文件预筛，并给该 `it` 30s 兜底。

不改 #165 token / 产品滚动条。

### Changes
- `tests/vitest/scrollbarVisualContract.test.ts`

### How to test
- `npx vitest run tests/vitest/scrollbarVisualContract.test.ts`

本地报告：该用例从 ~3.8s 降到整文件 778ms / 14 通过。

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

