### PR TITLE
fix(pdf): Windows 中文路径 canonicalize 前缀对齐，避免 pdfstream 403

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3104,8 +3104,13 @@ pub async fn pdfstream_check_access(
         Err(e) => return Ok(denied(&format!("文件不存在或不可读: {}", e))),
     };
 
+    // #59：与协议处理器使用同一 path_is_within 比较（Windows \\?\ verbatim 归一化），
+    // 避免探测与实际加载结果不一致。
     let allowed_dirs = crate::pdf_protocol::resolve_allowed_dirs(&app);
-    if !allowed_dirs.iter().any(|dir| canonical.starts_with(dir)) {
+    if !allowed_dirs
+        .iter()
+        .any(|dir| crate::pdf_protocol::path_is_within(&canonical, dir))
+    {
         return Ok(denied("路径不在 pdfstream 白名单目录内"));
     }
 

--- a/src-tauri/src/file_stream_protocol.rs
+++ b/src-tauri/src/file_stream_protocol.rs
@@ -118,7 +118,10 @@ fn opened_file_matches_authorized_path(
         else {
             return false;
         };
-        actual_path == expected_path && allowed_dirs.iter().any(|dir| path_is_within(&actual_path, dir))
+        actual_path == expected_path
+            && allowed_dirs
+                .iter()
+                .any(|dir| path_is_within(&actual_path, dir))
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
@@ -975,7 +978,10 @@ mod tests {
         let response =
             handle_asset_protocol(&request, &allowed_dirs, &blob_dirs).expect("response");
         assert_eq!(response.status(), tauri::http::StatusCode::OK);
-        assert_eq!(response.headers().get("Content-Type").unwrap(), "audio/mpeg");
+        assert_eq!(
+            response.headers().get("Content-Type").unwrap(),
+            "audio/mpeg"
+        );
         assert_eq!(response.body().as_slice(), b"ID3-test-body");
 
         // 白名单外的中文路径 → 403

--- a/src-tauri/src/file_stream_protocol.rs
+++ b/src-tauri/src/file_stream_protocol.rs
@@ -12,7 +12,11 @@
 // pdf_protocol 中仅 resolve_allowed_dirs / handle_asset_protocol / cors_origin_for_request
 // 为 pub，其余辅助函数（Range 解析、CORS 构造、预算、句柄复核）为私有，
 // 按任务约定在本文件内复制实现，不修改 pdf_protocol.rs。
+// ★ 2026-08-23（#59 例外）：白名单路径包含判定是安全关键比较，
+// 统一复用 pdf_protocol::path_is_within（Windows \\?\ verbatim 书写形式归一化），
+// 避免两个协议对同一路径给出不同的 403 判定。
 
+use crate::pdf_protocol::path_is_within;
 use log::{info, warn};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
@@ -114,7 +118,7 @@ fn opened_file_matches_authorized_path(
         else {
             return false;
         };
-        actual_path == expected_path && allowed_dirs.iter().any(|dir| actual_path.starts_with(dir))
+        actual_path == expected_path && allowed_dirs.iter().any(|dir| path_is_within(&actual_path, dir))
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
@@ -130,7 +134,7 @@ fn opened_file_matches_authorized_path(
             && post_open_path == expected_path
             && allowed_dirs
                 .iter()
-                .any(|dir| post_open_path.starts_with(dir))
+                .any(|dir| path_is_within(&post_open_path, dir))
     }
 }
 
@@ -189,9 +193,11 @@ pub fn resolve_blob_dirs(app: &tauri::AppHandle) -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     if let Some(state) = app.try_state::<crate::commands::AppState>() {
         if let Some(vfs_db) = state.vfs_db.as_ref() {
-            if let Ok(blobs_dir) = std::fs::canonicalize(vfs_db.blobs_dir()) {
-                dirs.push(blobs_dir);
-            }
+            // #59：canonicalize 失败时保留原始路径（与 resolve_allowed_dirs 一致），
+            // 书写形式差异由 path_is_within 归一化处理。
+            let blobs_dir = std::fs::canonicalize(vfs_db.blobs_dir())
+                .unwrap_or_else(|_| vfs_db.blobs_dir().to_path_buf());
+            dirs.push(blobs_dir);
         }
     }
     dirs
@@ -206,7 +212,10 @@ fn is_allowed_media_extension(ext: &str) -> bool {
 /// - blobs 目录内：任意扩展名（含无扩展名），目录本身即授权边界；
 /// - 其余白名单目录：必须命中媒体扩展名白名单（大小写不敏感）。
 fn extension_permitted(canonical_path: &Path, blob_dirs: &[PathBuf]) -> bool {
-    if blob_dirs.iter().any(|dir| canonical_path.starts_with(dir)) {
+    if blob_dirs
+        .iter()
+        .any(|dir| path_is_within(canonical_path, dir))
+    {
         return true;
     }
     canonical_path
@@ -222,22 +231,44 @@ fn extension_permitted(canonical_path: &Path, blob_dirs: &[PathBuf]) -> bool {
 fn has_hidden_segment_within(canonical_path: &Path, allowed_dirs: &[PathBuf]) -> bool {
     let Some(base) = allowed_dirs
         .iter()
-        .filter(|dir| canonical_path.starts_with(dir))
+        .filter(|dir| path_is_within(canonical_path, dir))
         .max_by_key(|dir| dir.components().count())
     else {
         // 不在白名单内：调用方应已拒绝，此处保守视为隐藏
         return true;
     };
-    let Ok(relative) = canonical_path.strip_prefix(base) else {
-        return true;
-    };
-    relative.components().any(|c| {
-        matches!(
-            c,
-            std::path::Component::Normal(name)
-                if name.to_string_lossy().starts_with('.')
-        )
-    })
+    hidden_component_after(canonical_path, base)
+}
+
+/// `path` 在 `base` 之下的相对部分是否含点号开头的组件。
+/// 组件级 strip_prefix 失败时（Windows 上两侧 \\?\ verbatim 书写形式不一致），
+/// 用归一化文本做同义比较；无法确定相对关系时保守视为隐藏（fail-closed）。
+fn hidden_component_after(path: &Path, base: &Path) -> bool {
+    if let Ok(relative) = path.strip_prefix(base) {
+        return relative.components().any(|c| {
+            matches!(
+                c,
+                std::path::Component::Normal(name)
+                    if name.to_string_lossy().starts_with('.')
+            )
+        });
+    }
+
+    #[cfg(windows)]
+    {
+        use crate::pdf_protocol::{windows_comparable_path_text, windows_path_starts_with};
+        if let (Some(path_text), Some(base_text)) = (path.to_str(), base.to_str()) {
+            if windows_path_starts_with(path_text, base_text) {
+                let path_norm = windows_comparable_path_text(path_text);
+                let base_norm = windows_comparable_path_text(base_text);
+                // 大小写折叠不影响 '.' 前缀判定
+                let rest = path_norm.strip_prefix(&base_norm).unwrap_or("");
+                return rest.split('\\').any(|segment| segment.starts_with('.'));
+            }
+        }
+    }
+
+    true
 }
 
 /// 根据文件扩展名返回 MIME 类型（大小写不敏感）。
@@ -378,9 +409,10 @@ pub fn handle_asset_protocol(
     };
 
     // 安全检查 1：目录白名单 — 规范路径必须位于已授权目录下
+    // （#59：path_is_within 归一化 Windows 的 \\?\ verbatim 与普通盘符书写形式）
     let is_in_allowed_dir = allowed_dirs
         .iter()
-        .any(|dir| canonical_path.starts_with(dir));
+        .any(|dir| path_is_within(&canonical_path, dir));
     if !is_in_allowed_dir {
         warn!(
             "[filestream] 拒绝访问白名单外路径: {}",
@@ -665,7 +697,10 @@ pub async fn filestream_check_access(app: tauri::AppHandle, path: String) -> Res
     };
 
     let allowed_dirs = crate::pdf_protocol::resolve_allowed_dirs(&app);
-    if !allowed_dirs.iter().any(|dir| canonical.starts_with(dir)) {
+    if !allowed_dirs
+        .iter()
+        .any(|dir| path_is_within(&canonical, dir))
+    {
         return Ok(false);
     }
 
@@ -920,6 +955,63 @@ mod tests {
         let response =
             handle_asset_protocol(&request, &allowed_dirs, &blob_dirs).expect("response");
         assert_eq!(response.status(), tauri::http::StatusCode::NOT_FOUND);
+    }
+
+    /// #59 回归：中文目录 + 中文文件名经百分号编码 URL 加载必须成功，
+    /// 白名单外的中文路径仍必须 403。
+    #[test]
+    fn test_protocol_serves_chinese_path_and_rejects_outside_whitelist() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let allowed_dirs = vec![temp_dir.path().canonicalize().expect("canonical tempdir")];
+        let blob_dirs: Vec<PathBuf> = Vec::new();
+
+        let nested = temp_dir.path().join("学习软件").join("学习");
+        std::fs::create_dir_all(&nested).expect("mkdir chinese dirs");
+        let media_path = nested.join("网课录音.mp3");
+        std::fs::write(&media_path, b"ID3-test-body").expect("write media");
+
+        let encoded = urlencoding::encode(&media_path.to_string_lossy()).into_owned();
+        let request = make_get_request(&format!("filestream://localhost/{}", encoded));
+        let response =
+            handle_asset_protocol(&request, &allowed_dirs, &blob_dirs).expect("response");
+        assert_eq!(response.status(), tauri::http::StatusCode::OK);
+        assert_eq!(response.headers().get("Content-Type").unwrap(), "audio/mpeg");
+        assert_eq!(response.body().as_slice(), b"ID3-test-body");
+
+        // 白名单外的中文路径 → 403
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outside_path = outside.path().join("明朝那些事儿.pdf");
+        std::fs::write(&outside_path, b"%PDF-secret").expect("write outside");
+        let encoded = urlencoding::encode(&outside_path.to_string_lossy()).into_owned();
+        let request = make_get_request(&format!("filestream://localhost/{}", encoded));
+        let response =
+            handle_asset_protocol(&request, &allowed_dirs, &blob_dirs).expect("response");
+        assert_eq!(response.status(), tauri::http::StatusCode::FORBIDDEN);
+    }
+
+    /// Windows 实机验证：白名单目录为普通盘符形式、请求路径为 \\?\ verbatim 时，
+    /// 隐藏路径段检查不得因书写形式差异误拒非隐藏路径，也不得放行隐藏路径。
+    #[cfg(windows)]
+    #[test]
+    fn test_hidden_segment_check_with_mixed_verbatim_forms_on_windows() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let media_dir = temp_dir.path().join("媒体");
+        std::fs::create_dir_all(&media_dir).expect("mkdir");
+        let media_path = media_dir.join("a.mp4");
+        std::fs::write(&media_path, b"data").expect("write media");
+
+        // 白名单保持普通形式，请求路径为 canonicalize 的 verbatim 形式
+        let allowed = vec![temp_dir.path().to_path_buf()];
+        let canonical_file = std::fs::canonicalize(&media_path).expect("canonical file");
+        assert!(!has_hidden_segment_within(&canonical_file, &allowed));
+
+        // 隐藏路径段仍被拒绝
+        let hidden_dir = temp_dir.path().join(".secret");
+        std::fs::create_dir_all(&hidden_dir).expect("mkdir hidden");
+        let hidden_path = hidden_dir.join("a.mp4");
+        std::fs::write(&hidden_path, b"data").expect("write hidden");
+        let canonical_hidden = std::fs::canonicalize(&hidden_path).expect("canonical hidden");
+        assert!(has_hidden_segment_within(&canonical_hidden, &allowed));
     }
 
     #[test]

--- a/src-tauri/src/pdf_protocol.rs
+++ b/src-tauri/src/pdf_protocol.rs
@@ -92,6 +92,74 @@ fn opened_file_path(_file: &File) -> Option<PathBuf> {
     None
 }
 
+// ★ 2026-08-23（#59）：Windows 白名单路径比较的书写形式归一化。
+//
+// `std::fs::canonicalize` 在 Windows 返回 `\\?\C:\...`（verbatim）形式；
+// 白名单目录一旦以普通 `C:\...` 形式参与比较（例如 canonicalize 失败后保留原始路径），
+// `Path::starts_with` 会因 Prefix 组件不同（VerbatimDisk(D) ≠ Disk(D)）恒为 false，
+// 导致授权目录内的文件（如 `D:\中文目录\x.pdf`）被误判 403。
+//
+// 下列辅助函数只统一"同一路径的不同书写形式"（verbatim 前缀、正/反斜杠、
+// 尾部分隔符、大小写——Windows 文件系统默认大小写不敏感），
+// 不放宽"仅允许授权目录"的判定语义：比较仍要求目录前缀在组件边界上完全匹配。
+// 字符串级实现使其可以在任意平台上做单元测试（std::path 的解析是平台相关的）。
+
+/// 把 Windows 路径文本归一到可比较形式：
+/// `\\?\UNC\srv\share\x` → `\\srv\share\x`；`\\?\D:\x` → `D:\x`；
+/// `/` → `\`；去除尾部 `\`；大小写折叠。
+#[cfg_attr(not(windows), allow(dead_code))]
+pub(crate) fn windows_comparable_path_text(path: &str) -> String {
+    let unified = path.replace('/', "\\");
+    let stripped = if let Some(rest) = unified.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{}", rest)
+    } else if let Some(rest) = unified.strip_prefix(r"\\?\") {
+        rest.to_string()
+    } else {
+        unified
+    };
+    stripped.trim_end_matches('\\').to_lowercase()
+}
+
+/// Windows 语义下 `path` 是否位于目录 `dir` 内（或就是 `dir` 本身）。
+/// 前缀匹配必须落在组件边界：`D:\Docs2\x` 不属于 `D:\Docs`。
+#[cfg_attr(not(windows), allow(dead_code))]
+pub(crate) fn windows_path_starts_with(path: &str, dir: &str) -> bool {
+    let path = windows_comparable_path_text(path);
+    let dir = windows_comparable_path_text(dir);
+    if dir.is_empty() {
+        return false;
+    }
+    if path == dir {
+        return true;
+    }
+    match path.strip_prefix(&dir) {
+        Some(rest) => rest.starts_with('\\'),
+        None => false,
+    }
+}
+
+/// 白名单包含判定：先走组件级 `Path::starts_with`（所有平台的快路径，
+/// 也是非 Windows 平台的唯一判定），Windows 上再做书写形式归一化比较，
+/// 消除 `\\?\` verbatim 与普通盘符形式不一致造成的误拒。
+pub(crate) fn path_is_within(path: &Path, dir: &Path) -> bool {
+    if path.starts_with(dir) {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        // 含非法 Unicode 的路径无法可靠做文本比较，保守拒绝（fail-closed，
+        // 上面的组件级比较已经覆盖了完全一致的情况）。
+        match (path.to_str(), dir.to_str()) {
+            (Some(path), Some(dir)) => windows_path_starts_with(path, dir),
+            _ => false,
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
 fn opened_file_matches_authorized_path(
     file: &File,
     expected_path: &std::path::Path,
@@ -104,7 +172,7 @@ fn opened_file_matches_authorized_path(
         else {
             return false;
         };
-        actual_path == expected_path && allowed_dirs.iter().any(|dir| actual_path.starts_with(dir))
+        actual_path == expected_path && allowed_dirs.iter().any(|dir| path_is_within(&actual_path, dir))
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
@@ -121,7 +189,7 @@ fn opened_file_matches_authorized_path(
             && post_open_path == expected_path
             && allowed_dirs
                 .iter()
-                .any(|dir| post_open_path.starts_with(dir))
+                .any(|dir| path_is_within(&post_open_path, dir))
     }
 }
 
@@ -205,9 +273,13 @@ pub fn resolve_allowed_dirs(app: &tauri::AppHandle) -> Vec<PathBuf> {
         resolvers.push(Box::new(|| app.path().picture_dir()));
     }
 
+    // ★ 2026-08-23（#59）：canonicalize 失败（权限、长路径、网络盘等）时保留
+    // 原始授权目录，而不是静默丢弃——丢弃会让该目录下所有文件误判 403。
+    // 请求路径仍会 canonicalize；两侧书写形式差异由 path_is_within 归一化处理。
     let mut dirs: Vec<PathBuf> = resolvers
         .into_iter()
-        .filter_map(|f| f().ok().and_then(|p| std::fs::canonicalize(&p).ok()))
+        .filter_map(|f| f().ok())
+        .map(|p| std::fs::canonicalize(&p).unwrap_or(p))
         .collect();
 
     // ★ 2026-06-12（审阅问题 R1 配套）：VFS blobs 目录加入白名单。
@@ -215,10 +287,10 @@ pub fn resolve_allowed_dirs(app: &tauri::AppHandle) -> Vec<PathBuf> {
     // 教材 PDF 复制进 blob 后需要可被 pdfstream:// 流式读取。
     if let Some(state) = app.try_state::<crate::commands::AppState>() {
         if let Some(vfs_db) = state.vfs_db.as_ref() {
-            if let Ok(blobs_dir) = std::fs::canonicalize(vfs_db.blobs_dir()) {
-                if !dirs.contains(&blobs_dir) {
-                    dirs.push(blobs_dir);
-                }
+            let blobs_dir = std::fs::canonicalize(vfs_db.blobs_dir())
+                .unwrap_or_else(|_| vfs_db.blobs_dir().to_path_buf());
+            if !dirs.contains(&blobs_dir) {
+                dirs.push(blobs_dir);
             }
         }
     }
@@ -285,9 +357,11 @@ pub fn handle_asset_protocol(
     };
 
     // 安全检查 1：目录白名单 — 规范路径必须位于已授权目录下
+    // （#59：path_is_within 归一化 Windows 的 \\?\ verbatim 与普通盘符书写形式，
+    //   避免中文路径 + 反斜杠 URL 在授权目录内仍被误拒）
     let is_in_allowed_dir = allowed_dirs
         .iter()
-        .any(|dir| canonical_path.starts_with(dir));
+        .any(|dir| path_is_within(&canonical_path, dir));
     if !is_in_allowed_dir {
         warn!(
             "[pdfstream] 拒绝访问白名单外路径: {}",
@@ -723,5 +797,164 @@ mod tests {
             get_mime_type(&PathBuf::from("test.unknown")),
             "application/octet-stream"
         );
+    }
+
+    // ── #59：Windows 路径书写形式归一化（字符串级实现，可在任意平台测试）──
+
+    #[test]
+    fn test_windows_comparable_path_text_aligns_verbatim_and_plain_forms() {
+        // \\?\ verbatim 盘符 与 普通盘符 归一后一致（含中文路径）
+        assert_eq!(
+            windows_comparable_path_text(r"\\?\D:\学习软件\学习"),
+            windows_comparable_path_text(r"D:\学习软件\学习")
+        );
+        // \\?\UNC\ 与 \\server\share 归一后一致
+        assert_eq!(
+            windows_comparable_path_text(r"\\?\UNC\srv\share\教材"),
+            windows_comparable_path_text(r"\\srv\share\教材")
+        );
+        // 大小写折叠（Windows 文件系统默认大小写不敏感）
+        assert_eq!(
+            windows_comparable_path_text(r"D:\Docs\A.PDF"),
+            windows_comparable_path_text(r"d:\docs\a.pdf")
+        );
+        // 尾部分隔符与正斜杠归一
+        assert_eq!(
+            windows_comparable_path_text(r"D:\Docs\"),
+            windows_comparable_path_text("D:/Docs")
+        );
+    }
+
+    #[test]
+    fn test_windows_path_starts_with_aligns_whitelist_forms() {
+        // issue #59 场景：canonicalize 后的 verbatim 文件路径 vs 普通形式白名单目录
+        assert!(windows_path_starts_with(
+            r"\\?\D:\学习软件\学习\明朝那些事儿.pdf",
+            r"D:\学习软件"
+        ));
+        // 反向：普通形式文件路径 vs verbatim 白名单目录
+        assert!(windows_path_starts_with(
+            r"D:\学习软件\学习\明朝那些事儿.pdf",
+            r"\\?\D:\学习软件\学习"
+        ));
+        // 盘符根目录作为白名单
+        assert!(windows_path_starts_with(r"\\?\D:\x.pdf", r"D:\"));
+        // 路径等于目录本身
+        assert!(windows_path_starts_with(r"\\?\D:\Docs", r"D:\Docs"));
+        // UNC 形式对齐
+        assert!(windows_path_starts_with(
+            r"\\?\UNC\srv\share\教材\a.pdf",
+            r"\\srv\share\教材"
+        ));
+
+        // 组件边界：D:\Docs2 不属于 D:\Docs（防止前缀目录逃逸）
+        assert!(!windows_path_starts_with(r"D:\Docs2\x.pdf", r"D:\Docs"));
+        assert!(!windows_path_starts_with(
+            r"\\?\D:\学习软件2\x.pdf",
+            r"D:\学习软件"
+        ));
+        // 不同盘符 / 白名单外路径仍拒绝
+        assert!(!windows_path_starts_with(r"\\?\C:\Windows\x.pdf", r"D:\"));
+        assert!(!windows_path_starts_with(
+            r"\\?\D:\学习软件\x.pdf",
+            r"D:\其他目录"
+        ));
+        // 空目录永不匹配
+        assert!(!windows_path_starts_with(r"D:\x.pdf", ""));
+    }
+
+    #[test]
+    fn test_path_is_within_preserves_unix_semantics() {
+        // 组件级快路径（所有平台一致）
+        assert!(path_is_within(Path::new("/a/b/c.pdf"), Path::new("/a/b")));
+        assert!(path_is_within(Path::new("/a/b"), Path::new("/a/b")));
+        // 组件边界不被破坏
+        assert!(!path_is_within(Path::new("/a/bc/x.pdf"), Path::new("/a/b")));
+        assert!(!path_is_within(Path::new("/etc/passwd"), Path::new("/a")));
+        // 非 Windows 平台大小写敏感语义保持不变
+        #[cfg(not(windows))]
+        assert!(!path_is_within(Path::new("/A/B/c.pdf"), Path::new("/a/b")));
+    }
+
+    /// 中文路径 + 百分号编码 URL 的端到端回归（#59）：
+    /// 与前端 convertFileSrc(encodeURIComponent) 一致的编码方式，
+    /// 授权目录内的中文名 PDF 必须能正常 200/206，不得误判 403。
+    #[test]
+    fn test_pdfstream_serves_chinese_path_via_encoded_url() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let nested = temp_dir.path().join("学习软件").join("学习");
+        std::fs::create_dir_all(&nested).expect("mkdir chinese dirs");
+        let pdf_path = nested.join("明朝那些事儿.pdf");
+        std::fs::write(&pdf_path, b"%PDF-1.4 test-body").expect("write pdf");
+
+        let encoded = urlencoding::encode(&pdf_path.to_string_lossy()).into_owned();
+        let uri = format!("pdfstream://localhost/{}", encoded);
+        let allowed_dirs = vec![temp_dir.path().canonicalize().expect("canonical tempdir")];
+
+        let get = tauri::http::Request::builder()
+            .method(tauri::http::Method::GET)
+            .uri(&uri)
+            .body(Vec::new())
+            .expect("GET request");
+        let response = handle_asset_protocol(&get, &allowed_dirs).expect("GET response");
+        assert_eq!(response.status(), tauri::http::StatusCode::OK);
+        assert_eq!(response.body().as_slice(), b"%PDF-1.4 test-body");
+
+        let range = tauri::http::Request::builder()
+            .method(tauri::http::Method::GET)
+            .uri(&uri)
+            .header("Range", "bytes=0-7")
+            .body(Vec::new())
+            .expect("Range request");
+        let response = handle_asset_protocol(&range, &allowed_dirs).expect("Range response");
+        assert_eq!(response.status(), tauri::http::StatusCode::PARTIAL_CONTENT);
+        assert_eq!(response.body().as_slice(), b"%PDF-1.4");
+    }
+
+    /// 白名单外的中文名 PDF 仍必须 403（修复不得削弱「只允许授权目录」）。
+    #[test]
+    fn test_pdfstream_still_rejects_chinese_path_outside_whitelist() {
+        let allowed = tempfile::tempdir().expect("allowed tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let pdf_path = outside.path().join("明朝那些事儿.pdf");
+        std::fs::write(&pdf_path, b"%PDF-secret").expect("write pdf");
+
+        let encoded = urlencoding::encode(&pdf_path.to_string_lossy()).into_owned();
+        let uri = format!("pdfstream://localhost/{}", encoded);
+        let allowed_dirs = vec![allowed.path().canonicalize().expect("canonical allowed")];
+
+        let get = tauri::http::Request::builder()
+            .method(tauri::http::Method::GET)
+            .uri(&uri)
+            .body(Vec::new())
+            .expect("GET request");
+        let response = handle_asset_protocol(&get, &allowed_dirs).expect("GET response");
+        assert_eq!(response.status(), tauri::http::StatusCode::FORBIDDEN);
+        assert!(response.body().is_empty());
+    }
+
+    /// Windows 实机验证：canonicalize 产生的 \\?\ verbatim 路径必须能匹配
+    /// 普通盘符形式的白名单目录（std::path 解析平台相关，仅 Windows 可测）。
+    #[cfg(windows)]
+    #[test]
+    fn test_path_is_within_mixed_verbatim_forms_on_windows() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let nested = temp_dir.path().join("学习软件");
+        std::fs::create_dir_all(&nested).expect("mkdir");
+        let pdf_path = nested.join("明朝那些事儿.pdf");
+        std::fs::write(&pdf_path, b"%PDF").expect("write pdf");
+
+        // canonicalize 输出 \\?\ verbatim 形式
+        let canonical_file = std::fs::canonicalize(&pdf_path).expect("canonical file");
+        // 白名单目录保持普通（非 verbatim）形式，模拟 canonicalize 失败保留原始路径
+        let plain_dir = temp_dir.path().to_path_buf();
+
+        assert!(path_is_within(&canonical_file, &plain_dir));
+        // 反向：普通形式文件路径 vs verbatim 目录
+        let canonical_dir = std::fs::canonicalize(temp_dir.path()).expect("canonical dir");
+        assert!(path_is_within(&pdf_path, &canonical_dir));
+        // 白名单外仍拒绝
+        let other_dir = tempfile::tempdir().expect("other tempdir");
+        assert!(!path_is_within(&canonical_file, other_dir.path()));
     }
 }

--- a/src-tauri/src/pdf_protocol.rs
+++ b/src-tauri/src/pdf_protocol.rs
@@ -172,7 +172,10 @@ fn opened_file_matches_authorized_path(
         else {
             return false;
         };
-        actual_path == expected_path && allowed_dirs.iter().any(|dir| path_is_within(&actual_path, dir))
+        actual_path == expected_path
+            && allowed_dirs
+                .iter()
+                .any(|dir| path_is_within(&actual_path, dir))
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

修 #59：学习资源走原始 `D:\中文\….pdf` 时 pdf.js 拿到 403。Windows `canonicalize` 返回 `\\?\D:\...`，与白名单 `D:\...` 的 `starts_with` 永不相等；canonicalize 失败的授权目录还被静默丢掉。

不削弱「只允许授权目录」。`filestream` 与探测命令用同一比较。

### Changes
- `path_is_within`：剥离 `\\?\` / UNC、统一分隔符与大小写，且必须落在路径组件边界
- canonicalize 失败时保留原始授权目录
- 中文路径 200/206、非白名单仍 403 的测试

### How to test
- `cargo test --manifest-path src-tauri/Cargo.toml --lib pdf_protocol`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib file_stream_protocol`

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [x] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。不改 #163 PDF 划词 UI。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

