### PR TITLE
fix(linux): X11 scale 延迟时按逻辑像素兜住最小窗口

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -265,6 +265,59 @@ fn prepare_linux_appimage_runtime_env() {
     }
 }
 
+/// Linux X11 HiDPI 兜底（#65/#66「窗口显示得很小」）：
+/// X11 上 GTK 可能在窗口映射后才上报真实 scale factor（GDK_SCALE、KDE
+/// 缩放等），初始客户区被按物理像素解释，换算成逻辑像素后小于
+/// tauri.linux.conf.json 的 minWidth/minHeight。此处按逻辑像素复核，
+/// 不足则恢复到配置默认尺寸（不低于下限）并重新居中。正常尺寸下为
+/// 幂等 no-op，可在 ScaleFactorChanged 时安全复检。
+#[cfg(target_os = "linux")]
+fn enforce_linux_main_window_min_logical_size(window: &tauri::WebviewWindow) {
+    use tauri::LogicalSize;
+
+    let app_config = window.app_handle().config();
+    let Some(window_config) = app_config.app.windows.iter().find(|w| w.label == "main") else {
+        return;
+    };
+    let min_width = window_config.min_width.unwrap_or(0.0);
+    let min_height = window_config.min_height.unwrap_or(0.0);
+    if min_width <= 0.0 || min_height <= 0.0 {
+        return;
+    }
+
+    let scale_factor = window.scale_factor().unwrap_or(1.0);
+    let Ok(physical_size) = window.inner_size() else {
+        return;
+    };
+    let logical_size = physical_size.to_logical::<f64>(scale_factor);
+
+    // 容忍 1 逻辑像素内的取整误差，避免正常尺寸下反复触发 set_size。
+    if logical_size.width + 1.0 >= min_width && logical_size.height + 1.0 >= min_height {
+        return;
+    }
+
+    let target_width = window_config.width.max(min_width);
+    let target_height = window_config.height.max(min_height);
+    warn!(
+        "[setup] Linux 主窗口客户区 {:.0}x{:.0}（逻辑px，scale={}）低于配置下限 {:.0}x{:.0}，重设为 {:.0}x{:.0}",
+        logical_size.width,
+        logical_size.height,
+        scale_factor,
+        min_width,
+        min_height,
+        target_width,
+        target_height
+    );
+    let _ = window.set_min_size(Some(LogicalSize::new(min_width, min_height)));
+    if let Err(e) = window.set_size(LogicalSize::new(target_width, target_height)) {
+        warn!("[setup] 重设 Linux 主窗口尺寸失败: {}", e);
+        return;
+    }
+    if window_config.center {
+        let _ = window.center();
+    }
+}
+
 /// 启动 Tauri 应用。
 ///
 /// 目前仅做最小实现，后续可补充 `invoke_handler!` 以注册命令。
@@ -1475,6 +1528,20 @@ pub fn run() {
 
             // 快速学习小窗按需创建。不要在 setup 阶段同步构建第二个隐藏
             // WebView；Windows 上它会与主窗口启动事件争用 UI 消息循环。
+
+            // Linux X11 HiDPI 兜底：客户区逻辑尺寸不得低于 linux conf 的
+            // minWidth/minHeight。scale factor 可能在窗口映射后才更新，
+            // 因此 ScaleFactorChanged 时复检（函数本身幂等）。
+            #[cfg(target_os = "linux")]
+            if let Some(window) = app.get_webview_window("main") {
+                enforce_linux_main_window_min_logical_size(&window);
+                let window_for_scale_check = window.clone();
+                window.on_window_event(move |event| {
+                    if matches!(event, tauri::WindowEvent::ScaleFactorChanged { .. }) {
+                        enforce_linux_main_window_min_logical_size(&window_for_scale_check);
+                    }
+                });
+            }
 
             // macOS 窗口圆角设置
             #[cfg(target_os = "macos")]

--- a/tests/vitest/linuxWindowSizeContract.test.ts
+++ b/tests/vitest/linuxWindowSizeContract.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// #65/#66：X11 桌面下主窗口「显示得很小」。契约分两层：
+// 1) tauri.linux.conf.json 的默认逻辑尺寸不得低于最小客户区；
+// 2) lib.rs 保留运行时 HiDPI 兜底（按逻辑像素复核并在 scale 变化时复检）。
+describe('Linux window size contract (#65/#66 X11 too-small)', () => {
+  const config = JSON.parse(
+    readFileSync(resolve(process.cwd(), 'src-tauri/tauri.linux.conf.json'), 'utf-8'),
+  );
+  const mainWindow = config.app.windows[0];
+
+  it('declares a resizable main window with logical min size bounds', () => {
+    expect(mainWindow.resizable).toBe(true);
+    expect(mainWindow.minWidth).toBeGreaterThan(0);
+    expect(mainWindow.minHeight).toBeGreaterThan(0);
+  });
+
+  it('keeps the default logical size at or above the minimum client area', () => {
+    expect(mainWindow.width).toBeGreaterThanOrEqual(mainWindow.minWidth);
+    expect(mainWindow.height).toBeGreaterThanOrEqual(mainWindow.minHeight);
+  });
+
+  it('backs the config with the runtime X11 HiDPI guard in lib.rs', () => {
+    const libSource = readFileSync(
+      resolve(process.cwd(), 'src-tauri/src/lib.rs'),
+      'utf-8',
+    );
+    expect(libSource).toContain('fn enforce_linux_main_window_min_logical_size');
+    // 必须按逻辑像素比较（物理像素 / scale factor），不能直接用物理尺寸。
+    expect(libSource).toContain('to_logical::<f64>(scale_factor)');
+    // scale factor 可能在窗口映射后才更新，必须在变化时复检。
+    expect(libSource).toContain('tauri::WindowEvent::ScaleFactorChanged');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

#66：X11 上 GTK 可能在映射后才给出真实 scale，客户区按物理像素解释会远小于 linux conf 的 980×680。setup 与 `ScaleFactorChanged` 时用逻辑像素与配置下限比较，过小则重设。

不改 linux conf，不改 workbench 壳；按钮契约在另一 PR。

### Changes
- `enforce_linux_main_window_min_logical_size` in `lib.rs`
- `tests/vitest/linuxWindowSizeContract.test.ts`

### How to test
- `npx vitest run tests/vitest/linuxWindowSizeContract.test.ts`

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [x] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

