### PR TITLE
test(chat): PlanGate / ToolApproval 查询对齐当前 i18n

### DIFF
--- a/src/features/chat/components/__tests__/PlanGateCard.test.tsx
+++ b/src/features/chat/components/__tests__/PlanGateCard.test.tsx
@@ -8,11 +8,8 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: unknown[]) => invokeMock(...args),
 }));
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string, fallback?: string) => fallback ?? key,
-  }),
-}));
+// react-i18next 走全局别名 mock（tests/ct/mocks/react-i18next.tsx），
+// 解析真实 zh-CN 文案；下方查询按当前 locale 文案对齐。
 
 describe('PlanGateCard', () => {
   beforeEach(() => {

--- a/src/features/chat/components/__tests__/ToolApprovalCard.test.tsx
+++ b/src/features/chat/components/__tests__/ToolApprovalCard.test.tsx
@@ -57,7 +57,7 @@ describe('ToolApprovalCard', () => {
       />
     );
 
-    const title = screen.getByText('approval.title');
+    const title = screen.getByText('工具执行确认');
     const titleElement = title.closest('h3');
     expect(titleElement).not.toBeNull();
     expect(titleElement?.querySelector('svg')).toBeNull();
@@ -71,17 +71,19 @@ describe('ToolApprovalCard', () => {
     it('opens inline reason input on reject click without sending', () => {
       render(<ToolApprovalCard request={pendingRequest} sessionId="session-1" />);
 
-      fireEvent.click(screen.getByRole('button', { name: 'approval.reject' }));
+      fireEvent.click(screen.getByRole('button', { name: '本次拒绝' }));
 
       expect(invokeMock).not.toHaveBeenCalled();
-      expect(screen.getByPlaceholderText('approval.rejectReasonPlaceholder')).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText('可选：告诉 AI 为什么拒绝或希望它怎么做'),
+      ).toBeInTheDocument();
     });
 
     it('submits rejection with custom reason on Enter', async () => {
       render(<ToolApprovalCard request={pendingRequest} sessionId="session-1" />);
 
-      fireEvent.click(screen.getByRole('button', { name: 'approval.reject' }));
-      const input = screen.getByPlaceholderText('approval.rejectReasonPlaceholder');
+      fireEvent.click(screen.getByRole('button', { name: '本次拒绝' }));
+      const input = screen.getByPlaceholderText('可选：告诉 AI 为什么拒绝或希望它怎么做');
       fireEvent.change(input, { target: { value: '不要覆盖这个模板' } });
       fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -101,8 +103,8 @@ describe('ToolApprovalCard', () => {
     it('rejects immediately with sentinel reason via the direct-reject button', async () => {
       render(<ToolApprovalCard request={pendingRequest} sessionId="session-1" />);
 
-      fireEvent.click(screen.getByRole('button', { name: 'approval.reject' }));
-      fireEvent.click(screen.getByRole('button', { name: 'approval.rejectDirectly' }));
+      fireEvent.click(screen.getByRole('button', { name: '本次拒绝' }));
+      fireEvent.click(screen.getByRole('button', { name: '直接拒绝' }));
 
       await waitFor(() => {
         expect(invokeMock).toHaveBeenCalledWith(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主干这两个套件因本地 i18n mock / 裸 key 查询失败。PlanGate 去掉错误本地 mock；ToolApproval 查询改为当前 zh-CN 文案。不改产品组件，不改 #185。

### How to test
```bash
npx vitest run \
  src/features/chat/components/__tests__/PlanGateCard.test.tsx \
  src/features/chat/components/__tests__/ToolApprovalCard.test.tsx
```

### Third-party content
- [ ] 本 PR 包含第三方代码

**不要合并**：CLA 未签。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

