### PR TITLE
test(workbench): 对齐 Dock 与桌面快照恢复契约

### DIFF
--- a/src/features/workbench/components/__tests__/DockContextMenu.test.tsx
+++ b/src/features/workbench/components/__tests__/DockContextMenu.test.tsx
@@ -107,15 +107,21 @@ describe('DockContextMenu', () => {
     expect(itemB).not.toHaveClass('app-menu-item-checked');
   });
 
-  it('键盘 ContextMenu 打开并聚焦首个可用项，方向键跳过禁用项', async () => {
+  it('键盘 ContextMenu 打开聚焦菜单容器，方向键从选中项进入并跳过禁用项', async () => {
     openWin('files', 'f', '资源库');
     render(<Dock />);
     const trigger = dockButton('files');
     trigger.focus();
     fireEvent.keyDown(trigger, { key: 'ContextMenu' });
     const menu = await screen.findByRole('menu');
+    // 当前契约：打开后焦点落在菜单容器（tabIndex=-1）上，不预聚焦任何菜单项，
+    // 避免鼠标打开时的「假悬浮」高亮；方向键从容器进入导航
+    await waitFor(() => expect(menu).toHaveFocus());
+
+    // 容器上按 ArrowDown：从当前选中项（前台窗口「资源库」带 checked）开始
+    fireEvent.keyDown(menu, { key: 'ArrowDown' });
     const firstEnabled = within(menu).getByText('资源库').closest('button')!;
-    await waitFor(() => expect(firstEnabled).toHaveFocus());
+    expect(firstEnabled).toHaveFocus();
 
     fireEvent.keyDown(firstEnabled, { key: 'ArrowDown' });
     expect(within(menu).getByText('固定到 Dock').closest('button')).toHaveFocus();

--- a/src/features/workbench/components/__tests__/DockWindowList.test.tsx
+++ b/src/features/workbench/components/__tests__/DockWindowList.test.tsx
@@ -245,8 +245,13 @@ describe('DockWindowList', () => {
       await Promise.resolve();
     });
     ownerRef.current.focus();
-    const rafSpy = vi.spyOn(window, 'requestAnimationFrame');
-    rafSpy.mockClear();
+    // CustomScrollArea（OverlayScrollbars）会在内容更新时用 rAF 刷新滚动几何，
+    // 不能全局断言 rAF 未被调用；改为捕获全部帧回调并冲刷执行，
+    // 验证标题更新触发的任何异步回调都不会把焦点抢回列表。
+    const scheduled: FrameRequestCallback[] = [];
+    const rafSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb) => scheduled.push(cb));
 
     rerender(
       <DockWindowList
@@ -259,7 +264,13 @@ describe('DockWindowList', () => {
       />,
     );
 
-    expect(rafSpy).not.toHaveBeenCalled();
+    act(() => {
+      // 冲刷帧回调（回调可能续排新帧，限 10 轮防死循环）
+      for (let round = 0; round < 10 && scheduled.length > 0; round += 1) {
+        const batch = scheduled.splice(0, scheduled.length);
+        for (const cb of batch) cb(performance.now());
+      }
+    });
     expect(document.activeElement).toBe(ownerRef.current);
     rafSpy.mockRestore();
   });

--- a/tests/vitest/workbench/p11-workbench-desktop.test.tsx
+++ b/tests/vitest/workbench/p11-workbench-desktop.test.tsx
@@ -181,6 +181,9 @@ describe('P11 WorkbenchDesktop 总装', () => {
   });
 
   it('快照恢复：挂载前写入快照 → hydrate 后窗口恢复', async () => {
+    // 当前实现默认不恢复上次窗口布局（冷启动更快），需显式开启恢复设置
+    // 才会走 loadSnapshot → hydrate（key 契约见 WorkbenchSettingsSection）
+    localStorage.setItem('desktop.workbenchRestoreSession', 'true');
     const snapshot = {
       version: 1,
       windows: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主干 Vitest 在 #185 解除分片 OOM 后，Dock 窗口列表、右键菜单与桌面快照恢复测试仍按旧焦点/旧 hydrate 行为失败。本 PR **只改测试**，不改 Dock / WorkbenchDesktop 产品（#161 占 workbench 壳）。

### Changes
- `DockWindowList.test.tsx`：冲刷 OverlayScrollbars 的 rAF，断言标题更新后焦点仍在 owner
- `DockContextMenu.test.tsx`：对齐「先聚焦菜单容器，方向键再进项」
- `p11-workbench-desktop.test.tsx`：快照恢复用例先打开 `desktop.workbenchRestoreSession`

### How to test
- `npx vitest run src/features/workbench/components/__tests__/DockWindowList.test.tsx src/features/workbench/components/__tests__/DockContextMenu.test.tsx tests/vitest/workbench/p11-workbench-desktop.test.tsx`

### Screenshots / Logs

本地 3 files / 25 tests passed。

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

