### PR TITLE
test(settings): SiliconFlow 源码契约改用 cwd 相对路径

### DIFF
--- a/tests/vitest/siliconflow-qbank-assignment-mapping.test.ts
+++ b/tests/vitest/siliconflow-qbank-assignment-mapping.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 describe('SiliconFlow one-click assignment mapping', () => {
   it('includes qbank grading mapping key in preset assignments', () => {
     const source = readFileSync(
-      '/Volumes/cipan/deep-student/src/features/settings/components/SiliconFlowSection.tsx',
+      resolve(process.cwd(), 'src/features/settings/components/SiliconFlowSection.tsx'),
       'utf-8'
     );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

测试写死了开发者本机 `/Volumes/cipan/deep-student/...`，CI Linux 上 ENOENT。产品映射已含 qbank grading key。改为 `process.cwd()` 相对路径。

### How to test
- `npx vitest run tests/vitest/siliconflow-qbank-assignment-mapping.test.ts`

**不要合并**：CLA 未签。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

