### PR TITLE
fix(ci): Windows Sandbox 去掉多余 cargo check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,10 +347,11 @@ jobs:
         with:
           workspaces: src-tauri
 
-      - name: Compile Windows backend
-        working-directory: src-tauri
-        run: cargo check --lib
-
+      # 单次 cargo test 同时承担编译与执行：此前先 cargo check --lib 再
+      # cargo test --lib 在 Windows 上等于完整编译两遍（check 的 metadata
+      # 产物无法被 test 的 codegen 复用），30 分钟超时被取消。编译失败
+      # 仍会让本步骤直接红。测试保持默认并行：起进程的 AppContainer 用例
+      # 已被实现内的命名 ACL 互斥锁串行化，无跨线程共享状态冲突。
       - name: Enforce AppContainer filesystem boundary
         working-directory: src-tauri
         run: cargo test --lib chat_v2::tools::shell_sandbox::windows::tests -- --nocapture


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`Windows Shell Sandbox` 先 `cargo check --lib` 再 `cargo test`，Windows 上编译两遍，30 分钟被取消。去掉 check，一次 test 同时编译和执行。不改 #168 的 Vitest heap。

### Changes
- `.github/workflows/ci.yml` 仅 `windows-shell-sandbox` job

### How to test
- 看该 job：不应再有 Compile Windows backend 步骤

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

