### PR TITLE
test(notes): 对齐笔记工作区与编辑器契约断言

### DIFF
--- a/src/features/workbench/apps/notes/__tests__/NotesSearchOverlay.test.tsx
+++ b/src/features/workbench/apps/notes/__tests__/NotesSearchOverlay.test.tsx
@@ -113,7 +113,9 @@ describe('NotesSearchOverlay', () => {
       target: { value: 'chem' },
     });
     expect(screen.queryByText('Recently opened')).toBeNull();
-    expect(screen.getByRole('option', { name: /Chemistry/ })).toBeInTheDocument();
+    // 命中片段会被 <mark> 高亮拆分（"Chem" + "istry"），可访问名称计算
+    // 在元素边界插入空格，因此按 "Chem istry" 匹配当前实现。
+    expect(screen.getByRole('option', { name: /Chem ?istry/ })).toBeInTheDocument();
   });
 
   it('searches full text through DSTU, renders a safe snippet, and filters unsupported results', async () => {

--- a/src/features/workbench/apps/notes/__tests__/NotesWorkspaceApp.test.tsx
+++ b/src/features/workbench/apps/notes/__tests__/NotesWorkspaceApp.test.tsx
@@ -176,9 +176,18 @@ describe('NotesWorkspaceApp', () => {
     getContent.mockReset();
     getContent.mockResolvedValue({ ok: true, value: '' });
     watchState.callback = null;
+    // @tanstack/virtual-core 在清理时调用 observer.unobserve，stub 必须完整
     vi.stubGlobal('ResizeObserver', class {
       observe() {}
+      unobserve() {}
       disconnect() {}
+    });
+    // jsdom 未实现 IntersectionObserver，提供含 observe/unobserve/disconnect 的局部 shim
+    vi.stubGlobal('IntersectionObserver', class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() { return []; }
     });
     const titlebarSlot = document.createElement('div');
     titlebarSlot.dataset.wbTitlebarSlot = '';
@@ -214,7 +223,10 @@ describe('NotesWorkspaceApp', () => {
     fireEvent.click(screen.getByRole('button', { name: /显示全部文件|Show all open files/ }));
     const menu = screen.getByRole('menu');
 
-    expect(menu.parentElement).toBe(document.body);
+    // role=menu 位于滚动容器的视口上；整个溢出菜单容器 portal 到 body
+    const portalHost = menu.closest('.notes-tabs-overflow-menu');
+    expect(portalHost).not.toBeNull();
+    expect(portalHost?.parentElement).toBe(document.body);
     expect(menu.closest('[data-wb-titlebar-slot]')).toBeNull();
   });
 
@@ -363,7 +375,8 @@ describe('NotesWorkspaceApp', () => {
     fireEvent.keyDown(firstTab, { key: 'F10', shiftKey: true });
     const menu = await screen.findByRole('menu');
     expect(firstTab).toHaveAttribute('aria-expanded', 'true');
-    await waitFor(() => expect(within(menu).getByRole('menuitemcheckbox')).toHaveFocus());
+    // 菜单现在有多个 checkbox 项（固定 / 右侧分屏），键盘展开聚焦第一项「固定」
+    await waitFor(() => expect(within(menu).getByRole('menuitemcheckbox', { name: /固定|Pin/ })).toHaveFocus());
 
     fireEvent.keyDown(window, { key: 'Escape' });
     await waitFor(() => {
@@ -669,6 +682,7 @@ describe('NotesWorkspaceApp', () => {
     vi.stubGlobal('ResizeObserver', class {
       constructor(callback: (entries: ResizeObserverEntry[]) => void) { resizeCallbacks.push(callback); }
       observe() {}
+      unobserve() {}
       disconnect() {}
     });
     render(<NotesWorkspaceApp {...props()} />);
@@ -719,9 +733,14 @@ describe('NotesWorkspaceApp', () => {
       sortOrder: 0, createdAt: 1, updatedAt: 1,
     };
     vi.mocked(folderApi.listFolders).mockResolvedValue({ ok: true, value: [folder] });
+    // getFolderTree 的 items 是 VfsFolderItem（itemType/itemId），不是 DstuNode
     vi.mocked(folderApi.getFolderTree).mockResolvedValue({
       ok: true,
-      value: [{ folder, items: [nodes[0]], children: [] }],
+      value: [{
+        folder,
+        items: [{ id: 'fi_1', folderId: 'fld_course', itemType: 'note', itemId: 'note_1', sortOrder: 0, createdAt: 1 }],
+        children: [],
+      }],
     });
     const { createEmpty } = await import('@/dstu');
     vi.mocked(createEmpty).mockResolvedValueOnce({ ok: true, value: nodes[0] } as never);
@@ -796,7 +815,8 @@ describe('NotesWorkspaceApp', () => {
     fireEvent.click(await within(dialog).findByRole('option', { name: /匹配笔记/ }));
 
     await screen.findByTestId('note-editor-note_1');
-    expect(consumeNotesFindQuery('note_1')).toBe('内容');
+    // publish 发生在 openResource resolve 之后的微任务里，可能晚于编辑器首帧渲染
+    await waitFor(() => expect(consumeNotesFindQuery('note_1')).toBe('内容'));
   });
 
   it('toggles the backlinks panel from a workspace command', async () => {
@@ -948,13 +968,14 @@ describe('NotesWorkspaceApp', () => {
     });
   });
 
-  it('keeps the compact explorer inside the shared aria-hidden drawer until reopened', async () => {
+  it('keeps the shared drawer aria-hidden in compact mode and opens the inline files subscreen instead', async () => {
     const resizeCallbacks: Array<(entries: ResizeObserverEntry[]) => void> = [];
     vi.stubGlobal('ResizeObserver', class {
       constructor(callback: (entries: ResizeObserverEntry[]) => void) {
         resizeCallbacks.push(callback);
       }
       observe() {}
+      unobserve() {}
       disconnect() {}
     });
     render(<NotesWorkspaceApp {...props()} />);
@@ -968,6 +989,9 @@ describe('NotesWorkspaceApp', () => {
     const drawer = document.querySelector<HTMLElement>('[data-wb-sys-drawer]')!;
     await waitFor(() => expect(drawer).toHaveAttribute('aria-hidden', 'true'));
     fireEvent.click(screen.getByRole('button', { name: /显示导航|Show navigation/ }));
-    await waitFor(() => expect(drawer).toHaveAttribute('aria-hidden', 'false'));
+    // 窄窗契约已改为全屏内联「文件」子屏（无遮罩抽屉）；共享抽屉保持关闭
+    expect(await screen.findByRole('button', { name: /关闭文件面板|Close files/ })).toBeInTheDocument();
+    expect(document.querySelector('[data-notes-files-subscreen]')).not.toBeNull();
+    expect(drawer).toHaveAttribute('aria-hidden', 'true');
   });
 });

--- a/tests/vitest/notes/NotesCrepeEditor.saveQueue.test.tsx
+++ b/tests/vitest/notes/NotesCrepeEditor.saveQueue.test.tsx
@@ -9,6 +9,19 @@ let latestOnChange: ((markdown: string) => void) | null = null;
 let latestOnRetrySave: (() => Promise<void>) | undefined;
 let currentMarkdown = '';
 
+// jsdom 未实现 IntersectionObserver；NotesCrepeEditor 挂载时会为壳层可见性
+// 监听构造实例（observe/disconnect），这里提供无操作的局部 shim。
+class IntersectionObserverStub implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = '';
+  readonly thresholds: readonly number[] = [];
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] { return []; }
+}
+vi.stubGlobal('IntersectionObserver', IntersectionObserverStub);
+
 vi.mock('@/features/notes/NotesContext', () => ({
   useNotesOptional: () => undefined,
 }));

--- a/tests/vitest/notes/NotesCrepeEditor.windowing.test.tsx
+++ b/tests/vitest/notes/NotesCrepeEditor.windowing.test.tsx
@@ -22,6 +22,19 @@ let currentMarkdown = 'current markdown';
 let latestOnChange: ((markdown: string) => void) | null = null;
 let crepeMountCount = 0;
 
+// jsdom 未实现 IntersectionObserver；NotesCrepeEditor 挂载时会为壳层可见性
+// 监听构造实例（observe/disconnect），这里提供无操作的局部 shim。
+class IntersectionObserverStub implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = '';
+  readonly thresholds: readonly number[] = [];
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] { return []; }
+}
+vi.stubGlobal('IntersectionObserver', IntersectionObserverStub);
+
 const setMarkdown = vi.fn((markdown: string) => {
   currentMarkdown = markdown;
   latestOnChange?.(markdown);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主干 Vitest 在 #185 解除分片 OOM 后，笔记工作区大量失败来自不完整的 IntersectionObserver，以及空搜索/portal/建笔记 spy 漂移。本 PR **只改测试**，不改 NotesWorkspaceApp / NotesCrepeEditor 产品（#167 占）。也不改 `vitest.setup.ts`（#189 占全局 shim）。

### Changes
- `NotesWorkspaceApp.test.tsx`：局部补完整 IO mock（含 unobserve）；对齐 portal / 空搜索 / create note 断言
- `NotesSearchOverlay.test.tsx`：对齐当前 option 查询
- `NotesCrepeEditor.saveQueue.test.tsx` / `NotesCrepeEditor.windowing.test.tsx`：测试内补 IntersectionObserver

### How to test
- `npx vitest run src/features/workbench/apps/notes/__tests__/NotesWorkspaceApp.test.tsx src/features/workbench/apps/notes/__tests__/NotesSearchOverlay.test.tsx tests/vitest/notes/NotesCrepeEditor.saveQueue.test.tsx tests/vitest/notes/NotesCrepeEditor.windowing.test.tsx`

### Screenshots / Logs

主干其余漂移不在本刀范围。

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

