### PR TITLE
test(chat): 对齐 MessageItem 失败动作与流式可见性契约

### DIFF
--- a/src/features/chat/components/__tests__/MessageItem.failureActions.source.test.ts
+++ b/src/features/chat/components/__tests__/MessageItem.failureActions.source.test.ts
@@ -14,7 +14,7 @@ describe('MessageItem failure actions source', () => {
   });
 
   it('shows a dedicated zero-output failure bar with retry and error details affordances', () => {
-    expect(messageItemSource).toContain('showActions && !isInlineEditing && !isWaitingForContent && hasZeroOutputFailure');
+    expect(messageItemSource).toContain('showActions && !isReadOnlySession && !isInlineEditing && !isWaitingForContent && hasZeroOutputFailure');
     expect(messageItemSource).toContain("text-muted-foreground hover:bg-muted/50 hover:text-foreground");
     expect(messageItemSource).toContain('messageItem.failure.retry');
     expect(messageItemSource).not.toContain('messageItem.failure.viewErrorDetails');
@@ -28,7 +28,7 @@ describe('MessageItem failure actions source', () => {
     expect(messageItemSource).toContain('const shouldShowReconnectInline = !isUser && Boolean(streamReconnectState);');
     expect(messageItemSource).toContain("t('messageItem.reconnect.inline'");
     expect(messageItemSource).toContain('if (shouldShowReconnectInline && streamReconnectState)');
-    expect(messageItemSource).toContain('TextShimmer className="text-md leading-relaxed tracking-wide text-foreground"');
+    expect(messageItemSource).toContain('TextShimmer className="chat-message-status__text"');
     expect(messageItemSource).toContain('{reconnectInlineText}');
     expect(messageItemSource).not.toContain('reconnect...(');
     expect(messageItemSource).not.toContain('PulseDot className="w-1.5 h-1.5 text-foreground/60"');

--- a/src/features/chat/components/__tests__/MessageItem.streamingContentVisibility.test.tsx
+++ b/src/features/chat/components/__tests__/MessageItem.streamingContentVisibility.test.tsx
@@ -17,6 +17,7 @@ vi.mock('react-i18next', async () => {
     },
     useTranslation: () => ({
       t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+      i18n: { resolvedLanguage: 'en', language: 'en' },
     }),
   };
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主干 Vitest 在 #185 解除分片 OOM 后，MessageItem 源码契约与流式可见性测试仍按旧守卫/旧 mock 失败。本 PR **只改测试**，不改 MessageItem 产品（#163 占划词接线）。

### Changes
- `MessageItem.failureActions.source.test.ts`：失败条守卫对齐 `isReadOnlySession` / `hasZeroOutputFailure`；重连 shimmer 类名对齐 `chat-message-status__text`
- `MessageItem.streamingContentVisibility.test.tsx`：i18n mock 补 `resolvedLanguage`，避免挂载即崩

### How to test
- `npx vitest run src/features/chat/components/__tests__/MessageItem.failureActions.source.test.ts src/features/chat/components/__tests__/MessageItem.streamingContentVisibility.test.tsx`

### Screenshots / Logs

本地 2 files / 5 tests passed。

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

