### PR TITLE
fix(provider): 官方 Anthropic/Gemini 主机走原生协议

### DIFF
--- a/src/utils/__tests__/providerProtocolRegistry.test.ts
+++ b/src/utils/__tests__/providerProtocolRegistry.test.ts
@@ -185,4 +185,92 @@ describe('providerProtocolRegistry', () => {
     expect(getAllowedProtocolsForProviderType('anthropic')).toEqual(['anthropic_messages']);
     expect(getAllowedProtocolsForProviderType('gemini')).toEqual(['google_generate_content']);
   });
+
+  it('routes official Anthropic/Gemini hosts to native protocols even under a mislabeled providerType', () => {
+    // 官方端点只说原生协议：providerType 误配为 custom/openai 时官方 host 覆盖之，
+    // 避免 2026.8 官方 Claude/Gemini 被当成 OpenAI 兼容端点后 404/协议错。
+    for (const providerType of ['custom', 'openai', 'general']) {
+      expect(
+        resolvePreferredProtocol({
+          providerType,
+          baseUrl: 'https://api.anthropic.com',
+          adapter: 'general',
+        }),
+        `${providerType} + official Anthropic host`,
+      ).toBe('anthropic_messages');
+      expect(
+        resolvePreferredProtocol({
+          providerType,
+          baseUrl: 'https://generativelanguage.googleapis.com',
+          adapter: 'general',
+        }),
+        `${providerType} + official Gemini host`,
+      ).toBe('google_generate_content');
+    }
+
+    // 带 path、无 scheme、尾斜杠等常见写法同样按 hostname 精确识别。
+    expect(
+      resolvePreferredProtocol({
+        providerType: 'custom',
+        baseUrl: 'https://api.anthropic.com/v1/',
+        adapter: 'anthropic',
+      }),
+    ).toBe('anthropic_messages');
+    expect(
+      resolvePreferredProtocol({
+        providerType: 'custom',
+        baseUrl: 'generativelanguage.googleapis.com/v1beta',
+        adapter: 'google',
+      }),
+    ).toBe('google_generate_content');
+
+    // 官方 providerType + 官方 host 的既有原生路由不变。
+    expect(
+      resolvePreferredProtocol({
+        providerType: 'anthropic',
+        baseUrl: 'https://api.anthropic.com',
+        adapter: 'anthropic',
+      }),
+    ).toBe('anthropic_messages');
+    expect(
+      resolvePreferredProtocol({
+        providerType: 'gemini',
+        baseUrl: 'https://generativelanguage.googleapis.com',
+        adapter: 'google',
+      }),
+    ).toBe('google_generate_content');
+  });
+
+  it('does not treat relay URLs embedding official Anthropic/Gemini domains as official hosts', () => {
+    // path 携带官方域名（中转伪造）不得命中。
+    expect(
+      resolvePreferredProtocol({
+        providerType: 'custom',
+        baseUrl: 'https://myproxy.com/api.anthropic.com/v1',
+        adapter: 'anthropic',
+      }),
+    ).toBe('openai_chat_completions');
+    expect(
+      resolvePreferredProtocol({
+        providerType: 'custom',
+        baseUrl: 'https://myproxy.com/generativelanguage.googleapis.com/v1beta',
+        adapter: 'google',
+      }),
+    ).toBe('openai_chat_completions');
+    // 子域伪造不得命中。
+    expect(
+      resolvePreferredProtocol({
+        providerType: 'custom',
+        baseUrl: 'https://api.anthropic.com.evil.example/v1',
+        adapter: 'anthropic',
+      }),
+    ).toBe('openai_chat_completions');
+    expect(
+      resolvePreferredProtocol({
+        providerType: 'custom',
+        baseUrl: 'https://generativelanguage.googleapis.com.evil.example/v1beta',
+        adapter: 'google',
+      }),
+    ).toBe('openai_chat_completions');
+  });
 });

--- a/src/utils/providerProtocolRegistry.ts
+++ b/src/utils/providerProtocolRegistry.ts
@@ -33,15 +33,31 @@ export const getProviderProtocolRecord = (providerType?: string | null): Provide
 };
 
 // 使用 URL host 精确匹配，避免 `https://myproxy.com/api.openai.com/v1` 这类中转地址被误判为官方端点。
-const resolvesToOfficialOpenAi = (baseUrl?: string | null) => {
+const resolveHostnameFromBaseUrl = (baseUrl?: string | null): string | null => {
   const normalizedBaseUrl = normalizeBaseUrlForProtocolRegistry(baseUrl);
-  if (!normalizedBaseUrl) return false;
+  if (!normalizedBaseUrl) return null;
   const candidate = normalizedBaseUrl.includes('://') ? normalizedBaseUrl : `https://${normalizedBaseUrl}`;
   try {
-    return new URL(candidate).hostname === 'api.openai.com';
+    return new URL(candidate).hostname;
   } catch {
-    return false;
+    return null;
   }
+};
+
+const resolvesToOfficialOpenAi = (baseUrl?: string | null) =>
+  resolveHostnameFromBaseUrl(baseUrl) === 'api.openai.com';
+
+// 官方原生协议主机：与 resolvesToOfficialOpenAi 同风格的 hostname 精确匹配，
+// path 携带官方域名（myproxy.com/api.anthropic.com）或子域伪造
+// （api.anthropic.com.evil.example）都不会命中。
+const OFFICIAL_NATIVE_PROTOCOL_HOSTS: Readonly<Record<string, ApiProtocol>> = {
+  'api.anthropic.com': 'anthropic_messages',
+  'generativelanguage.googleapis.com': 'google_generate_content',
+};
+
+const resolveOfficialNativeProtocol = (baseUrl?: string | null): ApiProtocol | undefined => {
+  const hostname = resolveHostnameFromBaseUrl(baseUrl);
+  return hostname ? OFFICIAL_NATIVE_PROTOCOL_HOSTS[hostname] : undefined;
 };
 
 export const providerSupportsOpenAiResponses = (args: {
@@ -66,6 +82,18 @@ export const resolvePreferredProtocol = (args: {
   baseUrl?: string | null;
   supportsOpenAIResponses?: boolean | null;
 }): ApiProtocol => {
+  // 官方 Anthropic / Gemini 端点只说原生协议：用户把 Base URL 填成官方主机、
+  // 但 providerType 误配为 custom/openai 时，allowed 列表不含原生协议，若照走
+  // openai_chat_completions，2026.8 的官方 Claude/Gemini 会直接 404/协议错。
+  // 因此官方 host 在此覆盖错误的 providerType，即使 allowed 不含该原生协议也
+  // 返回 native——这是与官方 api.openai.com 相同的 URL 特例，不改动
+  // getAllowedProtocolsForProviderType('custom')；代理/中转 host 不受影响，
+  // 仍按下方 allowed + adapter 的既有规则走 OpenAI 兼容路由。
+  const officialNativeProtocol = resolveOfficialNativeProtocol(args.baseUrl);
+  if (officialNativeProtocol) {
+    return officialNativeProtocol;
+  }
+
   const normalizedAdapter = normalize(args.adapter);
   const allowed = getAllowedProtocolsForProviderType(args.providerType);
   const nativeProtocol =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

协议探测只把精确 hostname `api.openai.com` 当官方端点。用户把 Base URL 填成 `api.anthropic.com` / `generativelanguage.googleapis.com`、但 providerType 仍是 custom/openai 时，会走 OpenAI 兼容协议，2026.8 官方 Claude/Gemini 直接失败。

本 PR 用同样的 **hostname 精确匹配**（防 path/子域伪造），官方 Anthropic/Gemini 主机覆盖错误的 providerType，改为原生协议。不改 #183 占用的 `provider-protocol-registry.json`。

### Changes
- `api.anthropic.com` → `anthropic_messages`
- `generativelanguage.googleapis.com` → `google_generate_content`
- 中转 `myproxy.com/api.anthropic.com`、`api.anthropic.com.evil.example` 不误判
- 代理 host + anthropic/google adapter 的既有用例保持不变

### How to test
- `npx vitest run src/utils/__tests__/providerProtocolRegistry.test.ts`

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [x] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

