### PR TITLE
fix(settings): 模型家族补 Gemini 3 / Grok / MiniMax / Ernie / Llama 4

### DIFF
--- a/src/features/settings/components/__tests__/modelFamily.test.ts
+++ b/src/features/settings/components/__tests__/modelFamily.test.ts
@@ -38,6 +38,9 @@ describe('classifyModelFamily', () => {
 
   describe('Google', () => {
     it.each([
+      ['gemini-3.1-pro-preview', 'gemini-3'],
+      ['gemini-3.1-pro-preview-customtools', 'gemini-3'],
+      ['gemini-3.5-flash', 'gemini-3'],
       ['gemini-2.5-pro', 'gemini-2.5'],
       ['gemini-2.5-flash', 'gemini-2.5'],
       ['gemini-2.0-flash', 'gemini-2.0'],
@@ -74,6 +77,60 @@ describe('classifyModelFamily', () => {
       ['qwen-vl-plus', 'qwen-vl'],
       ['qwq-32b-preview', 'qwq'],
       ['qvq-72b-preview', 'qvq'],
+    ])('classifies %s as %s', (id, expectedFamilyId) => {
+      expect(classifyModelFamily(id).id).toBe(expectedFamilyId);
+    });
+  });
+
+  describe('xAI', () => {
+    it.each([
+      ['grok-4.5', 'grok'],
+      ['grok-4.3', 'grok'],
+      ['grok-4-0709', 'grok'],
+      ['grok-4-1-fast-reasoning', 'grok'],
+      ['grok-4-1-fast-non-reasoning', 'grok'],
+      ['grok-3-mini', 'grok'],
+    ])('classifies %s as %s', (id, expectedFamilyId) => {
+      expect(classifyModelFamily(id).id).toBe(expectedFamilyId);
+    });
+  });
+
+  describe('Meta Llama', () => {
+    it.each([
+      ['llama-4-scout', 'llama-4'],
+      ['llama-4-maverick', 'llama-4'],
+    ])('classifies %s as %s', (id, expectedFamilyId) => {
+      expect(classifyModelFamily(id).id).toBe(expectedFamilyId);
+    });
+
+    it('keeps DeepSeek distills out of the Llama family', () => {
+      expect(classifyModelFamily('deepseek-r1-distill-llama-70b').id).toBe('deepseek-r');
+    });
+  });
+
+  describe('Mistral', () => {
+    it.each([
+      ['magistral-medium-latest', 'magistral'],
+      ['magistral-small-latest', 'magistral'],
+      ['mistral-large-3', 'mistral'],
+      ['mistral-medium-3-5', 'mistral'],
+      ['mistral-small-4', 'mistral'],
+    ])('classifies %s as %s', (id, expectedFamilyId) => {
+      expect(classifyModelFamily(id).id).toBe(expectedFamilyId);
+    });
+  });
+
+  describe('Domestic vendors', () => {
+    it.each([
+      ['minimax-m3', 'minimax'],
+      ['minimax-m2.7', 'minimax'],
+      ['MiniMax-M2.5', 'minimax'],
+      ['ernie-5.1', 'ernie'],
+      ['ernie-5.0', 'ernie'],
+      ['ernie-5.0-thinking-latest', 'ernie'],
+      ['ernie-x1.1', 'ernie'],
+      ['ernie-x1-turbo', 'ernie'],
+      ['ernie-4.5', 'ernie'],
     ])('classifies %s as %s', (id, expectedFamilyId) => {
       expect(classifyModelFamily(id).id).toBe(expectedFamilyId);
     });

--- a/src/features/settings/components/modelFamily.ts
+++ b/src/features/settings/components/modelFamily.ts
@@ -37,6 +37,8 @@ const FAMILY_RULES: FamilyRule[] = [
   { pattern: /^claude-(?:2|instant)/i, family: { id: 'claude-legacy', label: 'Claude (Legacy)', order: 13 } },
 
   // === Google ===
+  // Gemini 3.x（3.1 / 3.5 等），需先于通用 ^gemini 兜底
+  { pattern: /gemini-?3(?:[.-]|$)/i, family: { id: 'gemini-3', label: 'Gemini 3', order: 19 } },
   { pattern: /gemini-?2\.5/i, family: { id: 'gemini-2.5', label: 'Gemini 2.5', order: 20 } },
   { pattern: /gemini-?2\.0/i, family: { id: 'gemini-2.0', label: 'Gemini 2.0', order: 21 } },
   { pattern: /gemini-?1\.5/i, family: { id: 'gemini-1.5', label: 'Gemini 1.5', order: 22 } },
@@ -61,12 +63,18 @@ const FAMILY_RULES: FamilyRule[] = [
   { pattern: /^qwen/i, family: { id: 'qwen', label: 'Qwen', order: 44 } },
 
   // === Meta Llama ===
+  { pattern: /llama-?4/i, family: { id: 'llama-4', label: 'Llama 4', order: 49 } },
   { pattern: /llama-?3/i, family: { id: 'llama-3', label: 'Llama 3', order: 50 } },
   { pattern: /llama-?2/i, family: { id: 'llama-2', label: 'Llama 2', order: 51 } },
+
+  // === xAI ===
+  { pattern: /^grok/i, family: { id: 'grok', label: 'Grok', order: 55 } },
 
   // === Mistral ===
   { pattern: /mixtral/i, family: { id: 'mixtral', label: 'Mixtral', order: 60 } },
   { pattern: /codestral/i, family: { id: 'codestral', label: 'Codestral', order: 61 } },
+  // Magistral（推理产线）不含 "mistral" 子串，需要独立规则
+  { pattern: /magistral/i, family: { id: 'magistral', label: 'Magistral', order: 63 } },
   { pattern: /mistral/i, family: { id: 'mistral', label: 'Mistral', order: 62 } },
 
   // === 国内大模型 ===
@@ -75,8 +83,10 @@ const FAMILY_RULES: FamilyRule[] = [
   { pattern: /(?:moonshot|kimi)/i, family: { id: 'moonshot', label: 'Moonshot', order: 72 } },
   { pattern: /(?:doubao|skylark|seed-)/i, family: { id: 'doubao', label: 'Doubao', order: 73 } },
   { pattern: /hunyuan/i, family: { id: 'hunyuan', label: 'Hunyuan', order: 74 } },
-  { pattern: /^abab/i, family: { id: 'minimax', label: 'MiniMax', order: 75 } },
+  // MiniMax：新一代 slug 为 minimax-m3 / minimax-m2.7 / MiniMax-M2.5，同时保留旧版 abab 前缀
+  { pattern: /(?:^abab|minimax)/i, family: { id: 'minimax', label: 'MiniMax', order: 75 } },
   { pattern: /^yi[-_]/i, family: { id: 'yi', label: 'Yi', order: 76 } },
+  { pattern: /^ernie/i, family: { id: 'ernie', label: 'ERNIE', order: 77 } },
 
   // === 能力分类（fallback） ===
   // 注意：reranker 必须先于 embedding 检查（匹配顺序），但显示顺序让 embedding 在前（order 小）


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

设置页 `modelFamily` 分组滞后，注册表里的 2026.8 型号落进 Other。只改分组规则与测试，ID 全部来自现有 registry，不编造。不改 #170/#171 引擎、#184 JSON、#178/#179 推理档。

### Changes
- gemini-3、llama-4、grok、magistral、minimax（含 minimax-m*）、ernie

### How to test
- `npx vitest run src/features/settings/components/__tests__/modelFamily.test.ts`

### Third-party content
- [ ] 本 PR 包含第三方代码

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the CLA and will sign it when prompted

**不要合并**：CLA 未签。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

