### PR TITLE
test(linux): 锁定原生装饰与可拉伸，防回归 #65

### DIFF
--- a/tests/vitest/linuxWindowChromeContract.test.ts
+++ b/tests/vitest/linuxWindowChromeContract.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #65/#66 防回归契约：Linux 桌面主窗口 chrome。
+ *
+ * 背景：v0.9.35 尚无 tauri.linux.conf.json，Linux 打包直接落到基座
+ * tauri.conf.json 的 decorations:false，而前端自定义窗口按钮只在
+ * isWindows() 下渲染 —— Debian/KDE（X11 与 Wayland）用户因此既没有
+ * 关闭/最大化/最小化按钮，也无法拉伸窗口（GTK 无装饰窗口没有
+ * 边缘 resize），X11 上还出现初始窗口过小。
+ *
+ * Tauri 2 会在 Linux 目标构建时用 JSON Merge Patch 合并
+ * tauri.linux.conf.json，其中数组是整体替换：linux conf 的
+ * app.windows[0] 必须自带完整窗口定义，任何字段都不会从基座继承。
+ *
+ * 本契约锁定：Linux 至少存在一条完整窗口 chrome 路径 ——
+ * 要么 linux conf 开启原生装饰（decorations + resizable + 可用尺寸），
+ * 要么前端壳层在 Linux 下渲染自定义 min/max/close 控件。
+ */
+
+const readText = (relativePath: string): string =>
+  readFileSync(resolve(process.cwd(), relativePath), 'utf-8');
+
+const baseConf = JSON.parse(readText('src-tauri/tauri.conf.json'));
+const linuxConf = JSON.parse(readText('src-tauri/tauri.linux.conf.json'));
+const appSource = readText('src/App.tsx');
+const statusBarSource = readText('src/features/workbench/components/StatusBar.tsx');
+
+const linuxWindows: Array<Record<string, unknown>> = linuxConf.app?.windows ?? [];
+const linuxWindow = linuxWindows[0] ?? {};
+
+const linuxHasNativeChrome =
+  linuxWindow.decorations === true && linuxWindow.resizable === true;
+
+// 壳层源码中是否存在 isLinux() 门控的自定义窗口控件渲染路径
+const rendersLinuxCustomControls = [appSource, statusBarSource].some((source) =>
+  /\bisLinux\(\)[^]{0,200}WindowControls/.test(source),
+);
+
+describe('Linux window chrome contract (#65/#66)', () => {
+  it('linux conf 保持原生装饰与可拉伸', () => {
+    expect(linuxWindows).toHaveLength(1);
+    expect(linuxWindow.decorations).toBe(true);
+    expect(linuxWindow.resizable).toBe(true);
+    expect(linuxWindow.fullscreen).toBe(false);
+    // lib.rs 通过 get_webview_window("main") 做显示/聚焦，label 不能漂移
+    expect((linuxWindow.label as string | undefined) ?? 'main').toBe('main');
+  });
+
+  it('linux conf 自带完整窗口定义（JSON Merge Patch 整体替换 windows 数组，字段不继承基座）', () => {
+    for (const key of [
+      'title',
+      'width',
+      'height',
+      'minWidth',
+      'minHeight',
+      'resizable',
+      'decorations',
+    ]) {
+      expect(linuxWindow, `tauri.linux.conf.json windows[0] 缺少 ${key}`).toHaveProperty(key);
+    }
+  });
+
+  it('默认尺寸可用且不小于最小尺寸（X11 初始小窗防回归）', () => {
+    const width = linuxWindow.width as number;
+    const height = linuxWindow.height as number;
+    const minWidth = linuxWindow.minWidth as number;
+    const minHeight = linuxWindow.minHeight as number;
+
+    expect(minWidth).toBeGreaterThanOrEqual(640);
+    expect(minHeight).toBeGreaterThanOrEqual(480);
+    expect(width).toBeGreaterThanOrEqual(minWidth);
+    expect(height).toBeGreaterThanOrEqual(minHeight);
+  });
+
+  it('Linux 桌面至少一条完整窗口 chrome 路径：原生装饰或前端自定义控件', () => {
+    expect(linuxHasNativeChrome || rendersLinuxCustomControls).toBe(true);
+  });
+
+  it('基座 decorations:false 不允许泄漏到 Linux 构建', () => {
+    const baseWindow = baseConf.app?.windows?.[0] ?? {};
+    if (baseWindow.decorations !== true) {
+      // 基座是无边框窗口时，linux conf 必须提供 windows overlay 兜底
+      expect(linuxWindows.length).toBeGreaterThan(0);
+      expect(linuxHasNativeChrome || rendersLinuxCustomControls).toBe(true);
+    }
+  });
+
+  it('原生装饰开启时，壳层不为 Linux 重复渲染自定义窗口按钮', () => {
+    if (linuxHasNativeChrome) {
+      expect(rendersLinuxCustomControls).toBe(false);
+      // 当前的平台门控快照：主壳层与工作台菜单栏的自定义三键仅限 Windows。
+      // 若这两行改动（例如把控件扩展到 Linux），需同步复核 linux conf 的
+      // decorations 设置，避免出现双份窗口按钮或两头皆无。
+      expect(appSource).toContain('{isWindows() && <WindowControls />}');
+      expect(statusBarSource).toContain('const winChromeInset = isWindows();');
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

#65/#66 在 0.9.35 上无 linux overlay，`decorations: false` 导致无三键、不可拉伸。main 自 #118 / v0.9.41 已有 `tauri.linux.conf.json`。本 PR 只加契约测试，防止再漏 overlay 或 Linux 两头都不画按钮。

### Changes
- `tests/vitest/linuxWindowChromeContract.test.ts`

### How to test
- `npx vitest run tests/vitest/linuxWindowChromeContract.test.ts`

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [x] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。不改 #161 / #172。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

