### PR TITLE
fix(attachments): 未占前端面图片上限 10MB→50MB

### DIFF
--- a/src/components/QuestionInlineEditor.tsx
+++ b/src/components/QuestionInlineEditor.tsx
@@ -144,7 +144,7 @@ function createStructuredDraft(question?: Question | null): StructuredDraft {
 }
 
 const MAX_IMAGES = 10;
-const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_IMAGE_SIZE = 50 * 1024 * 1024; // 50MB - 与后端 vfs_upload_attachment 的 MAX_IMAGE_BYTES 保持一致
 const ALLOWED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
 
 const MAX_OPTIONS = 26; // A-Z
@@ -327,7 +327,7 @@ export const QuestionInlineEditor: React.FC<QuestionInlineEditorProps> = ({
           continue;
         }
         if (file.size > MAX_IMAGE_SIZE) {
-          showGlobalNotification('warning', `${file.name}: ${t('exam_sheet:image.max_size', { size: '10MB' })}`);
+          showGlobalNotification('warning', `${file.name}: ${t('exam_sheet:image.max_size', { size: '50MB' })}`);
           continue;
         }
 

--- a/src/components/crepe/features/__tests__/imageUpload.test.ts
+++ b/src/components/crepe/features/__tests__/imageUpload.test.ts
@@ -108,3 +108,72 @@ describe('createImageUploader', () => {
     expect(result).toBe('data:image/png;base64,aW1hZ2U=');
   });
 });
+
+describe('createImageUploader size limit (50MB, aligned with backend notes_save_asset)', () => {
+  const MB = 1024 * 1024;
+
+  /** 小内容 + 伪造 size，避免在测试里真的分配几十 MB 内存 */
+  const makeImageFile = (size: number, name = 'photo.jpg'): File => {
+    const file = new File(['x'], name, { type: 'image/jpeg' });
+    Object.defineProperty(file, 'size', { value: size });
+    return file;
+  };
+
+  beforeEach(() => {
+    invokeMock.mockReset();
+    notificationMock.mockReset();
+  });
+
+  it('accepts a 25MB photo instead of rejecting it at the old 10MB limit', async () => {
+    invokeMock.mockResolvedValueOnce({
+      absolute_path: '/data/notes_assets/_global/note-1/photo.jpg',
+      relative_path: 'notes_assets/_global/note-1/photo.jpg',
+    });
+    const upload = createImageUploader('note-1');
+
+    const result = await upload(makeImageFile(25 * MB));
+
+    expect(result).toBe('notes_assets/_global/note-1/photo.jpg');
+    expect(invokeMock).toHaveBeenCalledWith('notes_save_asset', expect.objectContaining({
+      note_id: 'note-1',
+    }));
+    expect(notificationMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts a file just above the old 10MB limit', async () => {
+    invokeMock.mockResolvedValueOnce({
+      absolute_path: '/data/notes_assets/_global/note-1/photo.jpg',
+      relative_path: 'notes_assets/_global/note-1/photo.jpg',
+    });
+    const upload = createImageUploader('note-1');
+
+    const result = await upload(makeImageFile(10 * MB + 1));
+
+    expect(result).toBe('notes_assets/_global/note-1/photo.jpg');
+    expect(notificationMock).not.toHaveBeenCalled();
+  });
+
+  it('still rejects a file just above the 50MB backend limit', async () => {
+    const upload = createImageUploader('note-1');
+
+    const result = await upload(makeImageFile(50 * MB + 1));
+
+    expect(result).toBe('');
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(notificationMock).toHaveBeenCalledTimes(1);
+    expect(notificationMock).toHaveBeenCalledWith('warning', expect.any(String));
+  });
+
+  it('accepts a file at exactly 50MB', async () => {
+    invokeMock.mockResolvedValueOnce({
+      absolute_path: '/data/notes_assets/_global/note-1/photo.jpg',
+      relative_path: 'notes_assets/_global/note-1/photo.jpg',
+    });
+    const upload = createImageUploader('note-1');
+
+    const result = await upload(makeImageFile(50 * MB));
+
+    expect(result).toBe('notes_assets/_global/note-1/photo.jpg');
+    expect(notificationMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/crepe/features/imageUpload.ts
+++ b/src/components/crepe/features/imageUpload.ts
@@ -95,9 +95,14 @@ export const createImageUploader = (
   blobRegistry?: TransientBlobUrlRegistry
 ): ((file: File) => Promise<string>) => {
   return async (file: File): Promise<string> => {
-    const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10MB
+    // 50MB - 与后端 notes_save_asset（file_manager.rs）的资产上限保持一致
+    const MAX_IMAGE_SIZE_MB = 50;
+    const MAX_IMAGE_SIZE = MAX_IMAGE_SIZE_MB * 1024 * 1024;
     if (file.size > MAX_IMAGE_SIZE) {
-      showGlobalNotification('warning', i18next.t('notes:editor.image_upload.too_large'));
+      showGlobalNotification(
+        'warning',
+        i18next.t('notes:upload.image_too_large', { limit: MAX_IMAGE_SIZE_MB })
+      );
       return '';
     }
 

--- a/src/features/chat/context/__tests__/blobApi.cacheLimit.test.ts
+++ b/src/features/chat/context/__tests__/blobApi.cacheLimit.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@tauri-apps/api/core')>();
+  return { ...original, invoke: invokeMock };
+});
+
+import {
+  clearBlobCache,
+  getBlobBase64,
+  getBlobCacheStats,
+  type VfsBlobBase64Result,
+} from '../blobApi';
+
+const MB = 1024 * 1024;
+
+/**
+ * 缓存阈值逻辑只读取 base64.length，用带 length 的对象代替真实字符串，
+ * 避免在测试里真的分配几十 MB 内存（CI 堆敏感）。
+ */
+const fakeBlobResult = (byteLength: number): VfsBlobBase64Result => ({
+  base64: { length: byteLength } as unknown as string,
+  mimeType: 'image/jpeg',
+  size: byteLength,
+});
+
+describe('blobApi single-item cache limit (50MB, aligned with backend MAX_IMAGE_BYTES)', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    clearBlobCache();
+  });
+
+  it('caches a 25MB exam image instead of skipping it at the old 10MB limit', async () => {
+    invokeMock.mockResolvedValue(fakeBlobResult(25 * MB));
+
+    await getBlobBase64('hash-25mb');
+    await getBlobBase64('hash-25mb');
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(getBlobCacheStats().size).toBe(1);
+    expect(getBlobCacheStats().totalBytes).toBe(25 * MB);
+  });
+
+  it('caches a blob at exactly the 50MB single-item limit', async () => {
+    invokeMock.mockResolvedValue(fakeBlobResult(50 * MB));
+
+    await getBlobBase64('hash-50mb');
+    await getBlobBase64('hash-50mb');
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(getBlobCacheStats().size).toBe(1);
+  });
+
+  it('still skips caching for blobs above 50MB', async () => {
+    invokeMock.mockResolvedValue(fakeBlobResult(50 * MB + 1));
+
+    await getBlobBase64('hash-oversized');
+    await getBlobBase64('hash-oversized');
+
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+    expect(getBlobCacheStats().size).toBe(0);
+    expect(getBlobCacheStats().totalBytes).toBe(0);
+  });
+});

--- a/src/features/chat/context/blobApi.ts
+++ b/src/features/chat/context/blobApi.ts
@@ -50,7 +50,9 @@ const blobCache = new Map<string, VfsBlobBase64Result>();
 
 const MAX_CACHE_SIZE = 50;
 const MAX_CACHE_BYTES = 100 * 1024 * 1024; // 100 MB
-const MAX_SINGLE_ITEM_BYTES = 10 * 1024 * 1024; // 10 MB
+// 50 MB - 与后端图片上限（attachment_repo.rs MAX_IMAGE_BYTES）对齐，
+// 否则 10–50MB 的考题图每次都会跳过缓存、反复走 IPC 重新拉取
+const MAX_SINGLE_ITEM_BYTES = 50 * 1024 * 1024;
 
 let totalCacheBytes = 0;
 

--- a/src/features/settings/components/OcrEngineTestPanel.tsx
+++ b/src/features/settings/components/OcrEngineTestPanel.tsx
@@ -63,9 +63,11 @@ export const OcrEngineTestPanel: React.FC<OcrEngineTestPanelProps> = ({
   availableModels,
   onClose,
 }) => {
-  const { t } = useTranslation(['settings', 'common']);
+  const { t } = useTranslation(['settings', 'common', 'notes']);
   const clickInputRef = useRef<HTMLInputElement>(null);
-  const maxImageSize = 10 * 1024 * 1024;
+  // 50MB - 与后端图片上限（attachment_repo.rs MAX_IMAGE_BYTES）保持一致
+  const maxImageSizeMB = 50;
+  const maxImageSize = maxImageSizeMB * 1024 * 1024;
   // 测试所有已配置的引擎（不按 engineType 去重，支持同类型多引擎对比）
   const engineModels = availableModels;
   
@@ -87,7 +89,8 @@ export const OcrEngineTestPanel: React.FC<OcrEngineTestPanelProps> = ({
     }
 
     if (file.size > maxImageSize) {
-      showGlobalNotification('warning', t('settings:ocr.image_too_large'));
+      // settings:ocr.image_too_large 文案写死 10MB，改用带 {{limit}} 插值的 key
+      showGlobalNotification('warning', t('notes:upload.image_too_large', { limit: maxImageSizeMB }));
       return;
     }
 

--- a/src/hooks/useAttachmentSettings.ts
+++ b/src/hooks/useAttachmentSettings.ts
@@ -34,7 +34,7 @@ export interface AttachmentSettings {
  * - 大小限制：与 ATTACHMENT_MAX_SIZE (200MB，#62) 一致
  */
 const DEFAULT_SETTINGS: AttachmentSettings = {
-  maxImageSize: 10 * 1024 * 1024, // 10MB
+  maxImageSize: 50 * 1024 * 1024, // 50MB - 与后端 MAX_IMAGE_BYTES（attachment_repo.rs）保持一致
   maxFileSize: ATTACHMENT_MAX_SIZE, // 200MB - 与 constants.ts 和后端 VFS 保持一致（#62）
   maxAttachments: ATTACHMENT_MAX_COUNT,
   allowedImageTypes: ATTACHMENT_IMAGE_TYPES,
@@ -69,6 +69,12 @@ export function useAttachmentSettings(): UseAttachmentSettingsReturn {
             const LEGACY_DEFAULT_MAX_FILE_SIZE = 50 * 1024 * 1024;
             if (parsed?.maxFileSize === LEGACY_DEFAULT_MAX_FILE_SIZE) {
               delete parsed.maxFileSize;
+            }
+            // 同理：图片旧默认 10MB 曾被持久化；视为旧默认，升级到新默认 50MB
+            // （后端 MAX_IMAGE_BYTES 已放宽到 50MB，用户显式设置的其他值不受影响）
+            const LEGACY_DEFAULT_MAX_IMAGE_SIZE = 10 * 1024 * 1024;
+            if (parsed?.maxImageSize === LEGACY_DEFAULT_MAX_IMAGE_SIZE) {
+              delete parsed.maxImageSize;
             }
             setSettings({ ...DEFAULT_SETTINGS, ...parsed });
           } catch {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

后端图片存储已是 50MB（`attachment_repo` / 笔记资产 / `vfs_upload_attachment`），前端多处仍按 10MB 误拒手机原图。本 PR 只改未被 #198/#173/#194 占用的调用面，并避开写死 10MB 的占用 locale。

### Changes
- `useAttachmentSettings`：默认 `maxImageSize` 50MB；持久化旧默认 10MB 视为升级，不覆盖用户显式值
- `QuestionInlineEditor`：50MB，提示走 `exam_sheet:image.max_size` 插值
- 笔记 `imageUpload`：50MB，提示改用 `notes:upload.image_too_large`
- `OcrEngineTestPanel`：50MB，同样改用插值 key（不改 `settings.json`）
- `blobApi`：单条缓存阈值 50MB，避免 10–50MB 考题图每次跳过缓存
- 对应 vitest 锁定 25MB 通过、50MB+1 仍拒

不改：`resources/types.ts` `IMAGE_SIZE_LIMIT`（VFS Image 仍 10MB，`handlers.rs` 由 #194 占用）、附件 200MB 正主文件、`translation.json` / `settings.json` / `notes.json`。

### How to test
- 跑本 PR 新增/改动的 vitest
- 在笔记编辑器 / 题库插图上传 12–40MB 照片，应能通过前端校验

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [x] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

