### PR TITLE
fix(test): 为 jsdom 补 IntersectionObserver shim

### DIFF
--- a/tests/vitest/setup/intersectionObserverShim.test.ts
+++ b/tests/vitest/setup/intersectionObserverShim.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+// 锁定 vitest.setup.ts 提供的 IntersectionObserver 最小 shim：
+// jsdom 不实现该 API，一旦 setup 里的 shim 被移除，依赖它的组件
+// （NotesCrepeEditor / MindMapCanvas / PptxPreview / DocxPreview）
+// 会在 mount 时以 ReferenceError 崩掉整个用例。
+describe('IntersectionObserver shim (vitest.setup.ts)', () => {
+  it('exists on globalThis after setup', () => {
+    expect(globalThis.IntersectionObserver).toBeTypeOf('function');
+  });
+
+  it('can be constructed and exposes the four instance methods', () => {
+    const observer = new IntersectionObserver(() => {});
+    expect(observer.observe).toBeTypeOf('function');
+    expect(observer.unobserve).toBeTypeOf('function');
+    expect(observer.disconnect).toBeTypeOf('function');
+    expect(observer.takeRecords).toBeTypeOf('function');
+
+    const target = document.createElement('div');
+    expect(() => {
+      observer.observe(target);
+      observer.unobserve(target);
+      observer.disconnect();
+    }).not.toThrow();
+    expect(observer.takeRecords()).toEqual([]);
+  });
+
+  it('honors init options for root/rootMargin/thresholds', () => {
+    const root = document.createElement('div');
+    const observer = new IntersectionObserver(() => {}, {
+      root,
+      rootMargin: '10px',
+      threshold: [0, 0.5, 1],
+    });
+    expect(observer.root).toBe(root);
+    expect(observer.rootMargin).toBe('10px');
+    expect(observer.thresholds).toEqual([0, 0.5, 1]);
+
+    const defaults = new IntersectionObserver(() => {});
+    expect(defaults.root).toBeNull();
+    expect(defaults.rootMargin).toBe('0px');
+    expect(defaults.thresholds).toEqual([0]);
+  });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -68,6 +68,31 @@ class RO {
 // @ts-ignore
 global.ResizeObserver = (global as any).ResizeObserver || RO;
 
+// Minimal IntersectionObserver shim for JSDOM（jsdom 不实现该 API，
+// NotesCrepeEditor / MindMapCanvas / PptxPreview / DocxPreview 等组件
+// 在 mount 时 new IntersectionObserver 会直接 ReferenceError 崩掉整个用例）。
+// 只保证构造与四个实例方法可调用，不派发回调；需要驱动 isIntersecting
+// 的用例应在自身文件里替换为可控 mock。
+class IO implements IntersectionObserver {
+  readonly root: Element | Document | null;
+  readonly rootMargin: string;
+  readonly thresholds: ReadonlyArray<number>;
+  constructor(_callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+    this.root = options?.root ?? null;
+    this.rootMargin = options?.rootMargin ?? '0px';
+    const threshold = options?.threshold ?? 0;
+    this.thresholds = Array.isArray(threshold) ? threshold : [threshold];
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+// @ts-ignore
+globalThis.IntersectionObserver = (globalThis as any).IntersectionObserver || IO;
+
 if (typeof window !== 'undefined') {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

CI 分片里大量 `ReferenceError: IntersectionObserver is not defined`。在 `vitest.setup.ts` 补最小 shim，不改产品组件，不改 #185 的 i18n mock。

### Changes
- `vitest.setup.ts`：可构造的 IntersectionObserver（observe/unobserve/disconnect/takeRecords）
- `tests/vitest/setup/intersectionObserverShim.test.ts` 锁定契约

### How to test
```bash
npx vitest run tests/vitest/setup/intersectionObserverShim.test.ts \
  tests/vitest/notes/NotesCrepeEditor.windowing.test.tsx
```

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。与 #185 互补，不要互相改对方 harness。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

