### PR TITLE
test(shell): 对齐桌面壳与侧栏源码契约

### DIFF
--- a/tests/vitest/appChatHeaderTitleContract.test.ts
+++ b/tests/vitest/appChatHeaderTitleContract.test.ts
@@ -29,9 +29,12 @@ describe('app chat header title contract', () => {
     expect(appSource).toContain('if (currentView === \'chat-v2\') {');
     expect(appSource).toContain('return currentChatHeaderTitle;');
     expect(appSource).toContain("const [currentChatHeaderTitle, setCurrentChatHeaderTitle] = useState('');");
-    expect(appSource).toContain("if (!chatHeaderSessionId) {\n      setCurrentChatHeaderTitle('');");
+    expect(appSource).toContain(
+      "if (!chatHeaderSessionId) {\n      setCurrentChatHeaderSessionId(null);\n      setCurrentChatHeaderTitle('');"
+    );
     expect(appSource).toContain("if (!state) {\n      return '';");
-    expect(appSource).toContain('t(\'sidebar:navigation.chat_v2\', \'新会话\')');
+    // i18n 默认值已收敛到 locale 文件，调用点不再内联 defaultValue
+    expect(appSource).toContain("'chat-v2': t('sidebar:navigation.chat_v2'),");
   });
 
   it('subscribes the chat header to current-session changes and active-session title updates', () => {
@@ -63,12 +66,15 @@ describe('app chat header title contract', () => {
   it('keeps desktop header nav and title cells as explicit hotzones beyond the inner icon buttons', () => {
     expect(appSource).toContain('data-shell-hotzone="desktop-nav"');
     expect(appSource).toContain('data-shell-hotzone="desktop-title"');
-    expect(appSource).toContain('const desktopHeaderNavHotzoneLabel = t(\'chatV2:page.newSession\', \'新建会话\')');
-    expect(appSource).toContain('const desktopHeaderTitleHotzoneLabel = t(\'common:command_palette_label\', \'命令面板\')');
+    expect(appSource).toContain('const desktopHeaderNavHotzoneLabel = t(\'chatV2:page.newSession\');');
+    expect(appSource).toContain('const desktopHeaderTitleHotzoneLabel = t(\'common:command_palette_label\');');
     expect(appSource).toContain('const handleDesktopTitlebarMouseDown = useCallback((event: React.MouseEvent<HTMLElement>) => {');
     expect(appSource).toContain("const dragExclusionTarget = (event.target as HTMLElement).closest('[data-no-drag]');");
     expect(appSource).toContain('void startDragging(event);');
-    expect(appSource).toContain('onMouseDown={workbenchActive ? undefined : handleDesktopTitlebarMouseDown}');
+    // 工作台模式整个 titlebar 不渲染（拖拽由 wb-menubar 接管），
+    // 因此 onMouseDown 无需再按 workbenchActive 分流
+    expect(appSource).toContain('{!isSmallScreen && !workbenchActive && (');
+    expect(appSource).toContain('onMouseDown={handleDesktopTitlebarMouseDown}');
     expect(appSource).toContain('onMouseDown={handleHeaderHotzoneMouseDown}');
     expect(appSource).toContain('onMouseMove={handleHeaderHotzoneMouseMove}');
     expect(appSource).toContain('onMouseUp={handleHeaderHotzoneMouseUp}');
@@ -174,7 +180,7 @@ describe('app chat header title contract', () => {
     expect(accessoryEnd).toBeGreaterThan(accessoryStart);
     const accessorySource = appSource.slice(accessoryStart, accessoryEnd);
 
-    expect(appSource).toContain("const desktopSidebarToggleLabel = t('common:navigation.toggle_sidebar', '切换边栏');");
+    expect(appSource).toContain("const desktopSidebarToggleLabel = t('common:navigation.toggle_sidebar');");
     expect(accessorySource).toContain('<CommonTooltip content={label} position="bottom">');
     expect(accessorySource).not.toContain('title={label}');
 
@@ -196,11 +202,13 @@ describe('app chat header title contract', () => {
     expect(appSource).toContain('const getChatHeaderGroupNameFromStoreState = useCallback((state?: ChatStore | null) => {');
     expect(appSource).toContain("return groupCache.get(state.groupId)?.name ?? '';");
     expect(appSource).toContain('state.groupId !== prevState.groupId');
-    expect(appSource).toContain("window.addEventListener('chat-v2:groups-updated', syncCurrentChatHeaderGroupName);");
+    // 分组列表更新事件已迁移到统一的 app 事件总线（useAppEvent）
+    expect(appSource).toContain('useAppEvent(APP_EVENTS.CHAT_GROUPS_UPDATED, () => {');
+    expect(appSource).toContain('syncCurrentChatHeaderGroupName();');
     expect(appSource).toContain('const desktopHeaderNewSessionTooltipLabel = currentChatHeaderGroupName');
     expect(appSource).toContain("t('chatV2:page.newSessionInGroup', {");
     expect(appSource).toContain('groupName: currentChatHeaderGroupName');
-    expect(appSource).toContain("defaultValue: '在 {{groupName}} 中新建会话'");
+    expect(appSource).toContain(': desktopHeaderNavHotzoneLabel;');
     expect(appSource).toContain('newSessionLabel={desktopHeaderNewSessionTooltipLabel}');
     expect(appSource).toContain('aria-label={desktopHeaderNewSessionTooltipLabel}');
     expect(groupManagementSource).toContain('setGroupsCache(sorted);\n    emitGroupListUpdated();');

--- a/tests/vitest/appPhosphorImportConflictContract.test.ts
+++ b/tests/vitest/appPhosphorImportConflictContract.test.ts
@@ -10,7 +10,7 @@ describe('App phosphor import conflict contract', () => {
     assert.doesNotMatch(appSource, /^(<<<<<<<|=======|>>>>>>>)/mu);
     assert.match(
       appSource,
-      /import\s*\{\s*CaretLeft,\s*CaretRight,\s*CircleNotch,\s*DownloadSimple,\s*Terminal,\s*Warning,\s*X\s*\}\s*from\s*'@phosphor-icons\/react';/u,
+      /import\s*\{\s*CaretLeft,\s*CaretRight,\s*CircleNotch,\s*Terminal,\s*Warning,\s*X\s*\}\s*from\s*'@phosphor-icons\/react';/u,
     );
     assert.doesNotMatch(appSource, /\bArrowLeft\b/u);
   });

--- a/tests/vitest/desktopShellContract.test.ts
+++ b/tests/vitest/desktopShellContract.test.ts
@@ -6,6 +6,10 @@ describe('desktop shell migration contract', () => {
   const appSource = readFileSync(resolve(process.cwd(), 'src/App.tsx'), 'utf-8');
   const appCssSource = readFileSync(resolve(process.cwd(), 'src/shared/styles/app.css'), 'utf-8');
   const sidebarSource = readFileSync(resolve(process.cwd(), 'src/components/ModernSidebar.tsx'), 'utf-8');
+  const workbenchSidebarSource = readFileSync(
+    resolve(process.cwd(), 'src/features/workbench/components/sidebar/WorkbenchSidebar.tsx'),
+    'utf-8'
+  );
   const windowControlsSource = readFileSync(resolve(process.cwd(), 'src/components/WindowControls.tsx'), 'utf-8');
   const rendererSource = readFileSync(resolve(process.cwd(), 'src/app/components/ViewLayerRenderer.tsx'), 'utf-8');
   const themeSource = readFileSync(resolve(process.cwd(), 'src/styles/theme-colors.css'), 'utf-8');
@@ -14,7 +18,10 @@ describe('desktop shell migration contract', () => {
     expect(appSource).toContain('data-shell-role="app-shell"');
     expect(appSource).toContain('data-shell-layer="window-chrome"');
     expect(appSource).toContain('data-shell-layer="workspace"');
-    expect(sidebarSource).toContain('data-shell-layer="navigation"');
+    // navigation 层由 WorkbenchSidebarSurface primitive 统一盖章（os 重构），
+    // ModernSidebar 通过渲染该 primitive 获得 data-shell-layer="navigation"。
+    expect(sidebarSource).toContain('<WorkbenchSidebarSurface');
+    expect(workbenchSidebarSource).toContain('data-shell-layer="navigation"');
   });
 
   it('routes desktop shell surfaces through semantic tokens (flat-white architecture)', () => {

--- a/tests/vitest/desktopShellSidebarCollapseContract.test.ts
+++ b/tests/vitest/desktopShellSidebarCollapseContract.test.ts
@@ -16,7 +16,10 @@ describe('desktop shell sidebar collapse contract', () => {
     expect(appSource).toContain(": !isSmallScreen && leftPanelCollapsed ? 0 : desktopSidebarPresentationWidth;");
     expect(appSource).not.toContain("currentView !== 'settings' && leftPanelCollapsed ? 0 : shellSidebarWidth");
     expect(appSource).toContain("'--shell-navigation-width': `${desktopNavigationWidth}px`");
-    expect(appSource).toContain("workbenchActive && 'desktop-shell-titlebar--workbench-chrome'");
+    // 工作台模式不再渲染 desktop-shell-titlebar（窗口拖拽/Win 三键由 Workbench
+    // StatusBar 接管），因此不存在 workbench-chrome 变体类
+    expect(appSource).toContain('{!isSmallScreen && !workbenchActive && (');
+    expect(appSource).not.toContain('desktop-shell-titlebar--workbench-chrome');
     expect(appSource).toContain("width: 'var(--shell-navigation-width)'");
     expect(appCssSource).toContain('.desktop-shell-sidebar-track');
     expect(appCssSource).toContain('transform: translateX(var(--shell-sidebar-translate-x));');
@@ -37,19 +40,20 @@ describe('desktop shell sidebar collapse contract', () => {
     expect(appCssSource).toContain('transition: padding-left var(--resize-dur) var(--resize-ease)');
   });
 
-  it('keeps the collapse affordance alive as a floating titlebar accessory instead of letting it disappear with the sidebar column', () => {
-    expect(appSource).toContain('const shouldUseDesktopFloatingAccessory = !isSmallScreen;');
-    expect(appSource).not.toContain("const shouldUseDesktopFloatingAccessory = !isSmallScreen && currentView !== 'settings';");
-    expect(appSource).toContain('const desktopCollapsedLeadingWidth = 148;');
-    expect(appSource).toContain('const desktopFloatingAccessoryWidth = desktopCollapsedLeadingWidth;');
-    expect(appSource).not.toContain('const desktopFloatingAccessoryWidth = leftPanelCollapsed');
-    expect(appSource).toContain('const desktopSidebarExpandedAccessoryContent = (');
-    expect(appSource).toContain('const desktopSidebarCollapsedAccessoryContent = (');
+  it('keeps the collapse affordance alive as a fixed titlebar accessory instead of letting it disappear with the sidebar column', () => {
+    // 顶部控制组现挂载在固定的 desktop-shell-sidebar-top-accessory 锚点，
+    // 不再区分 expanded/collapsed 两套浮动 accessory 内容
+    expect(appSource).toContain('const desktopFloatingAccessoryOffset = isMacOS() ? DESKTOP_SHELL.macTrafficLightsSpacer + 16 : 16;');
+    expect(appSource).toContain('const desktopCollapsedLeadingWidth =');
+    expect(appSource).toContain('desktopHeaderIconButtonSize * desktopCollapsedControlCount');
+    expect(appSource).not.toContain('shouldUseDesktopFloatingAccessory');
+    expect(appSource).not.toContain('desktopSidebarExpandedAccessoryContent');
+    expect(appSource).not.toContain('desktopSidebarCollapsedAccessoryContent');
+    expect(appSource).toContain('const desktopSidebarTopAccessoryContent = (');
     expect(appSource).toContain('<DesktopSidebarAccessory');
-    expect(appSource).toContain('className="desktop-shell-sidebar-expanded-accessory"');
-    expect(appSource).toContain('className="desktop-shell-sidebar-collapsed-accessory"');
-    expect(appSource).toContain('width: `${desktopFloatingAccessoryWidth}px`');
-    expect(appSource).toContain('pointer-events-auto inline-flex h-full max-w-full items-center justify-between gap-1.5 overflow-hidden pr-1.5');
+    expect(appSource).toContain('className="desktop-shell-sidebar-top-accessory"');
+    expect(appSource).toContain('left: `${desktopFloatingAccessoryOffset}px`');
+    expect(appSource).toContain('pointer-events-auto inline-flex h-full items-center');
     expect(appSource).toContain('{shouldShowDesktopHeaderNavControls ? desktopHeaderNavControls : null}');
     expect(appSource).not.toContain('{leftPanelCollapsed && shouldShowDesktopHeaderNavControls ? desktopHeaderNavControls : null}');
     expect(appSource).not.toContain('{!leftPanelCollapsed && shouldShowDesktopHeaderNavControls ? desktopHeaderNavControls : null}');
@@ -87,10 +91,14 @@ describe('desktop shell sidebar collapse contract', () => {
     expect(appCssSource).toContain('width var(--resize-dur) var(--resize-ease)');
   });
 
-  it('animates the accessory internals and back-forward rhythm with the same motion vocabulary as study-ui', () => {
-    expect(appCssSource).toContain('.desktop-shell-sidebar-expanded-accessory');
-    expect(appCssSource).toContain('transition: transform var(--resize-dur) var(--resize-ease)');
-    expect(appSource).toContain('transition-[transform,opacity,margin-right] duration-200 ease-[var(--panel-ease)] motion-reduce:transition-none');
+  it('keeps the fixed top accessory static while the motion surface owns the sidebar rhythm', () => {
+    // 顶部控制组固定在标题栏锚点上（transition: none），滑动动画全部由
+    // desktop-shell-sidebar-motion-surface 以统一的 resize 节奏承担
+    expect(appCssSource).toContain('.desktop-shell-sidebar-top-accessory');
+    expect(appCssSource).toContain('transition: none !important;');
+    expect(appCssSource).not.toContain('.desktop-shell-sidebar-expanded-accessory');
+    expect(appCssSource).toContain('.desktop-shell-sidebar-motion-surface');
+    expect(appCssSource).toContain('transform var(--resize-dur) var(--resize-ease)');
   });
 
   it('renders the active desktop shell sidebar for every desktop route so width transitions can animate', () => {
@@ -120,11 +128,20 @@ describe('desktop shell sidebar collapse contract', () => {
   });
 
   it('rounds the visible desktop workspace edge across the fixed titlebar and body', () => {
-    expect(appSource).toContain("const isDesktopSidebarSurfaceVisible = !isSmallScreen && !leftPanelCollapsed && !workbenchActive;");
+    // 侧栏折叠滑出期间（desktopSidebarMotionWidth 非空）左侧表面保持可见，
+    // 避免 360ms 位移动画中露出底色
+    expect(appSource).toContain(
+      'const isDesktopSidebarSurfaceVisible =\n'
+      + '    !isSmallScreen\n'
+      + '    && !workbenchActive\n'
+      + '    && (!leftPanelCollapsed || desktopSidebarMotionWidth !== null);'
+    );
     expect(appSource).toContain('data-sidebar-visible={isDesktopSidebarSurfaceVisible ? \'true\' : \'false\'}');
     expect(appCssSource).toContain('--shell-workspace-edge-radius: 24px;');
     expect(appCssSource).toMatch(/\[data-shell-role="app-shell"\]\[data-sidebar-visible="true"\]\s*\{[\s\S]*background:\s*var\(--shell-navigation-surface\);/);
-    expect(appCssSource).toMatch(/\.desktop-shell-sidebar-titlebar-surface\s*\{[\s\S]*background:\s*var\(--shell-navigation-surface\);/);
+    // 独立的 sidebar-titlebar-surface 层已移除：标题栏自身用渐变直接铺出左列导航面
+    expect(appCssSource).not.toContain('.desktop-shell-sidebar-titlebar-surface');
+    expect(appCssSource).toMatch(/\.desktop-shell-titlebar\[data-sidebar-visible="true"\]\s*\{[\s\S]*?var\(--shell-navigation-surface\) 0,/);
     expect(appCssSource).toMatch(/\.desktop-shell-workspace\[data-sidebar-visible="true"\]\s*\{[\s\S]*overflow:\s*hidden;/);
     expect(appCssSource).toContain('background: var(--shell-workspace-panel);');
   });

--- a/tests/vitest/desktopShellTwoColumnSurfaceContract.test.ts
+++ b/tests/vitest/desktopShellTwoColumnSurfaceContract.test.ts
@@ -6,21 +6,24 @@ describe('desktop shell two-column surface contract', () => {
   const appSource = readFileSync(resolve(process.cwd(), 'src/App.tsx'), 'utf-8');
   const shellStylesSource = readFileSync(resolve(process.cwd(), 'src/shared/styles/app.css'), 'utf-8');
 
-  it('lets the dedicated sidebar titlebar layer own the left surface', () => {
+  it('lets the titlebar gradient paint the left navigation surface directly', () => {
     expect(appSource).toContain("data-sidebar-visible={isDesktopSidebarSurfaceVisible ? 'true' : 'false'}");
     const visibleTitlebarBlock = shellStylesSource.match(
       /\.desktop-shell-titlebar\[data-sidebar-visible="true"\]\s*\{[^}]*\}/
     )?.[0] ?? '';
 
+    // 独立的 sidebar-titlebar-surface 层已移除：标题栏渐变左段直接铺导航面，
+    // 分界点跟随 --shell-navigation-surface-width（折叠动画期间保持原宽度）
     expect(visibleTitlebarBlock).toContain('linear-gradient(');
-    expect(visibleTitlebarBlock).toContain('transparent 0');
-    expect(visibleTitlebarBlock).toContain('transparent var(--shell-navigation-width)');
-    expect(visibleTitlebarBlock).not.toContain('var(--shell-navigation-surface)');
-    expect(visibleTitlebarBlock).toContain('var(--shell-navigation-width)');
-    expect(visibleTitlebarBlock).toContain('var(--shell-workspace-panel)');
-    expect(shellStylesSource).toMatch(
-      /\.desktop-shell-sidebar-titlebar-surface\s*\{[\s\S]*?background:\s*var\(--shell-navigation-surface\);/,
+    expect(visibleTitlebarBlock).toContain('var(--shell-navigation-surface) 0');
+    expect(visibleTitlebarBlock).toContain(
+      'var(--shell-navigation-surface) var(--shell-navigation-surface-width, var(--shell-navigation-width))'
     );
+    expect(visibleTitlebarBlock).toContain(
+      'var(--shell-workspace-panel) var(--shell-navigation-surface-width, var(--shell-navigation-width))'
+    );
+    expect(visibleTitlebarBlock).not.toContain('transparent 0');
+    expect(shellStylesSource).not.toContain('.desktop-shell-sidebar-titlebar-surface');
   });
 
   it('keeps the header cells transparent so the shell reads as left column plus right column', () => {

--- a/tests/vitest/modernSidebarScrollContract.test.ts
+++ b/tests/vitest/modernSidebarScrollContract.test.ts
@@ -17,42 +17,23 @@ describe('modern sidebar scroll contract', () => {
     expect(primitiveSource).toContain('<CustomScrollArea');
   });
 
-  it('uses a viewport mask fade instead of overlay pseudo-elements that could block interactions', () => {
-    const fadeCss = appCss.slice(
-      appCss.indexOf('.desktop-shell-sidebar-session-scroll'),
-      appCss.indexOf('.desktop-shell-header-title')
-    );
-
+  it('does not paint overlay pseudo-elements or mask fades over the session scroll region', () => {
+    // 会话列表边缘渐隐（mask-image 方案）已随 os 重构移除：滚动壳只负责滚动，
+    // 不再叠加可能拦截交互或遮挡内容的伪元素/遮罩。
     expect(primitiveSource).toContain('desktop-shell-sidebar-session-scroll');
-    expect(fadeCss).not.toContain('.desktop-shell-sidebar-session-scroll::before');
-    expect(fadeCss).not.toContain('.desktop-shell-sidebar-session-scroll::after');
-    expect(fadeCss).toContain('.desktop-shell-sidebar-session-scroll-viewport');
-    expect(fadeCss).toContain('mask-image');
+    expect(appCss).not.toContain('.desktop-shell-sidebar-session-scroll::before');
+    expect(appCss).not.toContain('.desktop-shell-sidebar-session-scroll::after');
+    expect(appCss).not.toContain('.desktop-shell-sidebar-session-scroll-viewport');
+    expect(appCss).not.toContain('--desktop-shell-sidebar-session-fade-size');
   });
 
-  it('keeps the session edge fade compatible with desktop WebViews', () => {
-    const fadeCss = appCss.slice(
-      appCss.indexOf('.desktop-shell-sidebar-session-scroll'),
-      appCss.indexOf('.desktop-shell-header-title')
-    );
-
-    expect(fadeCss).not.toContain('color-mix');
-    expect(fadeCss).toContain('--desktop-shell-sidebar-session-fade-size: 28px');
-    expect(fadeCss).toContain('-webkit-mask-image');
+  it('keeps the session viewport free of the legacy fade mask class', () => {
+    expect(primitiveSource).not.toContain('desktop-shell-sidebar-session-scroll-viewport');
+    expect(primitiveSource).toContain('viewportClassName="h-full w-full"');
   });
 
-  it('applies the bottom edge fade directly to the session scroll viewport content', () => {
-    const fadeCss = appCss.slice(
-      appCss.indexOf('.desktop-shell-sidebar-session-scroll'),
-      appCss.indexOf('.desktop-shell-header-title')
-    );
-
-    expect(primitiveSource).toContain('desktop-shell-sidebar-session-scroll-viewport');
-    expect(fadeCss).toContain('.desktop-shell-sidebar-session-scroll-viewport');
-    expect(fadeCss).toContain('-webkit-mask-image');
-    expect(fadeCss).toContain('mask-image');
-    expect(fadeCss).toContain('transparent 0%');
-    expect(fadeCss).toContain('black var(--desktop-shell-sidebar-session-fade-size)');
-    expect(fadeCss).toContain('black calc(100% - var(--desktop-shell-sidebar-session-fade-size))');
+  it('shows the session scrollbar only while the user is scrolling', () => {
+    expect(primitiveSource).toContain('scrollAutoHide="scroll"');
+    expect(primitiveSource).toContain('scrollAutoHideSuspend={false}');
   });
 });

--- a/tests/vitest/modernSidebarSessionIndicators.test.tsx
+++ b/tests/vitest/modernSidebarSessionIndicators.test.tsx
@@ -68,6 +68,18 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: invokeMock,
 }));
 
+// ModernSidebar 的会话搜索入口依赖 CommandPaletteProvider 上下文；
+// 本测试只关心会话指示器，stub 掉 useCommandPalette 以免整棵 Provider 树入场。
+vi.mock('@/command-palette', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/command-palette')>();
+  return {
+    ...actual,
+    useCommandPalette: () => ({
+      openSessionSearch: () => undefined,
+    }),
+  };
+});
+
 vi.mock('@/features/chat/core/session/sessionManager', () => ({
   sessionManager: {
     getCurrentSessionId: getCurrentSessionIdMock,

--- a/tests/vitest/pointerCursorPreferenceContract.test.ts
+++ b/tests/vitest/pointerCursorPreferenceContract.test.ts
@@ -39,7 +39,8 @@ describe('pointer cursor preference contract', () => {
 
     expect(appSource).toContain("const POINTER_CURSOR_SETTING_KEY = 'ui.pointer_cursor'");
     expect(appSource).toContain('document.documentElement.dataset.pointerCursor = enabled ? \'true\' : \'false\'');
-    expect(appSource).toContain("event?.detail?.settingKey === POINTER_CURSOR_SETTING_KEY");
+    // 设置变更监听已迁移到 addAppEventListener（回调直接拿 detail）
+    expect(appSource).toContain("detail?.settingKey === POINTER_CURSOR_SETTING_KEY");
     expect(appSource).toContain('const loadPointerCursorSetting = async () => {');
     expect(appSource).toContain("applyPointerCursorPreference(String(val ?? '').trim() !== 'false')");
 

--- a/tests/vitest/secondarySurfaceShellContract.test.ts
+++ b/tests/vitest/secondarySurfaceShellContract.test.ts
@@ -45,6 +45,7 @@ describe('secondary surface shell migration contract', () => {
     expect(chatPageSource).toContain('study-shell-page chat-v2 absolute inset-0 flex overflow-hidden');
     expect(chatPageSource).toContain('renderMainContent()');
     expect(chatPageSource).toContain('study-shell-panel h-full flex flex-col');
-    expect(chatPageSource).toContain('study-shell-toolbar flex items-center justify-between');
+    // 移动端全屏时工具栏隐藏（hidden/flex 由条件类切换），flex 不再写死在基类串里
+    expect(chatPageSource).toContain('study-shell-toolbar items-center justify-between');
   });
 });

--- a/tests/vitest/segmentedControlMigrationContract.test.ts
+++ b/tests/vitest/segmentedControlMigrationContract.test.ts
@@ -16,10 +16,9 @@ const read = (relativePath: string) =>
   readFileSync(resolve(process.cwd(), relativePath), 'utf-8');
 
 // `minUsages` reflects how many <SegmentedControl ...> blocks must appear
-// in the file. TodoMainPanel has two (quick-add + detail pane); the others
-// have one.
+// in the file. TodoMainPanel 已在 todo 重构中移除分段控件（0 usages），
+// 不再属于本契约的覆盖范围。
 const migrated: Array<{ path: string; minUsages: number }> = [
-  { path: 'src/features/todo/components/TodoMainPanel.tsx', minUsages: 2 },
   { path: 'src/features/anki-tasks/AnkiTasksApp.tsx', minUsages: 1 },
   { path: 'src/components/skills-management/SkillsManagementPage.tsx', minUsages: 1 },
 ];

--- a/tests/vitest/styleDebugComponentInventoryContract.test.ts
+++ b/tests/vitest/styleDebugComponentInventoryContract.test.ts
@@ -36,22 +36,22 @@ describe('style debug component inventory contract', () => {
   ].map((file) => readFileSync(resolve(process.cwd(), file), 'utf-8')).join('\n');
 
   it('shows the current scan scope and refreshed inventory metrics on the style lab page', () => {
-    expect(source).toContain('"totalFiles": 1293');
-    expect(source).toContain('"tsxFiles": 521');
-    expect(source).toContain('"cssFiles": 75');
-    expect(source).toContain('"refs": 3772');
-    expect(source).toContain('"files": 310');
+    expect(source).toContain('"totalFiles": 2037');
+    expect(source).toContain('"tsxFiles": 726');
+    expect(source).toContain('"cssFiles": 153');
+    expect(source).toContain('"refs": 5004');
+    expect(source).toContain('"files": 381');
     expect(source).toContain('"label": "CSS !important"');
-    expect(source).toContain('"count": 1061');
+    expect(source).toContain('"count": 1062');
   });
 
   it('removes deleted CardForge files from the native button inventory', () => {
     const nativeButton = scanData.components.NativeButton;
     const buttonProgress = scanData.migrationProgress.find(({ id }) => id === 'button');
 
-    expect(nativeButton.refs).toBe(191);
-    expect(nativeButton.files).toBe(70);
-    expect(nativeButton.totalFileCount).toBe(70);
+    expect(nativeButton.refs).toBe(574);
+    expect(nativeButton.files).toBe(194);
+    expect(nativeButton.totalFileCount).toBe(194);
     expect(nativeButton.topFiles).toHaveLength(20);
     expect(nativeButton.topFiles).not.toContain(
       'src/components/anki/cardforge/engines/TaskController.examples.ts',

--- a/tests/vitest/workbenchWindowsChromeLayoutContract.test.ts
+++ b/tests/vitest/workbenchWindowsChromeLayoutContract.test.ts
@@ -5,6 +5,10 @@ import { describe, expect, it } from 'vitest';
 describe('workbench Windows chrome layout contract', () => {
   const appSource = readFileSync(resolve(process.cwd(), 'src/App.tsx'), 'utf-8');
   const appCssSource = readFileSync(resolve(process.cwd(), 'src/shared/styles/app.css'), 'utf-8');
+  const statusBarSource = readFileSync(
+    resolve(process.cwd(), 'src/features/workbench/components/StatusBar.tsx'),
+    'utf-8',
+  );
   const statusBarCssSource = readFileSync(
     resolve(process.cwd(), 'src/features/workbench/components/StatusBar.css'),
     'utf-8',
@@ -14,16 +18,21 @@ describe('workbench Windows chrome layout contract', () => {
     'utf-8',
   );
 
-  it('shares one Windows chrome width between the window controls and shortcut bar', () => {
-    expect(tokensSource).toContain('--wb-windows-chrome-width: 165px;');
-    expect(tokensSource).toContain('--wb-menubar-chrome-inset: var(--wb-windows-chrome-width);');
-    expect(appSource).toContain('className="desktop-shell-workbench-chrome-host');
-    expect(appCssSource).toMatch(
-      /\.desktop-shell-workbench-chrome-host\s*\{[\s\S]*?flex:\s*0 0 var\(--wb-windows-chrome-width, 165px\);/,
+  it('inlines the Windows window controls at the trailing end of the menubar', () => {
+    // Windows 三键已融入 wb-menubar 最右端（data-chrome-inset='windows'），
+    // 不再有共享 chrome 宽度 token，也没有 App 层的 chrome host 占位元素
+    expect(statusBarSource).toContain("data-chrome-inset={winChromeInset ? 'windows' : undefined}");
+    expect(statusBarSource).toContain('className="wb-menubar-window-controls"');
+    expect(statusBarSource).toContain('<WindowControls />');
+    expect(statusBarCssSource).toMatch(
+      /\.wb-menubar\[data-chrome-inset='windows'\]\s*\{[\s\S]*?padding-right:\s*6px;/,
     );
     expect(statusBarCssSource).toMatch(
-      /\.wb-menubar\[data-chrome-inset='windows'\]\s*\{[\s\S]*?right:\s*var\(--wb-menubar-chrome-inset, 165px\);/,
+      /\.wb-menubar\[data-chrome-inset='windows'\] \.wb-menubar-drag-region\s*\{[\s\S]*?inset:\s*0;/,
     );
+    expect(tokensSource).not.toContain('--wb-windows-chrome-width');
+    expect(appSource).not.toContain('desktop-shell-workbench-chrome-host');
+    expect(appCssSource).not.toContain('.desktop-shell-workbench-chrome-host');
   });
 
   it('keeps the trailing shortcuts from shrinking back underneath Windows controls', () => {
@@ -33,10 +42,13 @@ describe('workbench Windows chrome layout contract', () => {
   });
 
   it('keeps the macOS integrated chrome rule independent from the Windows inset', () => {
-    const macRule = statusBarCssSource.slice(
-      statusBarCssSource.indexOf(".wb-menubar[data-macos-chrome='integrated']"),
-      statusBarCssSource.indexOf('.wb-menubar-drag-region'),
-    );
+    // 结束锚点用行首的独立 .wb-menubar-drag-region 规则（前缀 \n），
+    // 避免命中 Windows 块里的 `[data-chrome-inset='windows'] .wb-menubar-drag-region`
+    const macRuleStart = statusBarCssSource.indexOf(".wb-menubar[data-macos-chrome='integrated']");
+    const macRuleEnd = statusBarCssSource.indexOf('\n.wb-menubar-drag-region {', macRuleStart);
+    expect(macRuleStart).toBeGreaterThanOrEqual(0);
+    expect(macRuleEnd).toBeGreaterThan(macRuleStart);
+    const macRule = statusBarCssSource.slice(macRuleStart, macRuleEnd);
 
     // fallback 与 workbench.tokens.css 的 --wb-macos-traffic-lights-inset: 72px 同值
     expect(macRule).toContain('padding-left: var(--wb-macos-traffic-lights-inset, 72px);');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主干 Vitest 在 #185 解除分片 OOM 后，桌面壳 / 侧栏 / 分段控件等源码契约仍按旧符号断言失败。本 PR **只改测试**，把 12 个契约文件对齐到 `origin/main` 当前实现，不改产品、CSS 或 command-palette。

### Changes
- `desktopShellContract`：navigation layer 断言改到 `WorkbenchSidebar` primitive
- `desktopShellSidebarCollapseContract` / `desktopShellTwoColumnSurfaceContract`：对齐工作台下 titlebar 不渲染、accessory 固定锚点、导航面渐变
- `segmentedControlMigrationContract`：TodoMainPanel 已不再使用 SegmentedControl，移出 migrated 列表
- `modernSidebarSessionIndicators`：测试里 mock `useCommandPalette`，不改产品
- `modernSidebarScrollContract`：对齐已移除的 mask-image 边缘渐隐
- `secondarySurfaceShellContract` / `workbenchWindowsChromeLayoutContract` / `pointerCursorPreferenceContract` / `appChatHeaderTitleContract` / `appPhosphorImportConflictContract` / `styleDebugComponentInventoryContract`：按当前源码与 scan-data 更新断言

### How to test
- `npx vitest run tests/vitest/desktopShellContract.test.ts tests/vitest/desktopShellSidebarCollapseContract.test.ts tests/vitest/desktopShellTwoColumnSurfaceContract.test.ts tests/vitest/segmentedControlMigrationContract.test.ts tests/vitest/modernSidebarSessionIndicators.test.tsx tests/vitest/modernSidebarScrollContract.test.ts tests/vitest/secondarySurfaceShellContract.test.ts tests/vitest/workbenchWindowsChromeLayoutContract.test.ts tests/vitest/pointerCursorPreferenceContract.test.ts tests/vitest/appChatHeaderTitleContract.test.ts tests/vitest/appPhosphorImportConflictContract.test.ts tests/vitest/styleDebugComponentInventoryContract.test.ts`

### Screenshots / Logs

本地：12 files / 63 tests passed。主干其余 Vitest 漂移不在本刀范围。

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

