### PR TITLE
fix(chat): 流式内容剥离 GLM/Qwen 特殊 token

### DIFF
--- a/src-tauri/src/chat_v2/pipeline/llm_adapter.rs
+++ b/src-tauri/src/chat_v2/pipeline/llm_adapter.rs
@@ -155,6 +155,10 @@ pub struct ChatV2LLMAdapter {
     in_think_tag: std::sync::Mutex<bool>,
     /// 🔧 <think> 标签解析缓冲区：用于处理跨 chunk 的标签边界
     think_tag_buffer: std::sync::Mutex<String>,
+    /// 🔧 issue #122：GLM/Qwen 特殊 token（`<|end_of_box|>` 等）流式剥离器，
+    /// 在内容进入 think 标签缓冲/前端 CONTENT 块之前剥离，白名单与 anki 管线一致
+    special_token_stripper:
+        std::sync::Mutex<crate::utils::model_special_tokens::SpecialTokenStreamStripper>,
     /// 🔧 Gemini 3 思维签名缓存：工具调用场景下必须在后续请求中回传
     cached_thought_signature: std::sync::Mutex<Option<String>>,
     /// Complete OpenAI Responses reasoning item for the current tool round.
@@ -197,6 +201,9 @@ impl ChatV2LLMAdapter {
             api_usage: std::sync::Mutex::new(None),
             in_think_tag: std::sync::Mutex::new(false),
             think_tag_buffer: std::sync::Mutex::new(String::new()),
+            special_token_stripper: std::sync::Mutex::new(
+                crate::utils::model_special_tokens::SpecialTokenStreamStripper::new(),
+            ),
             cached_thought_signature: std::sync::Mutex::new(None),
             cached_response_reasoning_item: std::sync::Mutex::new(None),
             preparing_block_ids: std::sync::Mutex::new(HashMap::new()),
@@ -329,6 +336,20 @@ impl ChatV2LLMAdapter {
     }
 
     fn finalize_all_inner(&self, include_authoritative_content: bool) {
+        // 🔧 issue #122：先吐出特殊 token 剥离器暂存的尾部
+        // （疑似 token 前缀但流已结束，属于正常内容，不得吞掉）
+        let stripper_residual = self
+            .special_token_stripper
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .flush();
+        if !stripper_residual.is_empty() {
+            self.think_tag_buffer
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push_str(&stripper_residual);
+        }
+
         // 🔧 先处理缓冲区中剩余的内容
         self.flush_think_tag_buffer();
 
@@ -497,6 +518,10 @@ impl ChatV2LLMAdapter {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .clear();
+        self.special_token_stripper
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .reset();
         *self
             .cached_thought_signature
             .lock()
@@ -1014,13 +1039,24 @@ impl LLMStreamHooks for ChatV2LLMAdapter {
             return;
         }
 
+        // 🔧 issue #122：GLM/Qwen 泄漏的特殊 token（`<|end_of_box|>` 等）在进入
+        // 内容管线前剥离；跨 chunk 撕裂的 token 由剥离器暂存尾部前缀处理
+        let cleaned = self
+            .special_token_stripper
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .process(text);
+        if cleaned.is_empty() {
+            return;
+        }
+
         // 🔧 <think> 标签解析：将 chunk 追加到缓冲区并处理
         {
             let mut buffer = self
                 .think_tag_buffer
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
-            buffer.push_str(text);
+            buffer.push_str(&cleaned);
         }
         self.process_think_tag_buffer();
     }

--- a/src-tauri/src/chat_v2/pipeline/variant_adapter.rs
+++ b/src-tauri/src/chat_v2/pipeline/variant_adapter.rs
@@ -20,6 +20,8 @@ pub(crate) struct VariantLLMAdapter {
     in_think_tag: Mutex<bool>,
     /// 🔧 <think> 标签解析缓冲区：用于处理跨 chunk 的标签边界
     think_tag_buffer: Mutex<String>,
+    /// 🔧 issue #122：GLM/Qwen 特殊 token 流式剥离器（白名单与 anki 管线一致）
+    special_token_stripper: Mutex<crate::utils::model_special_tokens::SpecialTokenStreamStripper>,
     /// tool_call_id → preparing block_id 映射
     preparing_block_ids: Mutex<HashMap<String, String>>,
     /// tool_call_id → 累积的 args delta（节流缓冲）
@@ -45,6 +47,9 @@ impl VariantLLMAdapter {
             finalized_thinking_block_id: Mutex::new(None),
             in_think_tag: Mutex::new(false),
             think_tag_buffer: Mutex::new(String::new()),
+            special_token_stripper: Mutex::new(
+                crate::utils::model_special_tokens::SpecialTokenStreamStripper::new(),
+            ),
             preparing_block_ids: Mutex::new(HashMap::new()),
             args_delta_buffer: Mutex::new(HashMap::new()),
             last_activity_at: Mutex::new(std::time::Instant::now()),
@@ -93,6 +98,19 @@ impl VariantLLMAdapter {
     }
 
     fn finalize_all_inner(&self, include_authoritative_content: bool) {
+        // 🔧 issue #122：先吐出特殊 token 剥离器暂存的尾部（正常内容，不得吞掉）
+        let stripper_residual = self
+            .special_token_stripper
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .flush();
+        if !stripper_residual.is_empty() {
+            self.think_tag_buffer
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push_str(&stripper_residual);
+        }
+
         // 🔧 先处理缓冲区中剩余的内容
         self.flush_think_tag_buffer();
         self.finalize_thinking();
@@ -386,6 +404,10 @@ impl VariantLLMAdapter {
             .think_tag_buffer
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = String::new();
+        self.special_token_stripper
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .reset();
         // 🔧 F2：新一轮视为新的流，重置空闲计时
         self.touch_activity();
         self.ctx.reset_for_new_round();
@@ -404,13 +426,24 @@ impl crate::llm_manager::LLMStreamHooks for VariantLLMAdapter {
             return;
         }
 
+        // 🔧 issue #122：GLM/Qwen 泄漏的特殊 token 在进入内容管线前剥离；
+        // 跨 chunk 撕裂的 token 由剥离器暂存尾部前缀处理
+        let cleaned = self
+            .special_token_stripper
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .process(text);
+        if cleaned.is_empty() {
+            return;
+        }
+
         // 🔧 <think> 标签解析：将 chunk 追加到缓冲区并处理
         {
             let mut buffer = self
                 .think_tag_buffer
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
-            buffer.push_str(text);
+            buffer.push_str(&cleaned);
         }
         self.process_think_tag_buffer();
     }

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -6,5 +6,6 @@ pub mod token_budget;
 pub mod unicode;
 
 pub mod fetch;
+pub mod model_special_tokens;
 pub mod sse_buffer;
 pub mod text;

--- a/src-tauri/src/utils/model_special_tokens.rs
+++ b/src-tauri/src/utils/model_special_tokens.rs
@@ -1,0 +1,203 @@
+//! 模型特殊 token 剥离（issue #122 / #58）
+//!
+//! GLM/Qwen 系模型会把内部协议 token（`<|begin_of_box|>`、`<|im_end|>` 等）
+//! 泄漏进流式正文。Anki 制卡管线（#187，`streaming_anki_service.rs`）已在
+//! 残片切出后剥离同一白名单；本模块把该白名单抽为共享实现，供聊天流式
+//! ContentChunk 路径在下发前端之前复用。
+//!
+//! 白名单必须与 `streaming_anki_service.rs` 中的保持一致：只剥离已知的
+//! 协议 token，不碰用户内容里的其他 `<|...|>` 字面量。
+
+/// 已知会泄漏进流式正文的模型特殊 token（与 #187 Anki 白名单一致）。
+pub const MODEL_SPECIAL_TOKENS: &[&str] = &[
+    "<|begin_of_box|>",
+    "<|end_of_box|>",
+    "<|im_start|>",
+    "<|im_end|>",
+    "<|endoftext|>",
+];
+
+/// 剥离白名单内的模型特殊 token（纯函数，语义与 anki 版一致）。
+/// 仅适用于完整文本；流式分片请用 [`SpecialTokenStreamStripper`]，
+/// 否则 token 跨 chunk 撕裂时会漏剥。
+pub fn strip_model_special_tokens(text: &str) -> String {
+    let mut out = text.to_string();
+    for token in MODEL_SPECIAL_TOKENS {
+        if out.contains(token) {
+            out = out.replace(token, "");
+        }
+    }
+    out
+}
+
+/// 尾部疑似"未写完的特殊 token 前缀"的字节长度。
+/// 返回 0 表示尾部不可能补全成白名单 token，可以全部下发。
+fn trailing_token_prefix_len(text: &str) -> usize {
+    // 白名单 token 全为 ASCII；能匹配上前缀的尾部必然也是 ASCII，
+    // 因此按 char 边界回退切片是安全的。
+    let max_hold = MODEL_SPECIAL_TOKENS
+        .iter()
+        .map(|t| t.len())
+        .max()
+        .unwrap_or(0)
+        .saturating_sub(1);
+
+    let mut best = 0;
+    for (idx, _) in text.char_indices().rev() {
+        let suffix = &text[idx..];
+        if suffix.len() > max_hold {
+            break;
+        }
+        if MODEL_SPECIAL_TOKENS
+            .iter()
+            .any(|token| token.starts_with(suffix))
+        {
+            best = suffix.len();
+        }
+    }
+    best
+}
+
+/// 流式安全的特殊 token 剥离器。
+///
+/// 逐 chunk 调用 [`process`](Self::process)：完整出现的白名单 token 被剥掉；
+/// chunk 尾部若恰好是某个 token 的前半截（如 `数学<|end_of`），该前缀会被
+/// 暂存，等后续 chunk 拼出完整 token 再剥、或证明不是 token 后原样吐出。
+/// 流结束时必须调用 [`flush`](Self::flush) 取回暂存尾部，避免吞掉正常内容。
+#[derive(Debug, Default)]
+pub struct SpecialTokenStreamStripper {
+    /// 尾部暂存：白名单 token 的某个真前缀（长度 < 最长 token，有界）。
+    pending: String,
+}
+
+impl SpecialTokenStreamStripper {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// 输入一个流式 chunk，返回此刻可安全下发前端的文本。
+    pub fn process(&mut self, chunk: &str) -> String {
+        self.pending.push_str(chunk);
+        let stripped = strip_model_special_tokens(&self.pending);
+        let hold = trailing_token_prefix_len(&stripped);
+        let emit_end = stripped.len() - hold;
+        self.pending = stripped[emit_end..].to_string();
+        stripped[..emit_end].to_string()
+    }
+
+    /// 流结束/收尾：吐出暂存尾部（此时不会再有后续 chunk 补全 token）。
+    pub fn flush(&mut self) -> String {
+        // pending 在 process 中已剥过完整 token，这里再剥一次仅作防御。
+        strip_model_special_tokens(&std::mem::take(&mut self.pending))
+    }
+
+    /// 重试/新一轮前清空暂存状态。
+    pub fn reset(&mut self) {
+        self.pending.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ===== 纯函数：issue #122 核心场景 =====
+
+    #[test]
+    fn strip_removes_inline_special_token() {
+        assert_eq!(strip_model_special_tokens("数学<|end_of_box|>题"), "数学题");
+    }
+
+    #[test]
+    fn strip_removes_all_whitelisted_tokens() {
+        let input = "<|im_start|>解：<|begin_of_box|>42<|end_of_box|><|im_end|><|endoftext|>";
+        assert_eq!(strip_model_special_tokens(input), "解：42");
+    }
+
+    #[test]
+    fn strip_keeps_normal_markdown_untouched() {
+        let markdown = "# 标题\n\n**加粗** 与 `code`，公式 $a < b$，表格 | A | B |\n\n<b>html</b> 以及 <think 字面量";
+        assert_eq!(strip_model_special_tokens(markdown), markdown);
+    }
+
+    #[test]
+    fn strip_keeps_non_whitelisted_pipe_brackets() {
+        // 非白名单的 <|...|> 字面量属于用户内容，不得误剥
+        let input = "自定义标记 <|custom|> 保留";
+        assert_eq!(strip_model_special_tokens(input), input);
+    }
+
+    // ===== 流式剥离器：单 chunk 与跨 chunk =====
+
+    #[test]
+    fn stream_strips_token_within_single_chunk() {
+        let mut stripper = SpecialTokenStreamStripper::new();
+        let mut out = stripper.process("数学<|end_of_box|>题");
+        out.push_str(&stripper.flush());
+        assert_eq!(out, "数学题");
+    }
+
+    #[test]
+    fn stream_strips_token_torn_across_chunks() {
+        // GLM 的 token 常被 SSE 切在中间：`<|end_of` + `_box|>`
+        let mut stripper = SpecialTokenStreamStripper::new();
+        let mut out = String::new();
+        out.push_str(&stripper.process("数学<|end_of"));
+        out.push_str(&stripper.process("_box|>题"));
+        out.push_str(&stripper.flush());
+        assert_eq!(out, "数学题");
+    }
+
+    #[test]
+    fn stream_strips_token_torn_char_by_char() {
+        let mut stripper = SpecialTokenStreamStripper::new();
+        let mut out = String::new();
+        for ch in "解<|im_end|>毕".chars() {
+            out.push_str(&stripper.process(&ch.to_string()));
+        }
+        out.push_str(&stripper.flush());
+        assert_eq!(out, "解毕");
+    }
+
+    #[test]
+    fn stream_releases_lookalike_prefix_once_disproven() {
+        // `<|end` 之后接的不是 token 余下部分，应原样吐出，不吞用户内容
+        let mut stripper = SpecialTokenStreamStripper::new();
+        let mut out = String::new();
+        out.push_str(&stripper.process("对比 <|end"));
+        out.push_str(&stripper.process(" 与其他写法"));
+        out.push_str(&stripper.flush());
+        assert_eq!(out, "对比 <|end 与其他写法");
+    }
+
+    #[test]
+    fn stream_flush_returns_trailing_prefix_at_stream_end() {
+        // 流在疑似前缀处终止：flush 必须吐回暂存内容，不得丢字
+        let mut stripper = SpecialTokenStreamStripper::new();
+        let mut out = stripper.process("结尾悬着 <|end_of");
+        assert_eq!(out, "结尾悬着 ");
+        out.push_str(&stripper.flush());
+        assert_eq!(out, "结尾悬着 <|end_of");
+    }
+
+    #[test]
+    fn stream_keeps_normal_markdown_untouched() {
+        let markdown = "1. 列表 `<div>` 与 a < b、竖线 | 表格 |";
+        let mut stripper = SpecialTokenStreamStripper::new();
+        let mut out = stripper.process(markdown);
+        out.push_str(&stripper.flush());
+        assert_eq!(out, markdown);
+    }
+
+    #[test]
+    fn stream_reset_clears_pending() {
+        let mut stripper = SpecialTokenStreamStripper::new();
+        let _ = stripper.process("重试前残留 <|im_");
+        stripper.reset();
+        assert_eq!(stripper.flush(), "");
+        // reset 后重新处理不受旧状态影响
+        let mut out = stripper.process("新内容<|im_end|>！");
+        out.push_str(&stripper.flush());
+        assert_eq!(out, "新内容！");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

#122 的另一面：`<|end_of_box|>` / `<|im_end|>` 等泄漏进气泡。共享 `strip_model_special_tokens` + 跨 chunk `SpecialTokenStreamStripper`，挂在 `ChatV2LLMAdapter` / `VariantLLMAdapter` 的 ContentChunk 入口。不改 #187 anki 文件，不改 #195 sse_buffer。

### How to test
- `cargo test --manifest-path src-tauri/Cargo.toml --lib model_special_tokens`

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [x] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

