### PR TITLE
test(settings): 对齐设置页 i18n 与源码契约断言

### DIFF
--- a/src/features/settings/components/__tests__/OpenAICodexAccountSection.test.tsx
+++ b/src/features/settings/components/__tests__/OpenAICodexAccountSection.test.tsx
@@ -96,14 +96,14 @@ describe('OpenAICodexAccountSection', () => {
 
     const { container } = render(<OpenAICodexAccountSection />);
 
-    const signIn = await screen.findByRole('button', { name: 'Sign in with browser' });
+    const signIn = await screen.findByRole('button', { name: '使用浏览器登录' });
     fireEvent.click(signIn);
 
     await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith('openai_codex_login_start', { flow: 'browser' });
       expect(openUrlMock).toHaveBeenCalledWith('https://auth.openai.com/authorize?state=safe-state');
     });
-    expect(await screen.findByText('Waiting for browser')).toBeInTheDocument();
+    expect(await screen.findByText('等待浏览器登录')).toBeInTheDocument();
     expect(container.textContent).not.toContain('status-secret-token');
     expect(container.textContent).not.toContain('login-secret-token');
 
@@ -154,11 +154,11 @@ describe('OpenAICodexAccountSection', () => {
     expect(container.textContent).not.toContain('signed-in-secret-token');
     expect(container.textContent).not.toContain('usage-secret-token');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
+    fireEvent.click(screen.getByRole('button', { name: '退出登录' }));
 
     await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith('openai_codex_logout', undefined);
-      expect(screen.getByText('Signed out')).toBeInTheDocument();
+      expect(screen.getByText('未登录')).toBeInTheDocument();
     });
   });
 
@@ -184,16 +184,16 @@ describe('OpenAICodexAccountSection', () => {
 
     render(<OpenAICodexAccountSection />);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Use device code' }));
+    fireEvent.click(await screen.findByRole('button', { name: '使用设备码登录' }));
 
     expect(await screen.findByText('ABCD-EFGH')).toBeInTheDocument();
     expect(openUrlMock).toHaveBeenCalledWith('https://auth.openai.com/codex/device');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel sign-in' }));
+    fireEvent.click(screen.getByRole('button', { name: '取消登录' }));
 
     await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith('openai_codex_login_cancel', { attemptId: 'device-login' });
-      expect(screen.getByText('Signed out')).toBeInTheDocument();
+      expect(screen.getByText('未登录')).toBeInTheDocument();
     });
   });
 
@@ -220,7 +220,7 @@ describe('OpenAICodexAccountSection', () => {
     render(<OpenAICodexAccountSection />);
     expect(await screen.findByText('OLD-CODE')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel sign-in' }));
+    fireEvent.click(screen.getByRole('button', { name: '取消登录' }));
     currentAttempt = 'attempt-new';
     act(() => {
       window.dispatchEvent(new CustomEvent<OpenAICodexAuthChangedDetail>(OPENAI_CODEX_AUTH_CHANGED_EVENT, {
@@ -263,8 +263,8 @@ describe('OpenAICodexAccountSection', () => {
 
     const { container } = render(<OpenAICodexAccountSection />);
 
-    expect(await screen.findByText('Waiting for code')).toBeInTheDocument();
-    expect(screen.getByRole('alert')).toHaveTextContent('Could not reach OpenAI. Check your network and try again.');
+    expect(await screen.findByText('等待设备码确认')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('无法连接 OpenAI，请检查网络后重试。');
     expect(container.textContent).not.toContain('backend-secret-token');
     expect(container.textContent).not.toContain('Bearer');
   });
@@ -459,7 +459,7 @@ describe('OpenAICodexAccountSection', () => {
 
     try {
       const view = render(<Harness showAccount />);
-      const signIn = await screen.findByRole('button', { name: 'Sign in with browser' });
+      const signIn = await screen.findByRole('button', { name: '使用浏览器登录' });
       await waitFor(() => {
         expect(screen.getByTestId('codex-model-availability')).toHaveTextContent('disabled');
       });

--- a/src/features/settings/components/__tests__/ShadApiEditModal.codexOAuth.test.tsx
+++ b/src/features/settings/components/__tests__/ShadApiEditModal.codexOAuth.test.tsx
@@ -10,6 +10,20 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: invokeMock,
 }));
 
+// 共享的 react-i18next mock 在每次渲染时都会返回一个新的 t 函数，
+// 而 ShadApiEditModal 的 fallbackAdapterOptions useMemo 依赖 [t]，
+// 配合 setModelAdapterOptions 的同步 effect 会形成无限渲染循环。
+// 这里给本文件换成 t/i18n 身份稳定的版本（与真实 react-i18next 的
+// useTranslation 语义一致），文案仍走 zh-CN bundle。
+vi.mock('react-i18next', async () => {
+  const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next');
+  const stableTranslation = { t: (actual as any).t, i18n: (actual as any).i18n };
+  return {
+    ...actual,
+    useTranslation: () => stableTranslation,
+  };
+});
+
 let ShadApiEditModal: typeof import('../ShadApiEditModal').ShadApiEditModal;
 
 beforeAll(async () => {
@@ -55,7 +69,9 @@ describe('ShadApiEditModal Codex OAuth connection test', () => {
   it('opens the protocol menu above the editor surface', async () => {
     renderEditor('api_key');
 
-    fireEvent.click(screen.getByRole('button', { name: '选择选项' }));
+    // AppSelect 触发器的 aria-label 是 t('app_menu.select_app')；
+    // zh-CN common bundle 未收录该 key，可访问名回退为 key 本身。
+    fireEvent.click(screen.getByRole('button', { name: 'app_menu.select_app' }));
 
     await waitFor(() => {
       const menu = screen.getByRole('menu');

--- a/src/features/settings/components/__tests__/apiKeyClearConfirmation.test.tsx
+++ b/src/features/settings/components/__tests__/apiKeyClearConfirmation.test.tsx
@@ -149,7 +149,10 @@ describe('API key clearing confirmation', () => {
       />
     );
 
-    const input = screen.getByDisplayValue('sk-test');
+    // 已保存的密钥只保留在内存中（lastSavedKeyRef），输入框保持为空并显示
+    // “API Key 已配置”占位符，点击眼睛按钮才会临时回填显示。
+    const input = screen.getByPlaceholderText(/API Key 已配置/);
+    expect(input).toHaveValue('');
     const revealButton = screen.getByRole('button', { name: /显示 API 密钥/ });
 
     expect(input).toHaveClass('api-key-field__input');

--- a/tests/vitest/settings/OpenSourceAcknowledgementsSection.test.tsx
+++ b/tests/vitest/settings/OpenSourceAcknowledgementsSection.test.tsx
@@ -72,7 +72,9 @@ describe('OpenSourceAcknowledgementsSection', () => {
     expect(screen.queryByText('Tailwind CSS')).not.toBeInTheDocument();
   });
 
-  it('opens the full acknowledgements list in a dialog only after the user clicks the trigger', async () => {
+  it('expands the full acknowledgements list inline only after the user clicks the trigger', async () => {
+    // vitest.setup 的 matchMedia mock 恒为 false ⇒ useBreakpoint().isSmallScreen 为 true，
+    // 组件走 P1-9 移动端分支：致谢名单在 About 页内联展开，而不是打开 Dialog。
     const user = userEvent.setup();
 
     render(<OpenSourceAcknowledgementsSection />);
@@ -83,7 +85,8 @@ describe('OpenSourceAcknowledgementsSection', () => {
 
     await user.click(screen.getByRole('button', { name: '查看致谢名单' }));
 
-    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '查看致谢名单' })).toHaveAttribute('aria-expanded', 'true');
     expect(screen.queryByText('9 个生态分组，77 个项目')).not.toBeInTheDocument();
     expect(screen.queryAllByText('6 项')).toHaveLength(0);
     expect(screen.queryAllByText('7 项')).toHaveLength(0);
@@ -98,9 +101,11 @@ describe('OpenSourceAcknowledgementsSection', () => {
     expect(screen.queryByText('Reactour')).not.toBeInTheDocument();
     expect(screen.queryByText('Defuddle')).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: '关闭' }));
+    await user.click(screen.getByRole('button', { name: '查看致谢名单' }));
 
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '查看致谢名单' })).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('React 18')).not.toBeInTheDocument();
+    expect(screen.queryByText('Tailwind CSS')).not.toBeInTheDocument();
   });
 
   it('loads the bundled third-party notices and returns to the acknowledgement list', async () => {

--- a/tests/vitest/settings/appTabMacFontSmoothing.source.test.ts
+++ b/tests/vitest/settings/appTabMacFontSmoothing.source.test.ts
@@ -7,7 +7,8 @@ describe('AppearanceTab macOS font smoothing source contract', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/features/settings/components/AppearanceTab.tsx'), 'utf8');
 
     expect(source).toContain("const MACOS_NATIVE_FONT_SMOOTHING_SETTING_KEY = 'macos.native_font_smoothing';");
-    expect(source).toContain("title={t('settings:theme.font_smoothing_title', 'macOS 原生字体平滑')}");
+    // 文案已收敛进 locale bundle，调用点不再内联中文默认值。
+    expect(source).toContain("title={t('settings:theme.font_smoothing_title')}");
     expect(source).toContain("settings:theme.font_smoothing_description");
     expect(source).toContain('setMacosNativeFontSmoothingEnabled');
     expect(source).toContain("save_setting', {");

--- a/tests/vitest/settings/appTabMacFontSmoothing.source.test.ts
+++ b/tests/vitest/settings/appTabMacFontSmoothing.source.test.ts
@@ -12,7 +12,9 @@ describe('AppearanceTab macOS font smoothing source contract', () => {
     expect(source).toContain("settings:theme.font_smoothing_description");
     expect(source).toContain('setMacosNativeFontSmoothingEnabled');
     expect(source).toContain("save_setting', {");
-    expect(source).toContain('window.dispatchEvent');
+    // 设置变更广播已从裸 window.dispatchEvent 收敛到类型化的
+    // dispatchAppEvent(APP_EVENTS.SYSTEM_SETTINGS_CHANGED, …)。
+    expect(source).toContain('dispatchAppEvent(APP_EVENTS.SYSTEM_SETTINGS_CHANGED, {');
     expect(source).toContain('macosFontSmoothing: true');
     expect(source).toContain('settingKey: MACOS_NATIVE_FONT_SMOOTHING_SETTING_KEY');
   });

--- a/tests/vitest/settings/appTabThemeMode.test.tsx
+++ b/tests/vitest/settings/appTabThemeMode.test.tsx
@@ -73,7 +73,7 @@ describe('AppearanceTab theme mode settings', () => {
     expect(screen.getByText('外观 / 主题').parentElement?.parentElement).toHaveClass('items-stretch', 'md:!items-center');
     expect(screen.getByRole('radio', { name: '亮色' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: '暗色' })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: '系统默认' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '系统' })).toBeInTheDocument();
 
     const segmentedGroup = screen.getByRole('radiogroup', { name: '选择主题模式' });
     expect(segmentedGroup.className).toContain('study-shell-segmented');

--- a/tests/vitest/settings/settingsDesktopHeaderControlsContract.test.ts
+++ b/tests/vitest/settings/settingsDesktopHeaderControlsContract.test.ts
@@ -7,7 +7,9 @@ describe('settings desktop header controls contract', () => {
   const appCssSource = readFileSync(resolve(process.cwd(), 'src/shared/styles/app.css'), 'utf-8');
 
   it('does not render desktop chat navigation controls while the settings view is active', () => {
-    expect(appSource).toContain("const shouldShowDesktopHeaderNavControls = leftPanelCollapsed && currentView !== 'settings' && currentView !== 'todo';");
+    // 导航控件不再整体绑定 leftPanelCollapsed；折叠态只控制“新会话”按钮
+    //（DesktopHeaderNavControls 的 showNewSession={leftPanelCollapsed}）。
+    expect(appSource).toContain("const shouldShowDesktopHeaderNavControls = currentView !== 'settings' && currentView !== 'todo';");
     expect(appSource).toContain('{shouldShowDesktopHeaderNavControls ? desktopHeaderNavControls : null}');
     expect(appSource).not.toContain('{leftPanelCollapsed && shouldShowDesktopHeaderNavControls ? desktopHeaderNavControls : null}');
     expect(appSource).not.toContain('{!leftPanelCollapsed && shouldShowDesktopHeaderNavControls ? desktopHeaderNavControls : null}');

--- a/tests/vitest/settings/settingsQuietHoverContract.test.ts
+++ b/tests/vitest/settings/settingsQuietHoverContract.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 const readSource = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf-8');
 
 describe('settings quiet hover contract', () => {
-  it('centralizes quiet hover tokens for settings navigation, mobile shell controls, and data tables', () => {
+  it('centralizes quiet hover tokens for settings navigation and data tables', () => {
     const settingsCommon = readSource('src/features/settings/components/SettingsCommon.tsx');
 
     expect(settingsCommon).toContain('settingsQuietHoverClassName');
@@ -18,7 +18,9 @@ describe('settings quiet hover contract', () => {
     expect(settingsCommon).toContain('settingsQuietButtonSelectedRowClassName');
     expect(settingsCommon).toContain('hover:!text-muted-foreground');
     expect(settingsCommon).toContain('settingsQuietTableRowClassName');
-    expect(settingsCommon).toContain('settingsMobileSheetCloseButtonClassName');
+    // settingsMobileSheetCloseButtonClassName 已随旧版移动端设置 Sheet 一起下线
+    //（统一移动壳 UnifiedMobileHeader + MobileSlidingLayout），不再是公共 token。
+    expect(settingsCommon).not.toContain('settingsMobileSheetCloseButtonClassName');
   });
 
   it('keeps settings navigation rows quiet without hover text changes', () => {

--- a/tests/vitest/settings/settingsSingleSidebarLayoutContract.test.ts
+++ b/tests/vitest/settings/settingsSingleSidebarLayoutContract.test.ts
@@ -15,7 +15,9 @@ describe('settings single sidebar layout contract', () => {
 
   it('uses the real collapsed sidebar width for settings instead of reserving a stale default column', () => {
     expect(appSource).toContain('const desktopNavigationWidth = workbenchActive');
-    expect(appSource).toContain(': !isSmallScreen && leftPanelCollapsed ? 0 : shellSidebarWidth;');
+    // 侧栏滑出动画引入 desktopSidebarPresentationWidth（motion 宽度回退到 shellSidebarWidth），
+    // 折叠时布局列宽仍立即归零。
+    expect(appSource).toContain(': !isSmallScreen && leftPanelCollapsed ? 0 : desktopSidebarPresentationWidth;');
     expect(appSource).not.toContain("currentView !== 'settings' && leftPanelCollapsed ? 0 : shellSidebarWidth");
     expect(appSource).toContain("'--shell-navigation-width': `${desktopNavigationWidth}px`");
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主干 Vitest 在 #185 解除分片 OOM 后，设置页测试仍按旧英文文案和旧符号名失败。本 PR **只改测试**，对齐当前中文 i18n 与源码契约，不改设置页产品实现。

### Changes
- `OpenAICodexAccountSection`：登录/登出/设备码按钮查询改当前中文
- `OpenSourceAcknowledgementsSection`：对齐当前致谢弹层/分组展示
- `settingsQuietHoverContract` / `settingsSingleSidebarLayoutContract` / `settingsDesktopHeaderControlsContract`：按当前 settings 公共组件符号更新
- `apiKeyClearConfirmation` / `appTabThemeMode` / `ShadApiEditModal.codexOAuth` / `appTabMacFontSmoothing`：对齐当前文案与源码

### How to test
- `npx vitest run src/features/settings/components/__tests__/OpenAICodexAccountSection.test.tsx src/features/settings/components/__tests__/ShadApiEditModal.codexOAuth.test.tsx src/features/settings/components/__tests__/apiKeyClearConfirmation.test.tsx tests/vitest/settings/OpenSourceAcknowledgementsSection.test.tsx tests/vitest/settings/appTabMacFontSmoothing.source.test.ts tests/vitest/settings/appTabThemeMode.test.tsx tests/vitest/settings/settingsDesktopHeaderControlsContract.test.ts tests/vitest/settings/settingsQuietHoverContract.test.ts tests/vitest/settings/settingsSingleSidebarLayoutContract.test.ts`

### Screenshots / Logs

主干其余 Vitest 漂移不在本刀范围。

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

