### PR TITLE
fix(provider-icon): Meta 认 Llama 4，并锁定 2026.8 官方模型图标

### DIFF
--- a/src/utils/__tests__/providerIconEngine.test.ts
+++ b/src/utils/__tests__/providerIconEngine.test.ts
@@ -37,6 +37,14 @@ describe('ProviderIconEngine', () => {
       expect(detectProviderBrand('meta-llama/Llama-3.2')).toBe('meta');
     });
 
+    it('应该正确识别 Meta Llama 4 模型（含无连字符写法）', () => {
+      expect(detectProviderBrand('llama-4-maverick')).toBe('meta');
+      expect(detectProviderBrand('meta-llama/Llama-4-Scout')).toBe('meta');
+      expect(detectProviderBrand('Llama-4')).toBe('meta');
+      expect(detectProviderBrand('llama4')).toBe('meta');
+      expect(detectProviderBrand('llama-guard-3-8b')).toBe('meta');
+    });
+
     it('应该正确识别 Mistral 模型', () => {
       expect(detectProviderBrand('mistral-large')).toBe('mistral');
       expect(detectProviderBrand('mixtral-8x7b')).toBe('mistral');
@@ -191,6 +199,47 @@ describe('ProviderIconEngine', () => {
 
     it('未识别的模型不应该再回退到 generic 图标路径', () => {
       expect(getProviderIcon('unknown-model-xyz')).toBe('');
+    });
+  });
+
+  describe('2026.8 官方模型 ID 锁定（brand + iconPath）', () => {
+    it('Meta Llama 4 系列应该识别为 meta 并使用 meta 图标', () => {
+      for (const id of ['llama-4-maverick', 'meta-llama/Llama-4-Scout', 'Llama-4', 'llama4']) {
+        expect(detectProviderBrand(id)).toBe('meta');
+        expect(getProviderIcon(id)).toBe('/icons/providers/meta.svg');
+      }
+    });
+
+    it('Anthropic Claude 4.5/5 系列应该识别为 anthropic 并使用 anthropic 图标', () => {
+      // 官方 Haiku ID 为 claude-haiku-4-5（不存在 claude-haiku-5）
+      for (const id of ['claude-haiku-4-5', 'claude-sonnet-5', 'claude-opus-5', 'claude-fable-5']) {
+        expect(detectProviderBrand(id)).toBe('anthropic');
+        expect(getProviderIcon(id)).toBe('/icons/providers/anthropic.svg');
+      }
+    });
+
+    it('Google Gemini 3.x 系列应该识别为 google 并使用 gemini 图标', () => {
+      for (const id of ['gemini-3.1-flash-lite', 'gemini-3.5-flash-lite']) {
+        expect(detectProviderBrand(id)).toBe('google');
+        expect(getProviderIcon(id)).toBe('/icons/providers/gemini.svg');
+      }
+    });
+
+    it('xAI Grok 4 系列应该识别为 xai 并使用 grok 图标', () => {
+      for (const id of ['grok-4', 'grok-4-0709']) {
+        expect(detectProviderBrand(id)).toBe('xai');
+        expect(getProviderIcon(id)).toBe('/icons/providers/grok.svg');
+      }
+    });
+
+    it('MiniMax-M2 应该识别为 minimax', () => {
+      expect(detectProviderBrand('MiniMax-M2')).toBe('minimax');
+      expect(getProviderIcon('MiniMax-M2')).toBe('/icons/providers/minimax.svg');
+    });
+
+    it('gpt-5.6 应该识别为 openai', () => {
+      expect(detectProviderBrand('gpt-5.6')).toBe('openai');
+      expect(getProviderIcon('gpt-5.6')).toBe('/icons/providers/openai.svg');
     });
   });
 

--- a/src/utils/providerIconEngine.ts
+++ b/src/utils/providerIconEngine.ts
@@ -114,7 +114,8 @@ const PROVIDER_PATTERNS: Record<ProviderBrand, (string | RegExp)[]> = {
     /^meta$/i,
     /^meta\//i,
     /^meta-llama\//i,
-    /llama-[23]/i,
+    /llama-[234]/i,
+    /\bllama4/i,  // 无连字符写法（如 llama4），\b 避免误伤 ollama 等
     /llama-guard/i,
   ],
   


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

设置页/模型选择器对 Llama 4 显示 generic 空图标：Meta 规则只匹配 `llama-[23]`。本 PR 补上 Llama 4 / `llama4`，并用测试锁住 2026.8 已核验的官方模型 ID 图标映射。不编造 `claude-haiku-5`。

### Changes
- Meta 规则：`/llama-[234]/i` + `/\bllama4/i`（词边界避免误伤 ollama），保留 `llama-guard`
- 测试追加锁定：Llama 4 四种写法、`claude-haiku-4-5` / `claude-sonnet-5` / `claude-opus-5` / `claude-fable-5`、Gemini 3.x lite、Grok 4、MiniMax-M2、gpt-5.6

### How to test
- `npx vitest run src/utils/__tests__/providerIconEngine.test.ts`
- 在模型列表里选 `llama-4-maverick` / `meta-llama/Llama-4-Scout`，应显示 Meta 图标

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [x] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

