### PR TITLE
fix(a11y): 空态与欢迎引导补齐区域名称和描述

### DIFF
--- a/src/components/onboarding/WelcomeOnboardingDialog.tsx
+++ b/src/components/onboarding/WelcomeOnboardingDialog.tsx
@@ -252,6 +252,7 @@ export const WelcomeOnboardingDialog: React.FC<WelcomeOnboardingDialogProps> = (
         role="dialog"
         aria-modal="true"
         aria-labelledby="welcome-onboarding-title"
+        aria-describedby="welcome-onboarding-subtitle"
         tabIndex={-1}
         className={cn(
           'outline-none',
@@ -276,7 +277,10 @@ export const WelcomeOnboardingDialog: React.FC<WelcomeOnboardingDialogProps> = (
               <h1 id="welcome-onboarding-title" className="text-[20px] font-semibold text-foreground leading-tight tracking-[-0.01em]">
                 {t('welcome_onboarding.title')}
               </h1>
-              <p className="mt-1.5 text-[13px] text-foreground/50 leading-relaxed">
+              <p
+                id="welcome-onboarding-subtitle"
+                className="mt-1.5 text-[13px] text-foreground/50 leading-relaxed"
+              >
                 {t('welcome_onboarding.subtitle')}
               </p>
             </div>

--- a/src/components/onboarding/__tests__/WelcomeOnboardingDialog.a11y.test.tsx
+++ b/src/components/onboarding/__tests__/WelcomeOnboardingDialog.a11y.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * WelcomeOnboardingDialog a11y 契约
+ *
+ * 锁定可达性语义，不锁文案（common.json 归属其他 PR）、不改流程逻辑：
+ * - role="dialog" + aria-modal，aria-labelledby 指向 h1 标题
+ * - 副标题 <p> 有稳定 id，dialog 通过 aria-describedby 指向它
+ * - 可访问名称/描述与实际渲染的标题/副标题文本一致
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { WelcomeOnboardingDialog } from '../WelcomeOnboardingDialog';
+
+describe('WelcomeOnboardingDialog a11y 契约', () => {
+  it('dialog 通过 aria-labelledby / aria-describedby 暴露标题与副标题', () => {
+    render(<WelcomeOnboardingDialog onConfigure={vi.fn()} onSkip={vi.fn()} />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'welcome-onboarding-title');
+    expect(dialog).toHaveAttribute('aria-describedby', 'welcome-onboarding-subtitle');
+
+    const title = document.getElementById('welcome-onboarding-title');
+    const subtitle = document.getElementById('welcome-onboarding-subtitle');
+    expect(title).not.toBeNull();
+    expect(subtitle).not.toBeNull();
+    expect(title?.textContent).toBeTruthy();
+    expect(subtitle?.textContent).toBeTruthy();
+
+    expect(dialog).toHaveAccessibleName(title!.textContent!.trim());
+    expect(dialog).toHaveAccessibleDescription(subtitle!.textContent!.trim());
+  });
+
+  it('副标题 id 稳定且唯一，指向真实渲染的 <p>', () => {
+    render(<WelcomeOnboardingDialog onConfigure={vi.fn()} onSkip={vi.fn()} />);
+    const subtitles = document.querySelectorAll('#welcome-onboarding-subtitle');
+    expect(subtitles).toHaveLength(1);
+    expect(subtitles[0].tagName).toBe('P');
+  });
+});

--- a/src/features/chat/components/ui/ThreadEmptyStateShell.tsx
+++ b/src/features/chat/components/ui/ThreadEmptyStateShell.tsx
@@ -16,6 +16,8 @@ export interface ThreadEmptyStateShellProps extends Omit<React.HTMLAttributes<HT
   hint?: React.ReactNode;
   titleClassName?: string;
   contentClassName?: string;
+  /** 标题 h2 的稳定 id；缺省用 React.useId 生成，section 通过 aria-labelledby 指向它 */
+  titleId?: string;
 }
 
 /**
@@ -36,15 +38,20 @@ export const ThreadEmptyStateShell: React.FC<ThreadEmptyStateShellProps> = ({
   className,
   titleClassName,
   contentClassName,
+  titleId,
   children,
   ...props
 }) => {
+  // a11y：section 必须以内部 h2 命名（aria-labelledby），读屏用户才能拿到区域名称
+  const generatedTitleId = React.useId();
+  const headingId = titleId ?? generatedTitleId;
   return (
     <ThreadContentShell className={cn('flex min-h-full items-center', className)}>
       <section
         data-slot="thread-empty-state"
         className={cn('flex w-full flex-col items-center justify-center gap-4 text-center', contentClassName)}
         {...props}
+        aria-labelledby={headingId}
       >
         {brandIcon ? (
           <div
@@ -59,6 +66,7 @@ export const ThreadEmptyStateShell: React.FC<ThreadEmptyStateShellProps> = ({
           </div>
         ) : null}
         <h2
+          id={headingId}
           data-slot="thread-empty-primary-action"
           className={cn('text-balance text-2xl font-medium text-foreground', titleClassName)}
         >

--- a/src/features/chat/components/ui/__tests__/ThreadEmptyStateShell.a11y.test.tsx
+++ b/src/features/chat/components/ui/__tests__/ThreadEmptyStateShell.a11y.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * ThreadEmptyStateShell a11y 契约
+ *
+ * 锁定可达性语义，不锁视觉 token、不改空态内容模型：
+ * - 内部 h2 有稳定 id，外层 section 通过 aria-labelledby 指向它
+ * - section 因此暴露为命名 region，读屏用户能拿到区域名称
+ * - 支持调用方传入自定义 titleId
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ThreadEmptyStateShell } from '../ThreadEmptyStateShell';
+
+describe('ThreadEmptyStateShell a11y 契约', () => {
+  it('section 通过 aria-labelledby 指向内部 h2，暴露为命名 region', () => {
+    render(<ThreadEmptyStateShell title="今天想学点什么？" description="随便问点什么开始" />);
+    const heading = screen.getByRole('heading', { level: 2, name: '今天想学点什么？' });
+    expect(heading.id).not.toBe('');
+
+    const region = screen.getByRole('region', { name: '今天想学点什么？' });
+    expect(region).toHaveAttribute('data-slot', 'thread-empty-state');
+    expect(region).toHaveAttribute('aria-labelledby', heading.id);
+  });
+
+  it('支持传入自定义 titleId', () => {
+    render(<ThreadEmptyStateShell title="欢迎" titleId="custom-empty-title" />);
+    expect(screen.getByRole('heading', { level: 2, name: '欢迎' })).toHaveAttribute(
+      'id',
+      'custom-empty-title',
+    );
+    expect(screen.getByRole('region', { name: '欢迎' })).toHaveAttribute(
+      'aria-labelledby',
+      'custom-empty-title',
+    );
+  });
+
+  it('品牌图标区保持对读屏隐藏', () => {
+    const { container } = render(
+      <ThreadEmptyStateShell title="欢迎" brandIcon={<svg data-testid="brand-svg" />} />,
+    );
+    expect(
+      container.querySelector('[data-slot="thread-empty-brand"]'),
+    ).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/src/features/workbench/apps/content/ContentEmptyState.tsx
+++ b/src/features/workbench/apps/content/ContentEmptyState.tsx
@@ -26,14 +26,21 @@ export const ContentEmptyState: React.FC<ContentEmptyStateProps> = ({
   description,
   icon,
   className,
-}) => (
-  <div className={cn('wb-content-empty', className)} role="note">
-    <div className="wb-content-empty__icon" aria-hidden="true">
-      {icon ?? <FileDashed size={30} weight="duotone" />}
+}) => {
+  // a11y：标题必须是真 heading 并作为区域的可访问名称暴露；
+  // role="note" 对「资源缺失空态」语义不符，改用命名 region。
+  const titleId = React.useId();
+  return (
+    <div className={cn('wb-content-empty', className)} role="region" aria-labelledby={titleId}>
+      <div className="wb-content-empty__icon" aria-hidden="true">
+        {icon ?? <FileDashed size={30} weight="duotone" />}
+      </div>
+      <h2 id={titleId} className="wb-content-empty__title">
+        {title}
+      </h2>
+      {description && <div className="wb-content-empty__desc">{description}</div>}
     </div>
-    <div className="wb-content-empty__title">{title}</div>
-    {description && <div className="wb-content-empty__desc">{description}</div>}
-  </div>
-);
+  );
+};
 
 export default ContentEmptyState;

--- a/src/features/workbench/apps/content/__tests__/ContentEmptyState.a11y.test.tsx
+++ b/src/features/workbench/apps/content/__tests__/ContentEmptyState.a11y.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * ContentEmptyState a11y 契约
+ *
+ * 锁定可达性语义，不锁视觉 token：
+ * - 标题必须是真 heading（h2），保留 wb-content-empty__title 视觉类
+ * - 容器是命名 region（aria-labelledby 指向标题），不再是 role="note"
+ * - 装饰图标对读屏隐藏
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ContentEmptyState } from '../ContentEmptyState';
+
+describe('ContentEmptyState a11y 契约', () => {
+  it('标题是 level-2 heading，并保留现有视觉类名', () => {
+    render(<ContentEmptyState title="缺少资源标识" description="请从资源库重新打开" />);
+    const heading = screen.getByRole('heading', { level: 2, name: '缺少资源标识' });
+    expect(heading).toHaveClass('wb-content-empty__title');
+    expect(screen.getByText('请从资源库重新打开')).toHaveClass('wb-content-empty__desc');
+  });
+
+  it('容器是 region，可访问名称来自标题（aria-labelledby）', () => {
+    render(<ContentEmptyState title="缺少资源标识" />);
+    const region = screen.getByRole('region', { name: '缺少资源标识' });
+    expect(region).toHaveClass('wb-content-empty');
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading.id).not.toBe('');
+    expect(region).toHaveAttribute('aria-labelledby', heading.id);
+  });
+
+  it('不再使用 role="note"，装饰图标对读屏隐藏', () => {
+    const { container } = render(<ContentEmptyState title="缺少资源标识" />);
+    expect(container.querySelector('[role="note"]')).toBeNull();
+    expect(container.querySelector('.wb-content-empty__icon')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+  });
+
+  it('自定义 className 仍然透传到容器', () => {
+    render(<ContentEmptyState title="缺少资源标识" className="custom-empty" />);
+    expect(screen.getByRole('region', { name: '缺少资源标识' })).toHaveClass(
+      'wb-content-empty',
+      'custom-empty',
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

资源空态、会话空态和首次欢迎弹层的读屏语义不完整：标题不是 heading / 区域没有名字 / 对话框没有描述。本 PR 只补可达性，不改文案和空态内容模型。

### Changes
- `ContentEmptyState`：title 改为 h2，容器 `role="region"` + `aria-labelledby`
- `ThreadEmptyStateShell`：section `aria-labelledby` 指向内部 h2（`useId` / 可选 `titleId`）
- `WelcomeOnboardingDialog`：副标题补 id，dialog `aria-describedby`
- 新增三份 a11y 契约测试

### How to test
- 跑新增 a11y 测试
- 读屏：资源窗口空态应读到标题；无会话空态应读到区域名；欢迎弹层应读到副标题

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [x] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

