### PR TITLE
test(chat): 对齐输入栏、技能与制卡契约断言

### DIFF
--- a/src/features/chat/components/input-bar/__tests__/InputBarV2.staleContextRef.test.tsx
+++ b/src/features/chat/components/input-bar/__tests__/InputBarV2.staleContextRef.test.tsx
@@ -53,8 +53,17 @@ vi.mock('@tauri-apps/api/core', () => ({
 }));
 
 // 测试环境不加载异步 i18n 命名空间（chatV2 等按需加载），真实 t 会原样返回
-// 未插值的 defaultValue（如 '推理: {{depth}}'）。与同目录其它测试一致，
-// mock useTranslation 并补上 {{var}} 插值，保证断言确定性。
+// key。与同目录其它测试一致，mock useTranslation 并补上 {{var}} 插值；
+// thinkingState 系列 key 现在不再携带 defaultValue，这里按 zh-CN/chatV2.json
+// 提供模板，保证断言确定性。
+const ZH_TEMPLATES = vi.hoisted(
+  (): Record<string, string> => ({
+    'chatV2:inputBar.thinkingState.unsupported': '推理: 不支持',
+    'chatV2:inputBar.thinkingState.off': '推理: 关闭',
+    'chatV2:inputBar.thinkingState.on': '推理: {{depth}}',
+  })
+);
+
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-i18next')>();
   const translate = (
@@ -70,7 +79,7 @@ vi.mock('react-i18next', async (importOriginal) => {
       (typeof defaultValueOrOptions === 'object' && defaultValueOrOptions !== null
         ? (defaultValueOrOptions as Record<string, unknown>)
         : maybeOptions) ?? {};
-    const template = defaultValue ?? key;
+    const template = defaultValue ?? ZH_TEMPLATES[key] ?? key;
     return template.replace(/\{\{(\w+)\}\}/g, (match, name: string) =>
       options[name] !== undefined ? String(options[name]) : match
     );

--- a/src/features/chat/skills/__tests__/phase5TodoAutomationTools.test.ts
+++ b/src/features/chat/skills/__tests__/phase5TodoAutomationTools.test.ts
@@ -172,7 +172,7 @@ describe('phase 5 automation tool surface', () => {
       },
     });
     expect(update.inputSchema.properties.schedule.properties?.kind.enum).toEqual([
-      'daily', 'weekdays', 'weekly', 'monthly', 'interval',
+      'daily', 'weekdays', 'weekly', 'monthly', 'interval', 'once',
     ]);
     for (const tool of [setEnabled, deletion, runNow]) {
       expect(tool.inputSchema).toMatchObject({

--- a/src/features/chat/skills/__tests__/spssProjectSkills.test.ts
+++ b/src/features/chat/skills/__tests__/spssProjectSkills.test.ts
@@ -218,12 +218,15 @@ describe('SPSS project skills', () => {
     const mainSkill = parseProjectSkill('spss-paper-analysis');
     const toolSkill = parseProjectSkill('statistics-tools');
 
+    // 运行时准入现在对非 builtin 技能 fail-closed（project 默认 untrusted，
+    // 见 packageMetadata.getSkillTrustStatus / runtimeAdmission）。这里模拟
+    // 用户已在技能管理中显式授信这两个 project 技能后的加载路径。
     skillRegistry.registerMany([
       askUserSkill,
       xlsxToolsSkill,
       canvasNoteSkill,
-      mainSkill,
-      toolSkill,
+      { ...mainSkill, trustStatus: 'trusted' },
+      { ...toolSkill, trustStatus: 'trusted' },
     ]);
 
     const initial = JSON.parse(

--- a/src/services/__tests__/multimodalRagService.test.ts
+++ b/src/services/__tests__/multimodalRagService.test.ts
@@ -126,7 +126,9 @@ describe('multimodalRagService', () => {
     await expect(retrieve('vector query', undefined, undefined, { topK: 4 }))
       .resolves.toEqual([{
         source_type: 'image',
+        // 扁平路线后端不携带业务 sourceId：source_id 回退为 resource_id
         source_id: 'res-1',
+        resource_id: 'res-1',
         embedding_id: 'emb-1',
         page_index: 2,
         text_content: 'diagram',

--- a/src/styles/__tests__/transitionsDev.cardResize.test.ts
+++ b/src/styles/__tests__/transitionsDev.cardResize.test.ts
@@ -12,7 +12,8 @@ describe('transitions-dev card resize hook', () => {
     expect(css).toContain('.t-resize {');
     expect(css).toContain('width  var(--resize-dur) var(--resize-ease)');
     expect(css).toContain('height var(--resize-dur) var(--resize-ease)');
-    expect(css).toContain('will-change: width, height;');
+    // .t-resize 不再声明 will-change: width/height（持续占用合成层的反模式已移除）
+    expect(css).not.toContain('will-change: width, height;');
 
     const reducedMotion = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));
     expect(reducedMotion).toContain('.t-resize { transition: none !important; }');

--- a/tests/vitest/anki/cardforge/CardAgent.test.ts
+++ b/tests/vitest/anki/cardforge/CardAgent.test.ts
@@ -256,7 +256,10 @@ describe('CardAgent', () => {
         }),
       })
     );
-    expect(result.ok).toBe(true);
+    // 🔧 P0：空闲超时是可区分失败，不再以 ok:true 伪装成功
+    expect(result.ok).toBe(false);
+    expect(result.timedOut).toBe(true);
+    expect(result.error).toContain('空闲超时');
     expect(result.cards).toHaveLength(0);
     expect(result.paused).toBe(false);
   });

--- a/tests/vitest/chat-v2/components/ActivityTimeline.loadSkillsSummary.test.tsx
+++ b/tests/vitest/chat-v2/components/ActivityTimeline.loadSkillsSummary.test.tsx
@@ -36,6 +36,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('@/features/chat/utils/toolDisplayName', () => ({
   getReadableToolName: (name: string) => name,
+  getExternalToolProviderName: () => undefined,
 }));
 
 function createToolBlock(overrides?: Partial<Block>): Block {

--- a/tests/vitest/chat-v2/context/context.test.ts
+++ b/tests/vitest/chat-v2/context/context.test.ts
@@ -454,8 +454,11 @@ describe('预定义类型 formatToBlocks', () => {
       });
 
       const blocks = fileDefinition.formatToBlocks(resource);
-      expect(blocks.length).toBe(2); // 内容 + 截断提示
-      expect((blocks[1] as { type: 'text'; text: string }).text).toContain('truncated');
+      // 前置截断提示 + 内容 + 尾部 Note（截断提示前置让模型第一时间知道内容不完整）
+      expect(blocks.length).toBe(3);
+      expect((blocks[0] as { type: 'text'; text: string }).text).toContain('truncation_notice');
+      expect((blocks[0] as { type: 'text'; text: string }).text).toContain('truncated');
+      expect((blocks[2] as { type: 'text'; text: string }).text).toContain('truncated');
     });
   });
 

--- a/tests/vitest/chat-v2/context/fileDefinitionPdf.test.ts
+++ b/tests/vitest/chat-v2/context/fileDefinitionPdf.test.ts
@@ -74,7 +74,13 @@ describe('fileDefinition (PDF multimodal)', () => {
       }],
     };
 
-    const blocks = fileDefinition.formatToBlocks(resource, { isMultimodal: false } as any);
+    // ★ P0 契约（2026-07）：injectModes 在 ContextRef 创建时显式写入，缺省不再
+    // 隐式双开 text+image（缺省对齐 DEFAULT_PDF_INJECT_MODES = ['text']）。
+    // 这里显式声明 text+image，验证 OCR 仍是 opt-in（不随 image 模式带出）。
+    const blocks = fileDefinition.formatToBlocks(
+      resource,
+      { isMultimodal: false, injectModes: { pdf: ['text', 'image'] } } as any
+    );
     expect(blocks.filter(isImageContentBlock)).toHaveLength(1);
     const text = blocks.filter(isTextContentBlock).map((block: any) => block.text).join('\n');
     expect(text).toContain('native extracted text');

--- a/tests/vitest/chat-v2/markdownTableLayoutContract.test.ts
+++ b/tests/vitest/chat-v2/markdownTableLayoutContract.test.ts
@@ -29,7 +29,9 @@ describe('chat v2 markdown table layout contract', () => {
     expect(tableWrapperRuleStart).toBeGreaterThan(-1);
     expect(tableWrapperRuleEnd).toBeGreaterThan(tableWrapperRuleStart);
     expect(tableWrapperRule).toContain('width: 100%;');
-    expect(tableWrapperRule).toContain('overflow-x: auto;');
+    // 当前实现改为 overflow: visible（不再用 overflow-x: auto 的滚动容器包裹表格）
+    expect(tableWrapperRule).toContain('overflow: visible;');
+    expect(tableWrapperRule).not.toContain('overflow-x: auto;');
   });
 
   it('uses a lightweight document-style table surface instead of a chat card shell', () => {

--- a/tests/vitest/chat-v2/plugins/blocks/AnkiCardsBlock.test.tsx
+++ b/tests/vitest/chat-v2/plugins/blocks/AnkiCardsBlock.test.tsx
@@ -15,10 +15,10 @@ import type { Block } from '@/features/chat/core/types';
 import type { AnkiCardsBlockData } from '@/features/chat/plugins/blocks/ankiCardsBlock';
 import { blockRegistry } from '@/features/chat/registry';
 
-// Mock i18n（仅覆盖本组件使用的 key）
+// Mock i18n（仅覆盖本组件使用的 key，支持 {{var}} 插值）
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, options?: { defaultValue?: string }) => {
+    t: (key: string, options?: { defaultValue?: string } & Record<string, unknown>) => {
       const dict: Record<string, string> = {
         'blocks.ankiCards.edit': 'Edit',
         'blocks.ankiCards.save': 'Save',
@@ -34,10 +34,13 @@ vi.mock('react-i18next', () => ({
         'blocks.ankiCards.progress.ankiConnect.refresh': 'Refresh AnkiConnect status',
         'blocks.ankiCards.progress.ankiConnect.checking': 'checking',
         'blocks.ankiCards.progress.ankiConnect.notConnected': 'not connected',
+        'blocks.ankiCards.progress.metrics.cardsValue': 'Cards: {{count}}',
+        'blocks.ankiCards.progress.metrics.segmentsValue': 'Segments: {{completed}}/{{total}}',
       };
-      if (dict[key]) return dict[key];
-      if (options?.defaultValue) return options.defaultValue;
-      return key;
+      const template = dict[key] ?? options?.defaultValue ?? key;
+      return template.replace(/\{\{(\w+)\}\}/g, (match, name: string) =>
+        options && options[name] !== undefined ? String(options[name]) : match
+      );
     },
   }),
   // Some modules initialize i18n in test environment and expect this export.

--- a/tests/vitest/chat-v2/plugins/blocks/McpToolBlock.test.tsx
+++ b/tests/vitest/chat-v2/plugins/blocks/McpToolBlock.test.tsx
@@ -14,29 +14,40 @@ import React from 'react';
 import type { Block } from '@/features/chat/core/types';
 
 // Mock react-i18next
+// - 缺失词条时必须尊重 defaultValue（getReadableToolName 用 defaultValue: ''
+//   探测词条是否存在，返回 key 会把 tools.* 泄漏成显示名）
+// - t.i18n 固定英文，避免真实 i18n 单例默认中文时人性化兜底输出中文词根
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string, params?: Record<string, unknown>) => {
-      const translations: Record<string, string> = {
-        'blocks.mcpTool.title': 'Tool Call',
-        'blocks.mcpTool.unknownTool': 'Unknown Tool',
-        'blocks.mcpTool.input': 'Input Parameters',
-        'blocks.mcpTool.output': 'Output Result',
-        'blocks.mcpTool.noOutput': 'No output',
-        'blocks.mcpTool.showFullJson': 'Show full JSON',
-        'blocks.mcpTool.executing': 'Executing...',
-        'blocks.mcpTool.streamingOutput': 'Live Output',
-        'blocks.mcpTool.executionFailed': 'Execution Failed',
-        'blocks.mcpTool.unknownError': 'Unknown error',
-        'blocks.mcpTool.retry': 'Retry',
-        'blocks.mcpTool.status.pending': 'Pending',
-        'blocks.mcpTool.status.running': 'Running',
-        'blocks.mcpTool.status.success': 'Completed',
-        'blocks.mcpTool.status.error': 'Failed',
-      };
-      return translations[key] || key;
-    },
-  }),
+  useTranslation: () => {
+    const translations: Record<string, string> = {
+      'blocks.mcpTool.title': 'Tool Call',
+      'blocks.mcpTool.unknownTool': 'Unknown Tool',
+      'blocks.mcpTool.input': 'Input Parameters',
+      'blocks.mcpTool.output': 'Output Result',
+      'blocks.mcpTool.noOutput': 'No output',
+      'blocks.mcpTool.showFullJson': 'Show full JSON',
+      'blocks.mcpTool.executing': 'Executing...',
+      'blocks.mcpTool.streamingOutput': 'Live Output',
+      'blocks.mcpTool.executionFailed': 'Execution Failed',
+      'blocks.mcpTool.unknownError': 'Unknown error',
+      'blocks.mcpTool.retry': 'Retry',
+      'blocks.mcpTool.status.pending': 'Pending',
+      'blocks.mcpTool.status.running': 'Running',
+      'blocks.mcpTool.status.success': 'Completed',
+      'blocks.mcpTool.status.error': 'Failed',
+      'labels.skill': 'Skill',
+    };
+    const t = (key: string, params?: Record<string, unknown>) => {
+      if (key in translations) return translations[key];
+      if (params && 'defaultValue' in params) return String(params.defaultValue);
+      return key;
+    };
+    (t as unknown as { i18n: { language: string; resolvedLanguage: string } }).i18n = {
+      language: 'en-US',
+      resolvedLanguage: 'en-US',
+    };
+    return { t, i18n: { language: 'en-US' } };
+  },
   // Some modules initialize i18n in test environment and expect this export.
   initReactI18next: { type: '3rdParty', init: () => undefined },
 }));
@@ -187,7 +198,9 @@ describe('McpToolBlock', () => {
       render(<McpToolBlockComponent block={block} />);
 
       expect(screen.getByText('vfs-memory')).toBeInTheDocument();
-      expect(screen.getByText('builtin-memory_delete')).toBeInTheDocument();
+      // 工具徽标现在渲染可读名（来源前缀 + 人性化短名），原始注册名保留在 title 上
+      expect(screen.getByTitle('builtin-memory_delete')).toBeInTheDocument();
+      expect(screen.getByText('Skill · Memory Delete')).toBeInTheDocument();
     });
 
     it('should format output based on type (JSON)', () => {

--- a/tests/vitest/chat-v2/session-browser/sessionExport.test.ts
+++ b/tests/vitest/chat-v2/session-browser/sessionExport.test.ts
@@ -13,18 +13,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('i18next', () => {
+  // 实现不再携带 defaultValue，直接使用 chatV2 命名空间 key；
+  // 这里按 zh-CN/chatV2.json 提供模板，保证插值断言确定性。
+  const templates: Record<string, string> = {
+    'chatV2:browser.exportSession': '导出会话',
+    'chatV2:browser.exportSuccess': '已导出 {{messageCount}} 条消息到 {{path}}',
+    'chatV2:browser.exportFailed': '导出失败：{{error}}',
+  };
   const t = (_key: string, arg?: unknown) => {
     if (typeof arg === 'string') return arg;
     if (arg && typeof arg === 'object') {
       const opts = arg as Record<string, unknown>;
-      let text = String(opts.defaultValue ?? _key);
+      let text = String(opts.defaultValue ?? templates[_key] ?? _key);
       for (const [k, v] of Object.entries(opts)) {
         if (k === 'defaultValue') continue;
         text = text.replace(`{{${k}}}`, String(v));
       }
       return text;
     }
-    return _key;
+    return templates[_key] ?? _key;
   };
   // src/i18n.ts 会对 i18next 实例做 use().use().init() 链式初始化，
   // mock 需保持链式接口可用（errorUtils → src/i18n.ts 传递依赖）

--- a/tests/vitest/chat-v2/skills/chatAnkiAgentLoop.test.ts
+++ b/tests/vitest/chat-v2/skills/chatAnkiAgentLoop.test.ts
@@ -33,8 +33,8 @@ describe('ChatAnki agent acceptance loop', () => {
       .filter((name) => name.startsWith('builtin-chatanki_'));
     const embeddedChatAnkiTools = (chatAnkiSkill.embeddedTools ?? [])
       .filter((tool) => tool.name.startsWith('builtin-chatanki_'));
-    expect(allowedChatAnkiTools).toHaveLength(26);
-    expect(embeddedChatAnkiTools).toHaveLength(26);
+    expect(allowedChatAnkiTools).toHaveLength(28);
+    expect(embeddedChatAnkiTools).toHaveLength(28);
     for (const name of requiredTools) {
       expect(chatAnkiSkill.allowedTools).toContain(name);
       expect(chatAnkiSkill.embeddedTools?.some((tool) => tool.name === name)).toBe(true);

--- a/tests/vitest/chatV2GroupSyncContract.test.ts
+++ b/tests/vitest/chatV2GroupSyncContract.test.ts
@@ -5,13 +5,24 @@ import { describe, expect, it } from 'vitest';
 describe('chat v2 group sync contract', () => {
   it('emits a global group update event after group mutations', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/features/chat/hooks/useGroupManagement.ts'), 'utf-8');
+    const appEvents = readFileSync(resolve(process.cwd(), 'src/events/app.ts'), 'utf-8');
 
-    expect(source).toContain("new CustomEvent('chat-v2:groups-updated')");
+    // 组变更后通过类型化事件中心广播（禁止业务组件手写裸 CustomEvent 字符串）
+    expect(source).toContain('dispatchAppEvent(APP_EVENTS.CHAT_GROUPS_UPDATED)');
+    // 事件名契约保持不变，跨模块监听方依赖该字符串
+    expect(appEvents).toContain("CHAT_GROUPS_UPDATED: 'chat-v2:groups-updated'");
   });
 
   it('refreshes the modern sidebar when group updates are emitted', () => {
-    const source = readFileSync(resolve(process.cwd(), 'src/components/ModernSidebar.tsx'), 'utf-8');
+    const sidebarSource = readFileSync(resolve(process.cwd(), 'src/components/ModernSidebar.tsx'), 'utf-8');
+    const sessionHookSource = readFileSync(
+      resolve(process.cwd(), 'src/features/chat/hooks/useSessionManagement.ts'),
+      'utf-8'
+    );
 
-    expect(source).toContain("type: 'chat-v2:groups-updated'");
+    // ModernSidebar 的会话/分组数据来自 useSidebarSessionData，
+    // 该 hook 订阅 chat-v2:groups-updated 并去抖刷新
+    expect(sidebarSource).toContain('useSidebarSessionData');
+    expect(sessionHookSource).toContain("window.addEventListener('chat-v2:groups-updated', scheduleRefresh)");
   });
 });

--- a/tests/vitest/mindmap/canvasHoverClarity.test.ts
+++ b/tests/vitest/mindmap/canvasHoverClarity.test.ts
@@ -21,9 +21,12 @@ describe('mind map hover clarity contract', () => {
   );
 
   it('does not restyle every edge when the hovered node changes', () => {
+    // 悬停高亮现在只作用于「悬停节点 → 根」的祖先链树边（hoverPathEdgeKeys），
+    // onNodeMouseEnter/Leave 仅维护该路径状态；禁止回到基于 hoveredNodeId
+    // 的全量边压暗（opacity: 0.25）实现。
     expect(canvasSource).not.toContain('hoveredNodeId');
-    expect(canvasSource).not.toContain('onNodeMouseEnter');
-    expect(canvasSource).not.toContain('onNodeMouseLeave');
+    expect(canvasSource).toContain('hoverPathEdgeKeys');
+    expect(canvasSource).toContain('hoverPathEdgeKeys?.has(edgeKey)');
     expect(canvasSource).not.toContain('opacity: 0.25');
   });
 

--- a/tests/vitest/ui-shell/smokeRender.test.tsx
+++ b/tests/vitest/ui-shell/smokeRender.test.tsx
@@ -52,10 +52,11 @@ describe('ui shell smoke render', () => {
       </>
     );
 
-    const minimizeButton = screen.getByLabelText('window_controls.minimize');
+    // 测试环境现在会同步加载 zh-CN common 命名空间，aria-label 解析为本地化文案
+    const minimizeButton = screen.getByLabelText('最小化');
     expect(minimizeButton.closest('[data-shell-window-controls]')).toBeInTheDocument();
 
-    const mobileBackButton = screen.getByLabelText('common:mobile_header.back');
+    const mobileBackButton = screen.getByLabelText('返回');
     expect(mobileBackButton.closest('[data-mobile-shell="header"]')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主干 Vitest 在 #185 解除分片 OOM 后，输入栏/技能/制卡相关测试仍按旧中文文案或旧 schema 失败。本 PR **只改测试**，对齐当前 i18n key、工具 schema 与源码契约，不改聊天/技能产品实现。

### Changes
- `InputBarV2.staleContextRef`：推理标签断言改 i18n key
- `phase5TodoAutomationTools` / `spssProjectSkills`：对齐当前 automation / SPSS loader schema
- Anki / MCP / session export / group sync / markdown table / PDF file definition / ActivityTimeline / multimodal RAG / mindmap hover / cardResize / smokeRender：按当前实现更新断言

### How to test
- `npx vitest run src/features/chat/components/input-bar/__tests__/InputBarV2.staleContextRef.test.tsx src/features/chat/skills/__tests__/phase5TodoAutomationTools.test.ts src/features/chat/skills/__tests__/spssProjectSkills.test.ts src/services/__tests__/multimodalRagService.test.ts src/styles/__tests__/transitionsDev.cardResize.test.ts tests/vitest/anki/cardforge/CardAgent.test.ts tests/vitest/chat-v2/components/ActivityTimeline.loadSkillsSummary.test.tsx tests/vitest/chat-v2/context/context.test.ts tests/vitest/chat-v2/context/fileDefinitionPdf.test.ts tests/vitest/chat-v2/markdownTableLayoutContract.test.ts tests/vitest/chat-v2/plugins/blocks/AnkiCardsBlock.test.tsx tests/vitest/chat-v2/plugins/blocks/McpToolBlock.test.tsx tests/vitest/chat-v2/session-browser/sessionExport.test.ts tests/vitest/chat-v2/skills/chatAnkiAgentLoop.test.ts tests/vitest/chatV2GroupSyncContract.test.ts tests/vitest/mindmap/canvasHoverClarity.test.ts tests/vitest/ui-shell/smokeRender.test.tsx`

### Screenshots / Logs

主干其余 Vitest 漂移（Notes / Dock / MessageItem 产品正主）不在本刀范围。

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

