### PR TITLE
fix(settings): MCP 快捷操作与预设弹层在窄屏不再被裁切

### DIFF
--- a/src/features/settings/components/McpToolsSection.tsx
+++ b/src/features/settings/components/McpToolsSection.tsx
@@ -54,6 +54,7 @@ import { Switch } from '@/components/ui/shad/Switch';
 import { Input } from '@/components/ui/shad/Input';
 import { Checkbox } from '@/components/ui/shad/Checkbox';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/shad/Select';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/shad/Popover';
 import { ApiKeyField } from './ApiKeyField';
 import { DsAlertDialog } from '@/components/ui/DsDialog';
 import { showGlobalNotification } from '@/components/UnifiedNotification';
@@ -1510,8 +1511,8 @@ function EmptyServerList({ onAdd }: { onAdd: () => void }) {
   );
 }
 
-// 操作菜单组件
-function ActionMenu({
+// 操作菜单组件（导出供窄屏视口契约测试使用，见 #46）
+export function ActionMenu({
   onReconnect,
   onRefresh,
   onHealthCheck,
@@ -1555,38 +1556,55 @@ function ActionMenu({
     </>
   );
 
-  return (
-    <div className={cn('relative', isSmallScreen && isOpen && 'w-full')}>
-      <DsButton
-        variant="ghost"
-        size="sm"
-        onClick={() => setIsOpen(!isOpen)}
-        aria-expanded={isOpen}
-        className="bg-muted/50 hover:bg-[var(--interactive-hover)]"
-      >
-        <DotsThree className="w-4 h-4" />
-        {t('settings:mcp_descriptions.quick_actions')}
-      </DsButton>
+  // 移动端：按钮下方内联展开（操作栏为 flex-wrap，w-full 自动换行占满一行）
+  if (isSmallScreen) {
+    return (
+      <div className={cn('relative', isOpen && 'w-full')}>
+        <DsButton
+          variant="ghost"
+          size="sm"
+          onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          className="bg-muted/50 hover:bg-[var(--interactive-hover)]"
+        >
+          <DotsThree className="w-4 h-4" />
+          {t('settings:mcp_descriptions.quick_actions')}
+        </DsButton>
 
-      {isOpen && (
-        isSmallScreen ? (
-          // 移动端：按钮下方内联展开（操作栏为 flex-wrap，w-full 自动换行占满一行）
+        {isOpen && (
           <div className="mt-1 w-full rounded-lg border border-border bg-popover p-1.5 ui-zoom-fade-in motion-reduce:animate-none">
             {menuItems}
           </div>
-        ) : (
-          <>
-            <div
-              className="fixed inset-0 z-40"
-              onClick={() => setIsOpen(false)}
-            />
-            <div className="absolute top-full right-0 mt-1 z-50 min-w-[180px] p-1.5 bg-popover border border-border rounded-lg shadow-lg ui-zoom-fade-in">
-              {menuItems}
-            </div>
-          </>
-        )
-      )}
-    </div>
+        )}
+      </div>
+    );
+  }
+
+  // 桌面/平板（含安卓横屏 ≥768px）：Portal + fixed 定位（#46）。
+  // 旧实现是 `absolute right-0` + z-50：在窄视口下会超出屏幕左缘，
+  // 且被设置内容滚动容器裁切、被侧栏 stacking context 压住。
+  // Popover 原语自带视口碰撞钳制（resolvePopoverPosition）与 Z_INDEX.popover 层级。
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <DsButton
+          variant="ghost"
+          size="sm"
+          className="bg-muted/50 hover:bg-[var(--interactive-hover)]"
+        >
+          <DotsThree className="w-4 h-4" />
+          {t('settings:mcp_descriptions.quick_actions')}
+        </DsButton>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={4}
+        className="max-w-[calc(100vw-1rem)]"
+        data-testid="mcp-quick-actions-menu"
+      >
+        {menuItems}
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -1860,25 +1878,24 @@ export function PresetServerSelector({
     </>
   );
 
-  return (
-    <div className={cn('relative', isSmallScreen && isOpen && 'w-full')}>
-      <DsButton
-        ref={addPresetBtnRef}
-        onClick={() => setIsOpen(!isOpen)}
-        variant="default"
-        size="sm"
-        aria-haspopup={isSmallScreen ? undefined : 'dialog'}
-        aria-expanded={isOpen}
-        data-testid="mcp-preset-add-btn"
-      >
-        <Package className="w-4 h-4 mr-1" aria-hidden="true" />
-        {t('settings:mcp_presets.add_preset')}
-      </DsButton>
+  // P0-3 移动端：内联展开（操作栏为 flex-wrap，w-full 自动换行占满一行）。
+  // 选中预置后列表让位给权限确认卡，取消则回到列表。
+  if (isSmallScreen) {
+    return (
+      <div className={cn('relative', isOpen && 'w-full')}>
+        <DsButton
+          ref={addPresetBtnRef}
+          onClick={() => setIsOpen(!isOpen)}
+          variant="default"
+          size="sm"
+          aria-expanded={isOpen}
+          data-testid="mcp-preset-add-btn"
+        >
+          <Package className="w-4 h-4 mr-1" aria-hidden="true" />
+          {t('settings:mcp_presets.add_preset')}
+        </DsButton>
 
-      {isOpen && (
-        isSmallScreen ? (
-          // P0-3 移动端：内联展开（操作栏为 flex-wrap，w-full 自动换行占满一行）。
-          // 选中预置后列表让位给权限确认卡，取消则回到列表。
+        {isOpen && (
           pendingPreset ? (
             <div
               className="mt-1 w-full space-y-4 rounded-lg border border-border bg-popover p-4 text-sm ui-zoom-fade-in motion-reduce:animate-none mcp-preset-permission-drawer"
@@ -1913,71 +1930,94 @@ export function PresetServerSelector({
               {selectorContent}
             </CustomScrollArea>
           )
-        ) : (
-          <>
-            <div
-              className="fixed inset-0 z-40"
-              onClick={closeSelector}
-              aria-hidden="true"
-              data-testid="mcp-preset-selector-backdrop"
-            />
-            <CustomScrollArea
-              ref={selectorPanelRef}
-              className="absolute right-0 top-full z-50 mt-1 h-[min(60dvh,30rem)] w-[380px] max-w-[calc(100vw-3rem)] rounded-lg border border-border bg-popover shadow-lg ui-zoom-fade-in mcp-preset-selector"
-              viewportClassName="p-2"
-              trackOffsetTop={4}
-              trackOffsetBottom={4}
-              role="dialog"
-              aria-modal="true"
-              aria-label={t('settings:mcp_presets.title')}
-              tabIndex={-1}
-              data-testid="mcp-preset-selector"
-            >
-              {selectorContent}
-            </CustomScrollArea>
-          </>
-        )
-      )}
+        )}
+      </div>
+    );
+  }
+
+  // 桌面/平板（含安卓横屏 ≥768px）：Portal + fixed 定位（#46）。
+  // 旧实现是 `absolute right-0` + z-50：预置弹层在窄视口下向左溢出屏幕、
+  // 被设置内容滚动容器裁切、被侧栏 stacking context 压住。
+  // Popover 原语自带视口碰撞钳制（resolvePopoverPosition）与 Z_INDEX.popover 层级。
+  return (
+    <div className="relative">
+      <Popover
+        open={isOpen}
+        onOpenChange={(open) => {
+          if (open) setIsOpen(true);
+          else closeSelector();
+        }}
+      >
+        <PopoverTrigger asChild>
+          <DsButton
+            ref={addPresetBtnRef}
+            variant="default"
+            size="sm"
+            aria-haspopup="dialog"
+            data-testid="mcp-preset-add-btn"
+          >
+            <Package className="w-4 h-4 mr-1" aria-hidden="true" />
+            {t('settings:mcp_presets.add_preset')}
+          </DsButton>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          sideOffset={4}
+          aria-modal="true"
+          aria-label={t('settings:mcp_presets.title')}
+          data-testid="mcp-preset-selector"
+          className="w-[380px] max-w-[calc(100vw-1.5rem)] overflow-hidden !p-0"
+        >
+          <CustomScrollArea
+            ref={selectorPanelRef}
+            className="h-[min(60dvh,30rem)] w-full mcp-preset-selector"
+            viewportClassName="p-2"
+            trackOffsetTop={4}
+            trackOffsetBottom={4}
+            tabIndex={-1}
+          >
+            {selectorContent}
+          </CustomScrollArea>
+        </PopoverContent>
+      </Popover>
 
       {/* 桌面端：安装前权限确认保留 Sheet；移动端由上方内联卡承载（P0-3） */}
-      {!isSmallScreen && (
-        <Sheet open={Boolean(pendingPreset)} onOpenChange={(open) => { if (!open) closePermissionDrawer(); }}>
-          <SheetContent
-            side="right"
-            className="flex min-h-0 w-full flex-col overflow-hidden sm:max-w-md mcp-preset-permission-drawer"
-            data-testid="mcp-preset-permission-drawer"
-            aria-describedby="mcp-preset-permission-summary"
-            onWheel={(event) => event.stopPropagation()}
-          >
-            {pendingPreset && (
-              <>
-                <SheetHeader>
-                  <SheetTitle className="flex items-center gap-2">
-                    <Shield className="w-5 h-5" aria-hidden="true" />
-                    {t('settings:mcp_presets.permission_title', { name: pendingPreset.name })}
-                  </SheetTitle>
-                  <SheetDescription>
-                    {t(pendingPreset.descriptionKey)}
-                  </SheetDescription>
-                </SheetHeader>
-                <CustomScrollArea
-                  className="mt-4 min-h-0 flex-1"
-                  viewportClassName="pr-2 text-sm"
-                  trackOffsetTop={4}
-                  trackOffsetBottom={4}
-                >
-                  <div className="space-y-4">
-                    {permissionBody}
-                  </div>
-                </CustomScrollArea>
-                <SheetFooter className="mt-6 shrink-0 flex gap-2 sm:justify-end">
-                  {permissionFooterButtons}
-                </SheetFooter>
-              </>
-            )}
-          </SheetContent>
-        </Sheet>
-      )}
+      <Sheet open={Boolean(pendingPreset)} onOpenChange={(open) => { if (!open) closePermissionDrawer(); }}>
+        <SheetContent
+          side="right"
+          className="flex min-h-0 w-full flex-col overflow-hidden sm:max-w-md mcp-preset-permission-drawer"
+          data-testid="mcp-preset-permission-drawer"
+          aria-describedby="mcp-preset-permission-summary"
+          onWheel={(event) => event.stopPropagation()}
+        >
+          {pendingPreset && (
+            <>
+              <SheetHeader>
+                <SheetTitle className="flex items-center gap-2">
+                  <Shield className="w-5 h-5" aria-hidden="true" />
+                  {t('settings:mcp_presets.permission_title', { name: pendingPreset.name })}
+                </SheetTitle>
+                <SheetDescription>
+                  {t(pendingPreset.descriptionKey)}
+                </SheetDescription>
+              </SheetHeader>
+              <CustomScrollArea
+                className="mt-4 min-h-0 flex-1"
+                viewportClassName="pr-2 text-sm"
+                trackOffsetTop={4}
+                trackOffsetBottom={4}
+              >
+                <div className="space-y-4">
+                  {permissionBody}
+                </div>
+              </CustomScrollArea>
+              <SheetFooter className="mt-6 shrink-0 flex gap-2 sm:justify-end">
+                {permissionFooterButtons}
+              </SheetFooter>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/src/features/settings/components/__tests__/McpToolsSection.narrowViewportOverlay.test.tsx
+++ b/src/features/settings/components/__tests__/McpToolsSection.narrowViewportOverlay.test.tsx
@@ -1,0 +1,262 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('@/components/UnifiedNotification', () => ({
+  showGlobalNotification: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown> | string) => {
+      if (typeof opts === 'string') return opts;
+      if (opts && typeof opts === 'object' && 'name' in opts) {
+        return `${key}:${String(opts.name)}`;
+      }
+      return key;
+    },
+  }),
+}));
+
+import { ActionMenu, PresetServerSelector } from '../McpToolsSection';
+import { resolvePopoverPosition } from '@/components/ui/shad/Popover';
+import { Z_INDEX } from '@/config/zIndex';
+
+const originalMatchMedia = window.matchMedia;
+const originalInnerWidth = window.innerWidth;
+
+/**
+ * #46 窄屏（安卓平板/横屏，≥768px 但仍窄）视口模拟：
+ * matchMedia 按真实 min-width 解析，innerWidth 同步为目标宽度。
+ */
+function mockViewport(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => {
+      const minWidth = /\(min-width:\s*(\d+(?:\.\d+)?)px\)/.exec(query);
+      return {
+        matches: minWidth ? width >= parseFloat(minWidth[1]) : false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      };
+    }),
+  });
+}
+
+function restoreViewport() {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: originalInnerWidth,
+  });
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+}
+
+const actionMenuProps = {
+  onReconnect: vi.fn(),
+  onRefresh: vi.fn(),
+  onHealthCheck: vi.fn(),
+  onClearCache: vi.fn(),
+  onOpenPolicy: vi.fn(),
+};
+
+describe('McpToolsSection narrow-viewport overlays (#46)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    restoreViewport();
+  });
+
+  describe('quick actions menu on narrow ≥768px viewport (Android tablet/landscape)', () => {
+    it('portals to document.body with fixed positioning and popover z-index', async () => {
+      mockViewport(820);
+      const { container } = render(<ActionMenu {...actionMenuProps} />);
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /quick_actions/ }),
+      );
+
+      const menu = await screen.findByTestId('mcp-quick-actions-menu');
+      // Portal 到 body：不再是设置内容滚动容器的后代，不会被 overflow 裁切，
+      // 也不会被侧栏的局部 stacking context 压住
+      expect(container.contains(menu)).toBe(false);
+      expect(document.body.contains(menu)).toBe(true);
+      expect(menu.className).toContain('fixed');
+      expect(Number(menu.style.zIndex)).toBe(Z_INDEX.popover);
+      // 视口宽度约束：窄屏下不允许超出屏幕
+      expect(menu.className).toContain('max-w-[calc(100vw-1rem)]');
+    });
+
+    it('stays horizontally inside the viewport after collision clamping', async () => {
+      mockViewport(820);
+      render(<ActionMenu {...actionMenuProps} />);
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /quick_actions/ }),
+      );
+
+      const menu = await screen.findByTestId('mcp-quick-actions-menu');
+      await waitFor(() => {
+        const left = parseFloat(menu.style.left);
+        expect(Number.isNaN(left)).toBe(false);
+        expect(left).toBeGreaterThanOrEqual(0);
+        expect(left + menu.offsetWidth).toBeLessThanOrEqual(window.innerWidth);
+      });
+    });
+
+    it('closes after an action is chosen and invokes the handler', async () => {
+      mockViewport(820);
+      render(<ActionMenu {...actionMenuProps} />);
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /quick_actions/ }),
+      );
+      fireEvent.click(
+        await screen.findByRole('button', { name: /mcp\.reconnect/ }),
+      );
+
+      expect(actionMenuProps.onReconnect).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(screen.queryByTestId('mcp-quick-actions-menu')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('preset selector on narrow ≥768px viewport', () => {
+    it('portals to document.body with fixed positioning, popover z-index and viewport max-width', async () => {
+      mockViewport(820);
+      const { container } = render(
+        <PresetServerSelector existingServerIds={[]} onAddPreset={() => undefined} />,
+      );
+
+      const addBtn = screen.getByTestId('mcp-preset-add-btn');
+      expect(addBtn).toHaveAttribute('aria-haspopup', 'dialog');
+      fireEvent.click(addBtn);
+
+      const selector = await screen.findByTestId('mcp-preset-selector');
+      expect(container.contains(selector)).toBe(false);
+      expect(document.body.contains(selector)).toBe(true);
+      expect(selector.className).toContain('fixed');
+      expect(Number(selector.style.zIndex)).toBe(Z_INDEX.popover);
+      expect(selector.className).toContain('max-w-[calc(100vw-1.5rem)]');
+      // 旧实现的全屏 fixed 遮罩已移除（外点击由 Popover 文档级监听处理）
+      expect(screen.queryByTestId('mcp-preset-selector-backdrop')).not.toBeInTheDocument();
+    });
+
+    it('closes on Escape and returns focus to the trigger', async () => {
+      mockViewport(820);
+      render(
+        <PresetServerSelector existingServerIds={[]} onAddPreset={() => undefined} />,
+      );
+
+      const addBtn = screen.getByTestId('mcp-preset-add-btn');
+      fireEvent.click(addBtn);
+      await screen.findByTestId('mcp-preset-selector');
+
+      fireEvent.keyDown(window, { key: 'Escape', bubbles: true });
+      await waitFor(() => {
+        expect(screen.queryByTestId('mcp-preset-selector')).not.toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(addBtn).toHaveFocus();
+      });
+    });
+
+    it('closes when clicking outside the popover', async () => {
+      mockViewport(820);
+      render(
+        <PresetServerSelector existingServerIds={[]} onAddPreset={() => undefined} />,
+      );
+
+      fireEvent.click(screen.getByTestId('mcp-preset-add-btn'));
+      await screen.findByTestId('mcp-preset-selector');
+
+      fireEvent.mouseDown(document.body);
+      await waitFor(() => {
+        expect(screen.queryByTestId('mcp-preset-selector')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('small screen (<768px) keeps P0-3 inline expansion', () => {
+    it('quick actions expand inline without portal or fixed overlay', () => {
+      mockViewport(360);
+      const { container } = render(<ActionMenu {...actionMenuProps} />);
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /quick_actions/ }),
+      );
+
+      // 内联展开：菜单保持在组件子树内，无 body portal、无 fixed 遮罩
+      expect(screen.queryByTestId('mcp-quick-actions-menu')).not.toBeInTheDocument();
+      const reconnect = screen.getByRole('button', { name: /mcp\.reconnect/ });
+      expect(container.contains(reconnect)).toBe(true);
+      expect(container.querySelector('.fixed')).toBeNull();
+    });
+
+    it('preset selector expands inline within the component subtree', async () => {
+      mockViewport(360);
+      const { container } = render(
+        <PresetServerSelector existingServerIds={[]} onAddPreset={() => undefined} />,
+      );
+
+      fireEvent.click(screen.getByTestId('mcp-preset-add-btn'));
+      const selector = await screen.findByTestId('mcp-preset-selector');
+      expect(container.contains(selector)).toBe(true);
+      expect(selector).not.toHaveAttribute('aria-modal');
+    });
+  });
+
+  describe('resolvePopoverPosition narrow-viewport clamping contract', () => {
+    it('clamps a right-anchored 380px panel into a 820px viewport', () => {
+      // 触发器靠内容区左侧（窄屏 flex-wrap 后按钮可能落在左边），
+      // align=end 原生锚点会向左溢出为负值，必须钳回视口内
+      const position = resolvePopoverPosition({
+        triggerRect: { left: 20, right: 140, top: 200, bottom: 232, width: 120 },
+        contentWidth: 380,
+        contentHeight: 400,
+        viewportWidth: 820,
+        viewportHeight: 1180,
+        align: 'end',
+        side: 'bottom',
+        sideOffset: 4,
+        collisionPadding: 8,
+      });
+      expect(position.left).toBeGreaterThanOrEqual(8);
+      expect(position.left + 380).toBeLessThanOrEqual(820 - 8);
+    });
+
+    it('keeps the panel on-screen when the trigger hugs the right edge', () => {
+      const position = resolvePopoverPosition({
+        triggerRect: { left: 700, right: 812, top: 200, bottom: 232, width: 112 },
+        contentWidth: 380,
+        contentHeight: 400,
+        viewportWidth: 820,
+        viewportHeight: 1180,
+        align: 'end',
+        side: 'bottom',
+        sideOffset: 4,
+        collisionPadding: 8,
+      });
+      expect(position.left).toBeGreaterThanOrEqual(8);
+      expect(position.left + 380).toBeLessThanOrEqual(820 - 8);
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

修 #46：设置 → MCP 工具的「快捷操作」和「添加预设」在平板/窄屏被 overflow 和侧栏 stacking context 裁切。桌面分支改走已有 `Popover`（portal + 视口钳制 + 更高 z-index）。不改 #172 顶栏、#113 Dialog。

### How to test
- `npx vitest run src/features/settings/components/__tests__/McpToolsSection.narrowViewportOverlay.test.tsx`

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [x] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

