### PR TITLE
fix(gemini): 3.5 Flash-Lite 默认思考档不再被判成 Flash

### DIFF
--- a/src-tauri/src/llm_manager/adapters/gemini.rs
+++ b/src-tauri/src/llm_manager/adapters/gemini.rs
@@ -64,10 +64,13 @@ impl GeminiAdapter {
     /// Gemini 3.x Flash: 支持 "minimal", "low", "medium", "high"
     fn default_thinking_level(model: &str, is_flash: bool) -> &'static str {
         let lower = model.to_lowercase();
-        if lower.contains("gemini-3.5-flash") {
-            "medium"
-        } else if lower.contains("gemini-3.1-flash-lite") {
+        // flash-lite 必须先于 gemini-3.5-flash 匹配：
+        // "gemini-3.5-flash-lite" 包含子串 "gemini-3.5-flash"，
+        // 若顺序颠倒会被误判为 Flash 默认 "medium"
+        if lower.contains("flash-lite") {
             "minimal"
+        } else if lower.contains("gemini-3.5-flash") {
+            "medium"
         } else if lower.contains("gemini-3-flash") {
             "high"
         } else if is_flash {
@@ -425,6 +428,9 @@ mod tests {
     fn test_gemini_3_model_specific_default_levels() {
         for (model, expected) in [
             ("gemini-3.5-flash", "medium"),
+            // flash-lite 包含 "gemini-3.5-flash" 子串，需先匹配，默认 "minimal"
+            ("gemini-3.5-flash-lite", "minimal"),
+            ("gemini-3.5-flash-lite-preview-08-2026", "minimal"),
             ("gemini-3.1-flash-lite", "minimal"),
             ("gemini-3-flash-preview", "high"),
             ("gemini-3.1-pro-preview", "high"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`gemini-3.5-flash-lite` 包含子串 `gemini-3.5-flash`，后端默认 thinking level 被错判为 `"medium"`。本 PR 先匹配 `flash-lite`，lite 默认 `"minimal"`，非 lite 的 3.5 Flash 仍是 `"medium"`。

### Changes
- `default_thinking_level`：`flash-lite` 优先于 `gemini-3.5-flash`
- 测试锁定 `gemini-3.5-flash-lite` / preview 变体 → `minimal`

不改前端 `deepseekReasoningControls.ts`（#178/#179 占，同类顺序问题留给那两刀）。

### How to test
- `cargo test --manifest-path src-tauri/Cargo.toml gemini`

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [x] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

