### PR TITLE
test(chat): InputBar 推理标签断言对齐 i18n key

### DIFF
--- a/src/features/chat/components/input-bar/__tests__/InputBarV2.staleContextRef.test.tsx
+++ b/src/features/chat/components/input-bar/__tests__/InputBarV2.staleContextRef.test.tsx
@@ -52,9 +52,9 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }));
 
-// 测试环境不加载异步 i18n 命名空间（chatV2 等按需加载），真实 t 会原样返回
-// 未插值的 defaultValue（如 '推理: {{depth}}'）。与同目录其它测试一致，
-// mock useTranslation 并补上 {{var}} 插值，保证断言确定性。
+// 与同目录其它测试一致，mock useTranslation：t 返回 defaultValue（若有）并做
+// {{var}} 插值，否则原样返回 key。产品代码的 thinkingStateLabel 已改为纯 i18n
+// key 调用（不带 defaultValue），因此下方对 thinkingStateLabel 的断言使用 key。
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-i18next')>();
   const translate = (
@@ -238,7 +238,7 @@ describe('InputBarV2 stale context ref guard', () => {
       />
     );
 
-    expect(capturedInputBarUIProps?.thinkingStateLabel).toBe('推理: 高');
+    expect(capturedInputBarUIProps?.thinkingStateLabel).toBe('chatV2:inputBar.thinkingState.on');
     expect(capturedInputBarUIProps?.runtimeModelLabel).toBe('deepseek-v4-pro');
     expect(capturedInputBarUIProps?.thinkingDepthOptions?.map((option: any) => option.value)).toEqual(['high', 'max']);
     expect(capturedInputBarUIProps?.thinkingDepthOptions?.map((option: any) => option.labelKey)).toEqual([
@@ -277,7 +277,7 @@ describe('InputBarV2 stale context ref guard', () => {
       />
     );
 
-    expect(capturedInputBarUIProps?.thinkingStateLabel).toBe('推理: 不支持');
+    expect(capturedInputBarUIProps?.thinkingStateLabel).toBe('chatV2:inputBar.thinkingState.unsupported');
     expect(capturedInputBarUIProps?.thinkingUnsupported).toBe(true);
     expect(capturedInputBarUIProps?.enableThinking).toBe(false);
     expect(capturedInputBarUIProps?.thinkingDepthOptions).toEqual([]);
@@ -766,7 +766,7 @@ describe('InputBarV2 stale context ref guard', () => {
       />
     );
 
-    expect(capturedInputBarUIProps?.thinkingStateLabel).toBe('推理: 高');
+    expect(capturedInputBarUIProps?.thinkingStateLabel).toBe('chatV2:inputBar.thinkingState.on');
     expect(capturedInputBarUIProps?.thinkingDepthOptions?.map((option: any) => option.value)).toEqual(['high', 'max']);
   });
 
@@ -848,7 +848,7 @@ describe('InputBarV2 stale context ref guard', () => {
     );
 
     expect(capturedInputBarUIProps?.runtimeModelLabel).toBe('deepseek-v4-pro');
-    expect(capturedInputBarUIProps?.thinkingStateLabel).toBe('推理: 高');
+    expect(capturedInputBarUIProps?.thinkingStateLabel).toBe('chatV2:inputBar.thinkingState.on');
     expect(capturedInputBarUIProps?.thinkingDepthOptions?.map((option: any) => option.value)).toEqual(['high', 'max']);
   });
 
@@ -882,7 +882,7 @@ describe('InputBarV2 stale context ref guard', () => {
       />
     );
 
-    expect(capturedInputBarUIProps?.thinkingStateLabel).toBe('推理: 超高');
+    expect(capturedInputBarUIProps?.thinkingStateLabel).toBe('chatV2:inputBar.thinkingState.on');
     expect(capturedInputBarUIProps?.thinkingDepthOptions?.map((option: any) => option.value)).toEqual(['low', 'medium', 'high', 'xhigh']);
     expect(capturedInputBarUIProps?.thinkingDepthOptions?.map((option: any) => option.labelKey)).toEqual([
       'settings:api.modal.deepseek.depth.low',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主干 `InputBarV2.staleContextRef` 仍断言「推理: 高」，产品已走 `t('chatV2:inputBar.thinkingState.on')`。只改测试，不改 #185 mock、不改 InputBar 产品。

### How to test
- `npx vitest run src/features/chat/components/input-bar/__tests__/InputBarV2.staleContextRef.test.tsx`

### Third-party content
- [ ] 本 PR 包含第三方代码

**不要合并**：CLA 未签。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

