### PR TITLE
test(a11y): AppMenu 键盘用例对齐容器优先聚焦

### DIFF
--- a/src/components/ui/app-menu/AppMenu.keyboard.test.tsx
+++ b/src/components/ui/app-menu/AppMenu.keyboard.test.tsx
@@ -59,7 +59,11 @@ describe('AppMenu submenu keyboard contract', () => {
     await user.keyboard(key);
 
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
-    await waitFor(() => expect(screen.getByRole('menuitem', { name: 'First action' })).toHaveFocus());
+    // 打开后焦点落在菜单容器上（不预聚焦任何菜单项，避免"假悬浮"高亮）；
+    // 方向键从容器进入导航，第一次 ArrowDown 聚焦第一项。
+    await waitFor(() => expect(screen.getByRole('menu')).toHaveFocus());
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('menuitem', { name: 'First action' })).toHaveFocus();
   });
 
   it.each(['Enter', ' ', 'ArrowRight'])('%s opens the default hover submenu and focuses its first item', async (key) => {
@@ -85,9 +89,10 @@ describe('AppMenu submenu keyboard contract', () => {
       </AppMenu>
     );
     const view = render(renderMenu(1));
-    const first = await screen.findByRole('menuitem', { name: 'First action' });
+    await screen.findByRole('menuitem', { name: 'First action' });
     const second = screen.getByRole('menuitem', { name: 'Second action' });
-    await waitFor(() => expect(first).toHaveFocus());
+    // 打开后焦点先落在菜单容器上；随后模拟用户把焦点移到某个菜单项
+    await waitFor(() => expect(screen.getByRole('menu')).toHaveFocus());
     second.focus();
 
     view.rerender(renderMenu(2));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主干 AppMenu 键盘测试期望打开后第一项自动聚焦；组件有意把焦点放在 `role="menu"` 容器上。测试改为：容器聚焦后再 ArrowDown 进入第一项。不改产品。

### How to test
- `npx vitest run src/components/ui/app-menu/AppMenu.keyboard.test.tsx`

**不要合并**：CLA 未签。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

