### PR TITLE
feat(llm): 内置官方 Claude Haiku 4.5 / Sonnet 5 / Opus 5 / Fable 5

### DIFF
--- a/src-tauri/src/llm_manager/builtin_vendors.rs
+++ b/src-tauri/src/llm_manager/builtin_vendors.rs
@@ -1689,9 +1689,7 @@ mod tests {
         // 同理 mythos-5 仅存在于适配层代际判定，不应作为内置模型下发
         assert!(!BUILTIN_MODELS.iter().any(|m| m.model.contains("mythos")));
         // Haiku 线内置的就是 4.5
-        assert!(BUILTIN_MODELS
-            .iter()
-            .any(|m| m.model == "claude-haiku-4-5"));
+        assert!(BUILTIN_MODELS.iter().any(|m| m.model == "claude-haiku-4-5"));
     }
 
     #[test]

--- a/src-tauri/src/llm_manager/builtin_vendors.rs
+++ b/src-tauri/src/llm_manager/builtin_vendors.rs
@@ -192,6 +192,17 @@ pub const BUILTIN_VENDORS: &[BuiltinVendor] = &[
         max_tokens_limit: None,
         website_url: "https://chatgpt.com/codex",
     },
+    // Anthropic (Claude)
+    BuiltinVendor {
+        id: "builtin-anthropic",
+        name: "Anthropic",
+        provider_type: "anthropic",
+        auth_mode: None,
+        base_url: "https://api.anthropic.com/v1",
+        notes: "Anthropic 官方 Claude API（Messages 协议）。可用模型: claude-opus-5(旗舰), claude-sonnet-5(均衡), claude-fable-5(思考 always-on), claude-haiku-4-5(轻量, 官方最新 Haiku 仍为 4.5)。注意: 5 系/4.6+ 新代际思考仅接受 thinking:{type:\"adaptive\"}+output_config.effort，非默认采样参数会 400；Haiku 4.5 走 manual extended thinking(budget_tokens)。",
+        max_tokens_limit: None,
+        website_url: "https://platform.claude.com",
+    },
     // NVIDIA NIM / API Catalog
     BuiltinVendor {
         id: "builtin-nvidia",
@@ -909,6 +920,54 @@ pub const BUILTIN_MODELS: &[BuiltinModel] = &[
         max_output_tokens: 128000,
         temperature: 1.0,
     },
+    // ===== Anthropic 模型 =====
+    // 2026-08 官方在售 Claude 系列（对照 anthropic 适配器与 model-capability-registry 已核验条目）。
+    // 注意：官方最新 Haiku 仍为 4.5，不存在 claude-haiku-5。
+    BuiltinModel {
+        id: "builtin-claude-opus-5",
+        vendor_id: "builtin-anthropic",
+        label: "Claude Opus 5 (旗舰)",
+        model: "claude-opus-5",
+        is_multimodal: true,
+        is_reasoning: true,
+        supports_tools: true,
+        max_output_tokens: 128000,
+        temperature: 1.0, // 新代际对非默认采样参数一律 400，保持默认值
+    },
+    BuiltinModel {
+        id: "builtin-claude-sonnet-5",
+        vendor_id: "builtin-anthropic",
+        label: "Claude Sonnet 5 (均衡)",
+        model: "claude-sonnet-5",
+        is_multimodal: true,
+        is_reasoning: true,
+        supports_tools: true,
+        max_output_tokens: 128000,
+        temperature: 1.0,
+    },
+    BuiltinModel {
+        id: "builtin-claude-fable-5",
+        vendor_id: "builtin-anthropic",
+        label: "Claude Fable 5 (思考 always-on)",
+        model: "claude-fable-5",
+        is_multimodal: true,
+        is_reasoning: true,
+        supports_tools: true,
+        max_output_tokens: 128000,
+        temperature: 1.0,
+    },
+    // Haiku 4.5：旧代际 manual extended thinking（budget_tokens）
+    BuiltinModel {
+        id: "builtin-claude-haiku-4-5",
+        vendor_id: "builtin-anthropic",
+        label: "Claude Haiku 4.5 (轻量/官方最新 Haiku)",
+        model: "claude-haiku-4-5",
+        is_multimodal: true,
+        is_reasoning: true,
+        supports_tools: true,
+        max_output_tokens: 64000,
+        temperature: 1.0,
+    },
     // ===== NVIDIA NIM 模型 =====
     BuiltinModel {
         id: "builtin-nvidia-nemotron-3-nano",
@@ -1030,6 +1089,8 @@ impl BuiltinModel {
             ("general".to_string(), None)
         } else if self.vendor_id == "builtin-mimo" {
             ("mimo".to_string(), None)
+        } else if self.vendor_id == "builtin-anthropic" {
+            ("anthropic".to_string(), None)
         } else {
             ("general".to_string(), None)
         };
@@ -1289,6 +1350,15 @@ pub(crate) fn deepseek_context_window(model: &str) -> Option<u32> {
         Some(1_000_000)
     } else if normalized == "glm-5.1" {
         Some(200_000)
+    } else if matches!(
+        normalized.as_str(),
+        "claude-opus-5" | "claude-sonnet-5" | "claude-fable-5"
+    ) {
+        // Claude 2026 新代际 1M 上下文（对照 model-capability-registry）
+        Some(1_000_000)
+    } else if normalized.starts_with("claude-haiku-4-5") {
+        // Haiku 4.5 标准 200K 上下文
+        Some(200_000)
     } else {
         None
     }
@@ -1324,6 +1394,13 @@ mod tests {
             .iter()
             .find(|vendor| vendor.id == "builtin-mimo")
             .expect("builtin Xiaomi MiMo vendor should exist")
+    }
+
+    fn anthropic_vendor() -> &'static BuiltinVendor {
+        BUILTIN_VENDORS
+            .iter()
+            .find(|vendor| vendor.id == "builtin-anthropic")
+            .expect("builtin Anthropic vendor should exist")
     }
 
     #[test]
@@ -1548,6 +1625,73 @@ mod tests {
         assert!(multimodal.is_multimodal);
         assert_eq!(multimodal.max_output_tokens, 131_072);
         assert_eq!(multimodal.context_window, Some(1_000_000));
+    }
+
+    #[test]
+    fn anthropic_builtin_vendor_uses_official_messages_endpoint() {
+        let vendor = anthropic_vendor();
+
+        assert_eq!(vendor.name, "Anthropic");
+        assert_eq!(vendor.provider_type, "anthropic");
+        assert_eq!(vendor.base_url, "https://api.anthropic.com/v1");
+        assert!(vendor.notes.contains("adaptive"));
+        assert!(vendor.website_url.contains("platform.claude.com"));
+
+        let config = vendor.to_vendor_config();
+        assert_eq!(config.api_protocol.as_deref(), Some("anthropic_messages"));
+        assert!(config.api_key.is_empty());
+    }
+
+    #[test]
+    fn anthropic_builtin_profiles_cover_official_2026_catalog() {
+        // 2026-08 官方已核验 ID：Opus 5 / Sonnet 5 / Fable 5 / Haiku 4.5
+        let opus = builtin_model("builtin-claude-opus-5").to_model_profile();
+        assert_eq!(opus.model, "claude-opus-5");
+        assert_eq!(opus.vendor_id, "builtin-anthropic");
+        assert_eq!(opus.provider_scope.as_deref(), Some("anthropic"));
+        assert_eq!(opus.model_adapter, "anthropic");
+        assert!(opus.is_multimodal);
+        assert!(opus.is_reasoning);
+        assert!(opus.supports_tools);
+        assert!(opus.thinking_enabled);
+        assert!(opus.include_thoughts);
+        assert_eq!(opus.max_output_tokens, 128_000);
+        assert_eq!(opus.context_window, Some(1_000_000));
+
+        let sonnet = builtin_model("builtin-claude-sonnet-5").to_model_profile();
+        assert_eq!(sonnet.model, "claude-sonnet-5");
+        assert_eq!(sonnet.model_adapter, "anthropic");
+        assert_eq!(sonnet.max_output_tokens, 128_000);
+        assert_eq!(sonnet.context_window, Some(1_000_000));
+
+        let fable = builtin_model("builtin-claude-fable-5").to_model_profile();
+        assert_eq!(fable.model, "claude-fable-5");
+        assert!(fable.is_reasoning);
+        assert_eq!(fable.context_window, Some(1_000_000));
+
+        let haiku = builtin_model("builtin-claude-haiku-4-5").to_model_profile();
+        assert_eq!(haiku.model, "claude-haiku-4-5");
+        assert!(haiku.is_multimodal);
+        assert!(haiku.is_reasoning);
+        assert_eq!(haiku.max_output_tokens, 64_000);
+        assert_eq!(haiku.context_window, Some(200_000));
+    }
+
+    #[test]
+    fn builtin_catalog_has_no_fabricated_claude_haiku_5() {
+        // 官方最新 Haiku 仍为 4.5，claude-haiku-5 是编造 ID，禁止进入内置目录
+        assert!(
+            !BUILTIN_MODELS
+                .iter()
+                .any(|m| m.model.contains("claude-haiku-5") || m.id.contains("claude-haiku-5")),
+            "fabricated `claude-haiku-5` must not enter the builtin catalog"
+        );
+        // 同理 mythos-5 仅存在于适配层代际判定，不应作为内置模型下发
+        assert!(!BUILTIN_MODELS.iter().any(|m| m.model.contains("mythos")));
+        // Haiku 线内置的就是 4.5
+        assert!(BUILTIN_MODELS
+            .iter()
+            .any(|m| m.model == "claude-haiku-4-5"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主干内置供应商没有 Anthropic 条目，用户必须手填。官方 2026-08 API ID 已核验：`claude-haiku-4-5`、`claude-sonnet-5`、`claude-opus-5`、`claude-fable-5`。本 PR 只在 `builtin_vendors.rs` 增加 `builtin-anthropic` 与上述 profile。

**不编造 `claude-haiku-5`。** 不改 `apiCapabilityEngine.ts`（#170/#171）、`modelFamily.ts`（#202）、`model-capability-registry.json`（#184）。

### Changes
- 新增 `builtin-anthropic` vendor
- 内置 Haiku 4.5 / Sonnet 5 / Opus 5 / Fable 5
- rustfmt 与「不存在 claude-haiku-5」断言

### How to test
- `cargo test --manifest-path src-tauri/Cargo.toml builtin_vendors -- --nocapture`
- `cargo fmt --check`

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

