### PR TITLE
fix(attachments): 去掉散落的 50MB 上限，统一 200MB 常量

### DIFF
--- a/src/components/ExamSheetUploader.tsx
+++ b/src/components/ExamSheetUploader.tsx
@@ -42,6 +42,7 @@ import { UnifiedModelSelector, type UnifiedModelInfo } from '@/components/shared
 import { UnifiedDragDropZone, type FileTypeDefinition } from '@/components/shared/UnifiedDragDropZone';
 import type { ApiConfig } from '@/types';
 import { debugLog } from '@/debug-panel/debugMasterSwitch';
+import { ATTACHMENT_MAX_SIZE } from '@/features/chat/core/constants';
 
 // ★ 试卷上传专用文件类型（支持 HEIC，与统一组件的 IMAGE 略有不同）
 // 导出给题目集启动台的拖放区域复用，保证两处接受的文件类型一致
@@ -95,10 +96,11 @@ interface FileInfo {
 const IMAGE_FORMATS = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp', 'image/heic'];
 const DOCUMENT_EXTENSIONS = ['.docx', '.xlsx', '.xls', '.txt', '.md', '.pdf'];
 
-// ★ 上传文件大小上限：与 UnifiedDragDropZone 的 Tauri 原生拖拽路径保持一致（50MB）。
+// ★ 上传文件大小上限：与会话附件 ATTACHMENT_MAX_SIZE (200MB) 及
+// UnifiedDragDropZone 的 Tauri 原生拖拽路径保持一致（#62）。
 // 点击选择 / 浏览器 dataTransfer 拖拽路径不经过原生路径校验，必须在此兜底，
 // 否则超大文件会被整体 FileReader→base64 读入内存。
-const MAX_UPLOAD_FILE_SIZE = 50 * 1024 * 1024;
+const MAX_UPLOAD_FILE_SIZE = ATTACHMENT_MAX_SIZE;
 
 // 处理步骤
 type ProcessStep = 'select' | 'preview' | 'processing' | 'summary';
@@ -1285,7 +1287,7 @@ export const ExamSheetUploader: React.FC<ExamSheetUploaderProps> = ({
                 onDragStateChange={setIsDragActive}
                 acceptedFileTypes={[EXAM_IMAGE_TYPE, EXAM_DOCUMENT_TYPE]}
                 maxFiles={currentCategory === 'document' ? 1 : 20}
-                maxFileSize={50 * 1024 * 1024}
+                maxFileSize={MAX_UPLOAD_FILE_SIZE}
                 showOverlay={true}
                 enabled={!isProcessing}
                 className={cn(

--- a/src/components/QuestionBankListView.tsx
+++ b/src/components/QuestionBankListView.tsx
@@ -42,6 +42,7 @@ import type { Question, QuestionBankStats, QuestionStatus, Difficulty, QuestionT
 import { ratioToPercent } from '@/components/stats';
 import { QuestionInlineEditor } from './QuestionInlineEditor';
 import { UnifiedDragDropZone } from '@/components/shared/UnifiedDragDropZone';
+import { ATTACHMENT_MAX_SIZE } from '@/features/chat/core/constants';
 import { Skeleton } from '@/components/ui/shad/Skeleton';
 import { EXAM_DOCUMENT_TYPE, EXAM_IMAGE_TYPE } from './ExamSheetUploader';
 import { getQuestionTypeMeta, QUESTION_TYPE_ORDER, type ExtendedQuestionType } from './questionTypeMeta';
@@ -1171,7 +1172,7 @@ export const QuestionBankListView: React.FC<QuestionBankListViewProps> = ({
           onFilesDropped={onUploadFiles}
           acceptedFileTypes={[EXAM_IMAGE_TYPE, EXAM_DOCUMENT_TYPE]}
           maxFiles={20}
-          maxFileSize={50 * 1024 * 1024}
+          maxFileSize={ATTACHMENT_MAX_SIZE}
           showOverlay
           className="h-full"
         >

--- a/src/components/TranslateWorkbench.tsx
+++ b/src/components/TranslateWorkbench.tsx
@@ -24,6 +24,7 @@ import { debugLog } from '../debug-panel/debugMasterSwitch';
 // 子组件
 import { TranslationMain } from './translation/TranslationMain';
 import { copyTextToClipboard } from '@/utils/clipboardUtils';
+import { ATTACHMENT_MAX_SIZE } from '@/features/chat/core/constants';
 import { registerContentDirtyChecker } from '@/features/workbench/apps/content/contentDirtyRegistry';
 
 const console = debugLog as Pick<typeof debugLog, 'log' | 'warn' | 'error' | 'info' | 'debug'>;
@@ -450,7 +451,8 @@ export const TranslateWorkbench: React.FC<TranslateWorkbenchProps> = ({
 
     // ★ 大小校验兜底：浏览器拖拽/点击选择路径不经过原生路径校验，
     // 避免超大文件被 FileReader 整体读入内存
-    const MAX_UPLOAD_FILE_SIZE = 50 * 1024 * 1024;
+    // #62: 与会话附件 ATTACHMENT_MAX_SIZE (200MB) 对齐
+    const MAX_UPLOAD_FILE_SIZE = ATTACHMENT_MAX_SIZE;
     if (file.size > MAX_UPLOAD_FILE_SIZE) {
       const sizeMB = (MAX_UPLOAD_FILE_SIZE / (1024 * 1024)).toFixed(0);
       showGlobalNotification('error', t('translation:errors.file_too_large_dynamic', { size: sizeMB }));

--- a/src/components/essay-grading/InputPanel.tsx
+++ b/src/components/essay-grading/InputPanel.tsx
@@ -21,6 +21,7 @@ import {
   Sparkle,
 } from '@phosphor-icons/react';
 import UnifiedDragDropZone, { FILE_TYPES } from '../shared/UnifiedDragDropZone';
+import { ATTACHMENT_MAX_SIZE } from '@/features/chat/core/constants';
 import { UnifiedModelSelector } from '../shared/UnifiedModelSelector';
 import type { GradingMode, ModelInfo } from '@/essay-grading/essayGradingApi';
 import type { EssayTextStats } from '@/essay-grading/textStats';
@@ -705,7 +706,7 @@ export const InputPanel = React.forwardRef<HTMLTextAreaElement, InputPanelProps>
           onFilesDropped={onFilesDropped}
           acceptedFileTypes={[FILE_TYPES.IMAGE]}
           maxFiles={ocrMaxFiles}
-          maxFileSize={50 * 1024 * 1024}
+          maxFileSize={ATTACHMENT_MAX_SIZE}
           className="flex-1 min-h-0 flex flex-col relative"
         >
           {showEmptyState && (

--- a/src/components/shared/UnifiedDragDropZone.example.tsx
+++ b/src/components/shared/UnifiedDragDropZone.example.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { UnifiedDragDropZone, FILE_TYPES } from './UnifiedDragDropZone';
+import { ATTACHMENT_MAX_SIZE } from '../../features/chat/core/constants';
 
 /**
  * 示例 1: 简单图片上传
@@ -101,7 +102,7 @@ export function ChatAttachmentUploader() {
         onFilesDropped={handleFilesDropped}
         acceptedFileTypes={[FILE_TYPES.IMAGE, FILE_TYPES.DOCUMENT]}
         maxFiles={20}
-        maxFileSize={50 * 1024 * 1024} // 50MB
+        maxFileSize={ATTACHMENT_MAX_SIZE} // 200MB，与会话附件上限一致（#62）
         showOverlay={true}
         onError={handleError}
         onValidationError={handleValidationError}

--- a/src/components/shared/UnifiedDragDropZone.tsx
+++ b/src/components/shared/UnifiedDragDropZone.tsx
@@ -6,6 +6,7 @@ import { guardedListen } from '../../utils/guardedListen';
 import { getErrorMessage } from '../../utils/errorUtils';
 import { showGlobalNotification } from '../UnifiedNotification';
 import { ensureGlobalDragHandlers, markNativeDrop, isNativeDropRecent } from '../../hooks/useTauriDragAndDrop';
+import { ATTACHMENT_MAX_SIZE } from '../../features/chat/core/constants';
 
 /**
  * 扩展名到 MIME 类型的统一映射表
@@ -232,7 +233,8 @@ export const UnifiedDragDropZone: React.FC<UnifiedDragDropZoneProps> = ({
   enabled = true,
   acceptedFileTypes = [FILE_TYPES.IMAGE, FILE_TYPES.DOCUMENT],
   maxFiles = 10,
-  maxFileSize = 50 * 1024 * 1024,
+  // #62: 默认上限与会话附件 ATTACHMENT_MAX_SIZE (200MB) 对齐，不再硬编码 50MB
+  maxFileSize = ATTACHMENT_MAX_SIZE,
   showOverlay = true,
   customOverlayText,
   className = '',

--- a/src/components/shared/__tests__/UnifiedDragDropZone.defaultMaxSize.test.tsx
+++ b/src/components/shared/__tests__/UnifiedDragDropZone.defaultMaxSize.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * UnifiedDragDropZone 默认文件大小上限测试（#62）
+ *
+ * 证明拖拽区在未显式传入 maxFileSize 时，默认上限是 200MB
+ * （ATTACHMENT_MAX_SIZE），而不是旧的 50MB 硬编码：
+ * - 恰好 200MB 的文件通过校验并回调 onFilesDropped（旧 50MB 上限会拒绝）
+ * - 200MB + 1B 的文件被拒绝并回调 onValidationError
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { render, waitFor, act } from '@testing-library/react';
+
+type DragDropHandler = (event: { payload: unknown }) => void;
+
+/** 捕获组件注册的 Tauri onDragDropEvent 回调 */
+const dragDropHandlers: DragDropHandler[] = [];
+/** path → 后端 get_file_size 命令返回的文件大小 */
+const fileSizeByPath = new Map<string, number>();
+
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: async (handler: DragDropHandler) => {
+      dragDropHandlers.push(handler);
+      return () => undefined;
+    },
+  }),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: async (command: string, payload?: Record<string, unknown>) => {
+    if (command === 'get_file_size') {
+      const path = String(payload?.path ?? '');
+      const size = fileSizeByPath.get(path);
+      if (size === undefined) throw new Error(`unexpected path: ${path}`);
+      return size;
+    }
+    if (command === 'read_file_bytes') {
+      return new ArrayBuffer(4);
+    }
+    return null;
+  },
+}));
+
+vi.mock('@/components/UnifiedNotification', () => ({
+  showGlobalNotification: vi.fn(),
+}));
+
+vi.mock('@/hooks/useTauriDragAndDrop', () => ({
+  ensureGlobalDragHandlers: vi.fn(),
+  markNativeDrop: vi.fn(),
+  isNativeDropRecent: () => false,
+}));
+
+import { UnifiedDragDropZone } from '../UnifiedDragDropZone';
+import {
+  ATTACHMENT_MAX_SIZE,
+  FILE_SIZE_LIMIT as CORE_FILE_SIZE_LIMIT,
+} from '@/features/chat/core/constants';
+import { FILE_SIZE_LIMIT as RESOURCE_FILE_SIZE_LIMIT } from '@/features/chat/resources/types';
+
+// ---------------------------------------------------------------------------
+// JSDOM 可见性打桩：isDropZoneVisible 依赖 offsetWidth/offsetHeight 与
+// getBoundingClientRect，JSDOM 默认全为 0 会让 drop 事件被静默丢弃。
+// ---------------------------------------------------------------------------
+
+const originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+const originalOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => 800 });
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 600 });
+  Element.prototype.getBoundingClientRect = function () {
+    return {
+      x: 0, y: 0, top: 0, left: 0, right: 800, bottom: 600, width: 800, height: 600,
+      toJSON: () => ({}),
+    } as DOMRect;
+  };
+});
+
+afterAll(() => {
+  if (originalOffsetWidth) Object.defineProperty(HTMLElement.prototype, 'offsetWidth', originalOffsetWidth);
+  if (originalOffsetHeight) Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight);
+  Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+});
+
+beforeEach(() => {
+  dragDropHandlers.length = 0;
+  fileSizeByPath.clear();
+});
+
+/** 通过 Tauri 原生拖拽路径投递文件（该路径经 get_file_size 做大小校验） */
+async function dropPaths(paths: string[]) {
+  await waitFor(() => expect(dragDropHandlers.length).toBeGreaterThan(0));
+  const handler = dragDropHandlers[dragDropHandlers.length - 1];
+  await act(async () => {
+    handler({ payload: { type: 'drop', position: { x: 100, y: 100 }, paths } });
+  });
+}
+
+function renderDefaultZone() {
+  const onFilesDropped = vi.fn();
+  const onValidationError = vi.fn();
+  render(
+    // 关键：不传 maxFileSize，验证默认值
+    <UnifiedDragDropZone
+      zoneId="default-max-size-test"
+      onFilesDropped={onFilesDropped}
+      onValidationError={onValidationError}
+    >
+      <div>drop here</div>
+    </UnifiedDragDropZone>
+  );
+  return { onFilesDropped, onValidationError };
+}
+
+describe('UnifiedDragDropZone 默认 maxFileSize（#62）', () => {
+  it('SSOT：ATTACHMENT_MAX_SIZE 为 200MB，各处 FILE_SIZE_LIMIT 与之对齐', () => {
+    expect(ATTACHMENT_MAX_SIZE).toBe(200 * 1024 * 1024);
+    expect(CORE_FILE_SIZE_LIMIT).toBe(ATTACHMENT_MAX_SIZE);
+    expect(RESOURCE_FILE_SIZE_LIMIT).toBe(ATTACHMENT_MAX_SIZE);
+  });
+
+  it('默认上限放行恰好 200MB 的文件（旧 50MB 硬编码会拒绝）', async () => {
+    const { onFilesDropped, onValidationError } = renderDefaultZone();
+    fileSizeByPath.set('/tmp/exactly-200mb.pdf', ATTACHMENT_MAX_SIZE);
+
+    await dropPaths(['/tmp/exactly-200mb.pdf']);
+
+    await waitFor(() => expect(onFilesDropped).toHaveBeenCalledTimes(1));
+    const files = onFilesDropped.mock.calls[0][0] as File[];
+    expect(files.map((f) => f.name)).toEqual(['exactly-200mb.pdf']);
+    expect(onValidationError).not.toHaveBeenCalled();
+  });
+
+  it('默认上限拒绝超过 200MB（200MB + 1B）的文件', async () => {
+    const { onFilesDropped, onValidationError } = renderDefaultZone();
+    fileSizeByPath.set('/tmp/over-200mb.pdf', ATTACHMENT_MAX_SIZE + 1);
+
+    await dropPaths(['/tmp/over-200mb.pdf']);
+
+    await waitFor(() => expect(onValidationError).toHaveBeenCalledTimes(1));
+    const rejected = onValidationError.mock.calls[0][1] as string[];
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]).toContain('over-200mb.pdf');
+    expect(onFilesDropped).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/translation/SourcePanel.tsx
+++ b/src/components/translation/SourcePanel.tsx
@@ -6,6 +6,7 @@ import { CommonTooltip } from '../shared/CommonTooltip';
 import { FileArrowUp, Lightning, TextAa, Trash, X } from '@phosphor-icons/react';
 import { cn } from '@/utils/cn';
 import UnifiedDragDropZone, { FILE_TYPES } from '../shared/UnifiedDragDropZone';
+import { ATTACHMENT_MAX_SIZE } from '@/features/chat/core/constants';
 
 interface SourcePanelProps {
     sourceText: string;
@@ -257,7 +258,7 @@ export const SourcePanel = React.forwardRef<HTMLTextAreaElement, SourcePanelProp
                     onFilesDropped={onFilesDropped}
                     acceptedFileTypes={[FILE_TYPES.IMAGE, FILE_TYPES.DOCUMENT]}
                     maxFiles={1}
-                    maxFileSize={50 * 1024 * 1024}
+                    maxFileSize={ATTACHMENT_MAX_SIZE}
                     className="flex-1 min-h-0 flex flex-col"
                 >
                     <Textarea

--- a/src/features/chat/components/AttachmentUploader.tsx
+++ b/src/features/chat/components/AttachmentUploader.tsx
@@ -81,7 +81,7 @@ const DEFAULT_ACCEPT_TYPES = Array.from(new Set([
 
 // P1-08: 使用统一常量，不再硬编码
 // 旧值: DEFAULT_MAX_SIZE = 10MB, DEFAULT_MAX_COUNT = 10
-// 新值: ATTACHMENT_MAX_SIZE = 50MB, ATTACHMENT_MAX_COUNT = 20
+// 新值: ATTACHMENT_MAX_SIZE = 200MB (#62), ATTACHMENT_MAX_COUNT = 20
 
 // ============================================================================
 // 辅助函数

--- a/src/features/chat/core/constants.ts
+++ b/src/features/chat/core/constants.ts
@@ -127,8 +127,7 @@ export const GRAPH_TOPK_MAX = 50;
 
 // ==================== 文件配置 ====================
 
-/** 文件大小限制（50MB） */
-export const FILE_SIZE_LIMIT = 50 * 1024 * 1024;
+// 注：FILE_SIZE_LIMIT 已移至下方「附件上传配置」段，与 ATTACHMENT_MAX_SIZE 对齐（#62）
 
 /** 文本文件最大长度（100KB） */
 export const TEXT_FILE_MAX_LENGTH = 100 * 1024;
@@ -177,6 +176,13 @@ export const MAX_SCAN_LENGTH = 1000;
  *   document_parser::MAX_DOCUMENT_SIZE (200MB)、attachment_repo::MAX_FILE_BYTES 对齐
  */
 export const ATTACHMENT_MAX_SIZE = 200 * 1024 * 1024;
+
+/**
+ * 文件大小限制（200MB）
+ * ★ #62: 旧值 50MB；现与 ATTACHMENT_MAX_SIZE 及
+ *   resources/types.ts 的 FILE_SIZE_LIMIT (200MB) 对齐
+ */
+export const FILE_SIZE_LIMIT = ATTACHMENT_MAX_SIZE;
 
 /** 单次会话最大附件数量 */
 export const ATTACHMENT_MAX_COUNT = 20;

--- a/src/features/chat/resources/api.ts
+++ b/src/features/chat/resources/api.ts
@@ -9,7 +9,7 @@
  * 约束：
  * 1. 使用 invoke 调用后端命令
  * 2. 所有命令前缀 resources_（指向 resources.db）
- * 3. 大文件限制：图片 < 10MB，文件 < 50MB
+ * 3. 大文件限制：图片 < 10MB (IMAGE_SIZE_LIMIT)，文件 < 200MB (FILE_SIZE_LIMIT，#62)
  * 4. 错误处理使用 getErrorMessage
  */
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

#62 主干已把 `ATTACHMENT_MAX_SIZE` 提到 200MB，但翻译/作文/题库/试卷/拖拽区仍写死 50MB。本 PR 全部改为引用常量。#173 的提示文案切片不重叠。

### Changes
- UnifiedDragDropZone 默认及各上传入口
- `FILE_SIZE_LIMIT` 与 `ATTACHMENT_MAX_SIZE` 对齐
- 默认上限 200MB 的契约测试

### How to test
- `npx vitest run src/components/shared/__tests__/UnifiedDragDropZone.defaultMaxSize.test.tsx`

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [x] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

