### PR TITLE
fix(qbank): complete 时空反馈不再抹掉已流出的解析

### DIFF
--- a/src/hooks/useQbankAiGrading.ts
+++ b/src/hooks/useQbankAiGrading.ts
@@ -74,6 +74,9 @@ export function useQbankAiGrading() {
   // executor 外的路径也能结束 Promise，避免 startGrading 的 await 永久挂起。
   const settleRef = useRef<((result: 'completed' | 'cancelled') => void) | null>(null);
   const failRef = useRef<((error: Error) => void) | null>(null);
+  // #56: 流式累积文本的同步镜像。complete 事件的 payload.feedback 为空时
+  // （如网关终态不回传全文），以已累积文本兜底，保证 onComplete 不发空串。
+  const accumulatedFeedbackRef = useRef('');
   const lastRequestRef = useRef<{
     questionId: string;
     submissionId: string;
@@ -156,6 +159,7 @@ export function useQbankAiGrading() {
         // 生成新的 stream session ID
         const streamSessionId = nanoid(12);
         currentStreamSessionIdRef.current = streamSessionId;
+        accumulatedFeedbackRef.current = '';
 
         // 清理旧状态
         cleanup();
@@ -201,6 +205,9 @@ export function useQbankAiGrading() {
             resetTimeout();
 
             if (payload.type === 'data') {
+              if (payload.accumulated) {
+                accumulatedFeedbackRef.current = payload.accumulated;
+              }
               setState((prev) => ({
                 ...prev,
                 feedback: payload.accumulated || prev.feedback,
@@ -211,17 +218,22 @@ export function useQbankAiGrading() {
               cleanup();
               const finalVerdict = payload.verdict as QbankVerdict | undefined;
               const finalScore = payload.score;
+              // #56: 终态文本 = 非空 payload.feedback，否则回退到已累积的流式文本。
+              // state 与 onComplete 使用同一份终态文本——此前 onComplete 在
+              // payload.feedback 为空时传 ''，父组件（解析缓存等）拿到空串后
+              // 已渲染的流式内容会在切题回来时整段消失。
+              const finalFeedback = payload.feedback || accumulatedFeedbackRef.current;
               setState((prev) => ({
                 ...prev,
                 isGrading: false,
-                feedback: payload.feedback || prev.feedback,
+                feedback: finalFeedback || prev.feedback,
                 verdict: finalVerdict,
                 score: finalScore,
               }));
               isActiveRef.current = false;
               currentStreamSessionIdRef.current = null;
               // 直接回调，避免闭包过时值问题
-              onComplete?.(finalVerdict, finalScore, payload.feedback || '');
+              onComplete?.(finalVerdict, finalScore, finalFeedback);
               settle('completed');
             }
 
@@ -336,6 +348,7 @@ export function useQbankAiGrading() {
     cleanup();
     setState(INITIAL_STATE);
     currentStreamSessionIdRef.current = null;
+    accumulatedFeedbackRef.current = '';
     isActiveRef.current = false;
     isStartingRef.current = false;
     lastRequestRef.current = null;

--- a/tests/vitest/question-bank-ai-grading-stream.test.tsx
+++ b/tests/vitest/question-bank-ai-grading-stream.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * #56 回归：题库 AI 批改/解析流式完成后文本不消失
+ *
+ * 场景：DMXapi Gemini-3-flash 等网关在 complete 终态事件中可能不带全文
+ * （feedback 为空串）。此前 hook 的 state 用 prev 兜底，但 onComplete 却把
+ * 空串透传给父组件——QuestionBankEditor 的解析缓存（aiFeedbackCacheRef）
+ * 因空串守卫永远写不进终态文本，切题回来后已渲染的解析整段消失。
+ *
+ * 契约：complete 时终态文本 = 非空 payload.feedback，否则用已累积的流式
+ * 文本；state 与 onComplete 必须拿到同一份非空终态文本。
+ */
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockListen = vi.fn();
+const mockInvoke = vi.fn();
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: unknown[]) => mockListen(...args),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+import { useQbankAiGrading } from '@/hooks/useQbankAiGrading';
+
+type StreamHandler = (event: { payload: Record<string, unknown> }) => void;
+
+describe('useQbankAiGrading complete 终态文本（#56）', () => {
+  let streamHandler: StreamHandler | null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    streamHandler = null;
+
+    mockListen.mockImplementation(async (_event: string, handler: StreamHandler) => {
+      streamHandler = handler;
+      return () => undefined;
+    });
+    mockInvoke.mockResolvedValue(undefined);
+  });
+
+  async function startAndStream(
+    onComplete: (verdict?: string, score?: number, feedback?: string) => void,
+  ) {
+    const { result } = renderHook(() => useQbankAiGrading());
+
+    let settled: Promise<'completed' | 'cancelled'>;
+    act(() => {
+      settled = result.current.startGrading('q1', 'sub1', 'analyze', undefined, onComplete);
+      // 失败时避免 unhandled rejection 干扰断言输出
+      settled.catch(() => undefined);
+    });
+
+    await waitFor(() => {
+      expect(streamHandler).not.toBeNull();
+    });
+
+    act(() => {
+      streamHandler?.({ payload: { type: 'data', chunk: '解题', accumulated: '解题' } });
+      streamHandler?.({
+        payload: { type: 'data', chunk: '思路：先看题干', accumulated: '解题思路：先看题干' },
+      });
+    });
+
+    expect(result.current.state.feedback).toBe('解题思路：先看题干');
+
+    return { result, settled: settled! };
+  }
+
+  it('complete 的 feedback 为空串时，state 保留累积文本且 onComplete 不传空串', async () => {
+    const onComplete = vi.fn();
+    const { result, settled } = await startAndStream(onComplete);
+
+    act(() => {
+      streamHandler?.({
+        payload: {
+          type: 'complete',
+          submission_id: 'sub1',
+          verdict: null,
+          score: null,
+          feedback: '',
+        },
+      });
+    });
+
+    await expect(settled).resolves.toBe('completed');
+
+    // 已流式渲染的文本不能在 complete 后消失
+    expect(result.current.state.isGrading).toBe(false);
+    expect(result.current.state.feedback).toBe('解题思路：先看题干');
+
+    // onComplete 必须拿到同一份终态文本，而不是空串——
+    // 否则父组件解析缓存写不进去，切题回来解析整段消失
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete.mock.calls[0][2]).toBe('解题思路：先看题干');
+  });
+
+  it('complete 带非空 feedback 时，state 与 onComplete 都以 payload.feedback 为准', async () => {
+    const onComplete = vi.fn();
+    const { result, settled } = await startAndStream(onComplete);
+
+    act(() => {
+      streamHandler?.({
+        payload: {
+          type: 'complete',
+          submission_id: 'sub1',
+          verdict: null,
+          score: null,
+          feedback: '解题思路：先看题干（终态全文）',
+        },
+      });
+    });
+
+    await expect(settled).resolves.toBe('completed');
+
+    expect(result.current.state.feedback).toBe('解题思路：先看题干（终态全文）');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete.mock.calls[0][2]).toBe('解题思路：先看题干（终态全文）');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

修 #56：题库 AI 批改/解析流式文本在 complete 后消失。后端 complete 已带累积文本；hook 却把空的 `payload.feedback` 传给 `onComplete('')`，父组件缓存写不进终态，切题后整段没了。

### Changes
- `useQbankAiGrading`：终态文本 = 非空 payload.feedback，否则用累积 ref；state 与 onComplete 共用
- 新增 `question-bank-ai-grading-stream.test.tsx`

### How to test
- `npx vitest run tests/vitest/question-bank-ai-grading-stream.test.tsx`

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [x] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。不碰 #160 practice / #180 chat stream。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

