### PR TITLE
fix(ocr): completed_with_issues 可续跑，partial 态露出重试

### DIFF
--- a/src-tauri/src/vfs/handlers.rs
+++ b/src-tauri/src/vfs/handlers.rs
@@ -1801,9 +1801,15 @@ pub async fn vfs_upload_attachment(
                     let modes = status.progress.ready_modes.clone();
                     let stage = status.progress.stage.clone();
                     // ★ v2.1: 判断是否需要继续处理（未完成且非错误状态）
-                    let needs_resume = stage != "completed"
-                        && stage != "completed_with_issues"
-                        && stage != "error";
+                    // ★ #64: completed_with_issues 不再一律视为稳定终态——
+                    // 若上次留有可重试失败（如图片 OCR 网络错误），重新引用同一文件时
+                    // 自动续跑流水线（已完成阶段幂等跳过），否则 OCR 永久停在「未就绪」，
+                    // 且内容去重会让重新上传同一张图片也命中同一条死状态。
+                    let needs_resume = match stage.as_str() {
+                        "completed" | "error" => false,
+                        "completed_with_issues" => status.progress.has_retriable_failure(),
+                        _ => true,
+                    };
                     (Some(stage), Some(percent), Some(modes), needs_resume)
                 }
                 _ => {

--- a/src-tauri/src/vfs/pdf_processing_service.rs
+++ b/src-tauri/src/vfs/pdf_processing_service.rs
@@ -222,6 +222,21 @@ impl Default for ProcessingProgress {
     }
 }
 
+impl ProcessingProgress {
+    /// 是否存在可重试的失败阶段（`completed_with_issues` 状态下判定用）
+    ///
+    /// ★ #64：图片 OCR 阶段一次性调用失败（移动端弱网/引擎暂不可用）后，
+    /// 流水线以 completed_with_issues 收尾并记录 retriable 问题。
+    /// 该状态此前被上传链路当作稳定终态，重新引用同一文件不会续跑流水线，
+    /// OCR 永久停在「未就绪」。用此判定放行自动续跑。
+    pub fn has_retriable_failure(&self) -> bool {
+        self.failed_stages
+            .as_ref()
+            .map(|issues| issues.iter().any(|i| i.retriable))
+            .unwrap_or(false)
+    }
+}
+
 /// 处理状态
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -3587,5 +3602,65 @@ mod tests {
         assert_eq!(progress.stage, "pending");
         assert_eq!(progress.percent, 0.0);
         assert!(progress.ready_modes.is_empty());
+    }
+
+    // ★ #64 回归：completed_with_issues + retriable OCR 失败必须被判定为可续跑，
+    // 否则重新引用同一图片永远不会重试 OCR（内容去重命中同一条死状态）。
+    #[test]
+    fn test_has_retriable_failure_with_retriable_ocr_issue() {
+        let progress = ProcessingProgress {
+            stage: "completed_with_issues".to_string(),
+            failed_stages: Some(vec![ProcessingIssue {
+                stage: "ocr_processing".to_string(),
+                message: "OCR API call failed: network timeout".to_string(),
+                retriable: true,
+            }]),
+            ..Default::default()
+        };
+        assert!(progress.has_retriable_failure());
+    }
+
+    #[test]
+    fn test_has_retriable_failure_without_issues() {
+        assert!(!ProcessingProgress::default().has_retriable_failure());
+
+        let progress = ProcessingProgress {
+            stage: "completed_with_issues".to_string(),
+            failed_stages: Some(vec![]),
+            ..Default::default()
+        };
+        assert!(!progress.has_retriable_failure());
+    }
+
+    #[test]
+    fn test_has_retriable_failure_ignores_non_retriable() {
+        let progress = ProcessingProgress {
+            stage: "completed_with_issues".to_string(),
+            failed_stages: Some(vec![ProcessingIssue {
+                stage: "ocr_processing".to_string(),
+                message: "unsupported image format".to_string(),
+                retriable: false,
+            }]),
+            ..Default::default()
+        };
+        assert!(!progress.has_retriable_failure());
+    }
+
+    // 持久化到 files.processing_progress 的 JSON（camelCase failedStages）
+    // 必须能反序列化并保留 retriable 语义——上传续跑判定读的就是这份 JSON。
+    #[test]
+    fn test_has_retriable_failure_from_persisted_json() {
+        let json = r#"{
+            "stage": "completed_with_issues",
+            "percent": 100.0,
+            "readyModes": ["image"],
+            "mediaType": "image",
+            "failedStages": [
+                {"stage": "ocr_processing", "message": "OCR API call failed", "retriable": true}
+            ]
+        }"#;
+        let progress: ProcessingProgress = serde_json::from_str(json).unwrap();
+        assert!(progress.has_retriable_failure());
+        assert!(!progress.ready_modes.contains(&"ocr".to_string()));
     }
 }

--- a/src/features/chat/components/input-bar/AttachmentPreviewChips.tsx
+++ b/src/features/chat/components/input-bar/AttachmentPreviewChips.tsx
@@ -271,6 +271,11 @@ export const AttachmentPreviewChips: React.FC<AttachmentPreviewChipsProps> = mem
           const chipStatus = computeChipStatus(attachment, normalizedStoreStatus);
           const isBusy = chipStatus.lifecycle === 'uploading' || chipStatus.lifecycle === 'processing';
           const isError = chipStatus.lifecycle === 'error';
+          // ★ #64：partial（如「未就绪：OCR 文本」）同样提供重试入口。
+          // 后端 retry() 本就接受 completed_with_issues，此前只有 error 态
+          // 露出重试按钮，OCR 一次失败后用户没有任何恢复途径（重新上传
+          // 会被内容去重命中同一条失败记录），只能永远看着「未就绪」。
+          const isPartial = chipStatus.lifecycle === 'partial';
           const truncationLikely = !isError && willLikelyTruncate(attachment);
           const modeSummary = chipStatus.selectedModes.length > 0
             ? formatModeSummary(chipStatus.selectedModes)
@@ -408,8 +413,8 @@ export const AttachmentPreviewChips: React.FC<AttachmentPreviewChipsProps> = mem
                   />
                 )}
               </DsButton>
-              {/* 错误态内联重试（chip 外侧尾随，44px 触控命中区） */}
-              {isError && onRetry && attachment.sourceId && !disabled && (
+              {/* 错误态/部分未就绪态内联重试（chip 外侧尾随，44px 触控命中区） */}
+              {(isError || isPartial) && onRetry && attachment.sourceId && !disabled && (
                 <button
                   type="button"
                   onClick={(event) => {
@@ -418,7 +423,12 @@ export const AttachmentPreviewChips: React.FC<AttachmentPreviewChipsProps> = mem
                   }}
                   aria-label={t('chatV2:common.retryNamed', { name: attachment.name })}
                   title={t('common:retry')}
-                  className="relative ml-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-destructive/40 text-destructive transition-colors hover:bg-destructive/10 motion-reduce:transition-none [@media(pointer:coarse)]:after:absolute [@media(pointer:coarse)]:after:-inset-2.5 [@media(pointer:coarse)]:after:content-['']"
+                  className={cn(
+                    "relative ml-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border transition-colors motion-reduce:transition-none [@media(pointer:coarse)]:after:absolute [@media(pointer:coarse)]:after:-inset-2.5 [@media(pointer:coarse)]:after:content-['']",
+                    isError
+                      ? 'border-destructive/40 text-destructive hover:bg-destructive/10'
+                      : 'border-warning/40 text-warning hover:bg-warning/10'
+                  )}
                 >
                   <ArrowClockwise size={12} weight="bold" aria-hidden="true" />
                 </button>

--- a/tests/vitest/chat-v2/components/AttachmentPreviewChips.test.tsx
+++ b/tests/vitest/chat-v2/components/AttachmentPreviewChips.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * AttachmentPreviewChips 重试入口回归（issue #64：OCR 经常显示未就绪）
+ *
+ * 图片附件流水线 OCR 阶段一次性调用失败后，后端以 completed_with_issues 收尾，
+ * chip 进入 partial（「未就绪：OCR 文本」）。后端 retry() 本就接受该状态，
+ * 但此前只有 error 态露出重试按钮 → partial 是死状态（重新上传同一图片
+ * 会被内容去重命中同一条失败记录）。本组测试锁定：
+ * - partial 态必须露出重试入口并回调 onRetry；
+ * - ready 态不出现重试入口；
+ * - error 态重试入口保持既有行为。
+ */
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { AttachmentPreviewChips } from '@/features/chat/components/input-bar/AttachmentPreviewChips';
+import { usePdfProcessingStore } from '@/features/pdf/stores/pdfProcessingStore';
+import type { AttachmentMeta } from '@/features/chat/core/types/common';
+
+vi.mock('@/components/ui/DsButton', () => ({
+  DsButton: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock('@/components/custom-scroll-area', () => ({
+  CustomScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/features/chat/components/InlineImageViewer', () => ({
+  InlineImageViewer: () => null,
+}));
+
+function buildImageAttachment(overrides: Partial<AttachmentMeta> = {}): AttachmentMeta {
+  return {
+    id: 'att-ui-1',
+    name: 'photo.jpg',
+    type: 'image',
+    mimeType: 'image/jpeg',
+    size: 12345,
+    status: 'ready',
+    sourceId: 'att_source_1',
+    injectModes: { image: ['image', 'ocr'] },
+    ...overrides,
+  };
+}
+
+describe('AttachmentPreviewChips 重试入口', () => {
+  beforeEach(() => {
+    usePdfProcessingStore.getState().clear();
+  });
+
+  it('partial（OCR 未就绪）时露出重试入口并回调 onRetry', () => {
+    const onRetry = vi.fn();
+    const attachment = buildImageAttachment({
+      processingStatus: {
+        stage: 'completed_with_issues',
+        percent: 100,
+        readyModes: ['image'],
+        mediaType: 'image',
+      },
+    });
+
+    render(
+      <AttachmentPreviewChips
+        attachments={[attachment]}
+        onRemove={vi.fn()}
+        onRetry={onRetry}
+      />
+    );
+
+    const retryButton = screen.getByRole('button', { name: '重试 photo.jpg' });
+    expect(retryButton).toBeInTheDocument();
+
+    fireEvent.click(retryButton);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(attachment);
+  });
+
+  it('全部模式就绪时不出现重试入口', () => {
+    const attachment = buildImageAttachment({
+      processingStatus: {
+        stage: 'completed',
+        percent: 100,
+        readyModes: ['image', 'ocr'],
+        mediaType: 'image',
+      },
+    });
+
+    render(
+      <AttachmentPreviewChips
+        attachments={[attachment]}
+        onRemove={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: '重试 photo.jpg' })).toBeNull();
+  });
+
+  it('error 态重试入口保持既有行为', () => {
+    const onRetry = vi.fn();
+    const attachment = buildImageAttachment({
+      status: 'error',
+      error: '处理超时',
+    });
+
+    render(
+      <AttachmentPreviewChips
+        attachments={[attachment]}
+        onRemove={vi.fn()}
+        onRetry={onRetry}
+      />
+    );
+
+    const retryButton = screen.getByRole('button', { name: '重试 photo.jpg' });
+    fireEvent.click(retryButton);
+    expect(onRetry).toHaveBeenCalledWith(attachment);
+  });
+
+  it('缺少 sourceId 或未传 onRetry 时不出现重试入口', () => {
+    const partialStatus = {
+      stage: 'completed_with_issues' as const,
+      percent: 100,
+      readyModes: ['image'] as Array<'text' | 'ocr' | 'image'>,
+      mediaType: 'image' as const,
+    };
+
+    const { unmount } = render(
+      <AttachmentPreviewChips
+        attachments={[buildImageAttachment({ sourceId: undefined, processingStatus: partialStatus })]}
+        onRemove={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('button', { name: '重试 photo.jpg' })).toBeNull();
+    unmount();
+
+    render(
+      <AttachmentPreviewChips
+        attachments={[buildImageAttachment({ processingStatus: partialStatus })]}
+        onRemove={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('button', { name: '重试 photo.jpg' })).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

修 #64 在当前 main 上能证明的死锁：OCR 失败以 `completed_with_issues` 收尾后被当成稳定终态，重新引用/去重上传同一图不会续跑；前端 `partial`（「未就绪:OCR 文本」）又没有重试按钮。

未在真机复现 0.9.35/0.9.44。不改 #172 移动顶栏。

### Changes
- `has_retriable_failure()`：有可重试失败时允许自动续跑
- `AttachmentPreviewChips`：partial 态 warning 重试，走既有 `retry()`

### How to test
- `cargo test --manifest-path src-tauri/Cargo.toml --lib pdf_processing_service`
- `npx vitest run` 对应 AttachmentPreviewChips 测试

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [x] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。OEM 空 MIME 未改，需真机。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

