### PR TITLE
fix(drag-drop): 用户可见拒绝文案走 drag_drop i18n

### DIFF
--- a/src/hooks/useTauriDragAndDrop.ts
+++ b/src/hooks/useTauriDragAndDrop.ts
@@ -231,7 +231,7 @@ export const useTauriDragAndDrop = ({
           const isAllowed = allowedRegex.test(path);
           
           if (!isAllowed) {
-            rejectedFiles.push(`${fileName}: 不支持的文件类型`);
+            rejectedFiles.push(`${fileName}: ${i18n.t('drag_drop:errors.unsupported_type')}`);
             emitDebugEvent(zoneId, 'validation_failed', 'warning', `文件类型不支持: ${fileName}`, {
               fileName,
               path,
@@ -246,7 +246,7 @@ export const useTauriDragAndDrop = ({
               if (fileSize > maxFileSize) {
                 oversizeCount++;
                 const sizeMB = (maxFileSize / (1024 * 1024)).toFixed(1);
-                rejectedFiles.push(`${fileName}: 文件过大 (${(fileSize / (1024 * 1024)).toFixed(2)}MB > ${sizeMB}MB)`);
+                rejectedFiles.push(`${fileName}: ${i18n.t('drag_drop:errors.file_too_large', { size: sizeMB })}`);
                 emitDebugEvent(zoneId, 'validation_failed', 'warning', `文件过大: ${fileName}`, {
                   fileName,
                   fileSize: `${(fileSize / (1024 * 1024)).toFixed(2)}MB`,

--- a/tests/vitest/useTauriDragAndDrop.test.tsx
+++ b/tests/vitest/useTauriDragAndDrop.test.tsx
@@ -20,10 +20,25 @@ vi.mock('@tauri-apps/api/webview', () => ({
   }),
 }));
 
+// 返回 key 并附带插值参数，便于断言用户可见文案走了 i18n key 而非硬编码
 vi.mock('@/i18n', () => ({
   default: {
-    t: (key: string) => key,
+    t: (key: string, options?: Record<string, unknown>) => {
+      const vars = Object.entries(options ?? {}).filter(([name]) => name !== 'defaultValue');
+      if (vars.length === 0) return key;
+      return `${key}{${vars.map(([name, value]) => `${name}=${String(value)}`).join(',')}}`;
+    },
   },
+}));
+
+const showGlobalNotificationMock = vi.hoisted(() => vi.fn());
+vi.mock('@/components/UnifiedNotification', () => ({
+  showGlobalNotification: showGlobalNotificationMock,
+}));
+
+const invokeMock = vi.hoisted(() => vi.fn());
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
 }));
 
 function createDragEvent(types: string[]) {
@@ -41,9 +56,20 @@ function createDragEvent(types: string[]) {
   };
 }
 
+function createVisibleDropZoneRef(): React.RefObject<HTMLElement> {
+  const element = document.createElement('div');
+  Object.defineProperties(element, {
+    offsetWidth: { configurable: true, value: 320 },
+    offsetHeight: { configurable: true, value: 160 },
+  });
+  document.body.appendChild(element);
+  return { current: element } as React.RefObject<HTMLElement>;
+}
+
 describe('useTauriDragAndDrop', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    invokeMock.mockResolvedValue(null);
     nativeDragDropHandler = null;
   });
 
@@ -149,5 +175,69 @@ describe('useTauriDragAndDrop', () => {
       'lesson.mp4',
       'materials.zip',
     ]);
+  });
+
+  it('surfaces unsupported-type rejections through drag_drop i18n keys instead of hardcoded Chinese', async () => {
+    const dropZoneRef = createVisibleDropZoneRef();
+    const onDropFiles = vi.fn();
+
+    renderHook(() =>
+      useTauriDragAndDrop({
+        dropZoneRef,
+        onDropFiles,
+      })
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(nativeDragDropHandler).not.toBeNull();
+
+    await act(async () => {
+      nativeDragDropHandler?.({ payload: { type: 'drop', paths: ['C:\\downloads\\program.exe'] } });
+    });
+    await vi.waitFor(() => expect(showGlobalNotificationMock).toHaveBeenCalled());
+
+    expect(onDropFiles).not.toHaveBeenCalled();
+    const [type, message] = showGlobalNotificationMock.mock.calls.at(-1) as [string, string];
+    expect(type).toBe('error');
+    expect(message).toContain('drag_drop:errors.all_files_failed');
+    expect(message).toContain('program.exe: drag_drop:errors.unsupported_type');
+    expect(message).not.toContain('不支持的文件类型');
+  });
+
+  it('surfaces oversize rejections through drag_drop i18n keys with the size limit interpolated', async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'get_file_size') return 10 * 1024 * 1024;
+      if (command === 'read_file_bytes') return new ArrayBuffer(4);
+      return null;
+    });
+    const dropZoneRef = createVisibleDropZoneRef();
+    const onDropFiles = vi.fn();
+
+    renderHook(() =>
+      useTauriDragAndDrop({
+        dropZoneRef,
+        onDropFiles,
+        maxFileSize: 2 * 1024 * 1024,
+      })
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(nativeDragDropHandler).not.toBeNull();
+
+    await act(async () => {
+      nativeDragDropHandler?.({ payload: { type: 'drop', paths: ['/tmp/huge-notes.pdf'] } });
+    });
+    await vi.waitFor(() => expect(showGlobalNotificationMock).toHaveBeenCalled());
+
+    expect(onDropFiles).not.toHaveBeenCalled();
+    const [type, message] = showGlobalNotificationMock.mock.calls.at(-1) as [string, string];
+    expect(type).toBe('error');
+    expect(message).toContain('drag_drop:errors.all_files_failed');
+    expect(message).toContain('huge-notes.pdf: drag_drop:errors.file_too_large{size=2.0}');
+    expect(message).not.toContain('文件过大');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

桌面拖放 hook 把「不支持的文件类型 / 文件过大」硬编码中文写进 `all_files_failed` 的 reason，英文界面会漏出中文。改为复用已有 `drag_drop` key，不改 locale 文件。

### Changes
- `useTauriDragAndDrop`：拒绝原因改走 `drag_drop:errors.unsupported_type` / `file_too_large`
- 补 vitest：不支持类型与超限两条路径断言通知走 i18n key

### How to test
- `npx vitest run tests/vitest/useTauriDragAndDrop.test.tsx`
- 英文界面下拖入不支持类型或超限文件，通知应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

