### PR TITLE
test(chat): 工具显示名 locale 契约只剥一层 builtin- 前缀

### DIFF
--- a/src/features/chat/utils/__tests__/toolDisplayNameLocales.test.ts
+++ b/src/features/chat/utils/__tests__/toolDisplayNameLocales.test.ts
@@ -15,9 +15,13 @@ import {
 function embeddedToolKeys(skills: readonly SkillDefinition[]): string[] {
   const keys = skills.flatMap((skill) =>
     (skill.embeddedTools ?? []).map((tool) =>
-      tool.name
-        .replace(/^builtin[-:]/, '')
-        .replace(/^mcp_/, ''),
+      // Mirrors buildBuiltinToolsFromSkills/getToolDisplayNameKey: only one
+      // prefix is stripped. builtin-mcp_server_* tools keep their mcp_ prefix
+      // and resolve to the tools.mcp_server_* locale keys; a bare mcp_ prefix
+      // is stripped only when the builtin namespace is absent.
+      /^builtin[-:]/.test(tool.name)
+        ? tool.name.replace(/^builtin[-:]/, '')
+        : tool.name.replace(/^mcp_/, ''),
     ),
   );
   return [...new Set(keys)].sort();
@@ -64,6 +68,8 @@ describe('built-in tool display name locales', () => {
 
   it('never treats external MCP names as builtin display-name keys', () => {
     expect(getToolDisplayNameKey('builtin-web_search')).toBe('tools.web_search');
+    // Builtin MCP-manage tools keep mcp_ in the key: tools.mcp_server_*.
+    expect(getToolDisplayNameKey('builtin-mcp_server_propose')).toBe('tools.mcp_server_propose');
     expect(getToolDisplayNameKey('mcp_web_search')).toBeUndefined();
     expect(getToolDisplayNameKey('mcp.tools.web_search')).toBeUndefined();
     expect(hasToolDisplayName('mcp_web_search')).toBe(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

测试把 `builtin-mcp_server_*` 剥成不存在的 `tools.server_*`。运行时只剥 `builtin-`，对应 `mcp.json` 里已有的 `tools.mcp_server_*`。对齐测试，不补死词条。

### How to test
- `npx vitest run src/features/chat/utils/__tests__/toolDisplayNameLocales.test.ts`

**不要合并**：CLA 未签。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

