### PR TITLE
fix(updater): 更新失败文案走已有 settings i18n

### DIFF
--- a/src/hooks/__tests__/useAppUpdater.i18n.test.ts
+++ b/src/hooks/__tests__/useAppUpdater.i18n.test.ts
@@ -1,0 +1,123 @@
+/**
+ * useAppUpdater i18n regression tests
+ *
+ * 验证下载/安装失败路径的用户可见 error.message 来自 i18n key
+ * （settings:about.update.error.*），不再包含硬编码中文文案。
+ */
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { checkMock, relaunchMock } = vi.hoisted(() => ({
+  checkMock: vi.fn(),
+  relaunchMock: vi.fn(),
+}));
+
+vi.mock('@/i18n', () => ({
+  default: {
+    t: (key: string) => key,
+  },
+}));
+
+vi.mock('@tauri-apps/plugin-updater', () => ({
+  check: checkMock,
+}));
+
+vi.mock('@tauri-apps/plugin-process', () => ({
+  relaunch: relaunchMock,
+}));
+
+vi.mock('@/utils/platform', () => ({
+  isMobilePlatform: () => false,
+}));
+
+vi.mock('@/utils/urlOpener', () => ({
+  openLink: vi.fn(),
+}));
+
+import { useAppUpdater } from '@/hooks/useAppUpdater';
+
+const CJK_PATTERN = /[\u4e00-\u9fff]/;
+
+describe('useAppUpdater error message i18n', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    // 关闭启动自动检查，避免测试期间的定时器副作用
+    localStorage.setItem('ds-update-frequency', 'never');
+  });
+
+  it('uses the i18n unavailable key when check() finds no update before install', async () => {
+    checkMock.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAppUpdater());
+
+    await act(async () => {
+      await result.current.downloadAndInstall();
+    });
+
+    expect(checkMock).toHaveBeenCalledTimes(1);
+    expect(result.current.downloading).toBe(false);
+    expect(result.current.error).toEqual({
+      phase: 'unavailable',
+      message: 'settings:about.update.error.unavailable',
+    });
+    expect(result.current.error!.message).not.toMatch(CJK_PATTERN);
+  });
+
+  it('uses the i18n relaunch key when relaunch() fails after install', async () => {
+    checkMock.mockResolvedValue({
+      version: '99.0.0',
+      date: undefined,
+      body: undefined,
+      downloadAndInstall: vi.fn(async (onEvent: (event: any) => void) => {
+        onEvent({ event: 'Started', data: { contentLength: 10 } });
+        onEvent({ event: 'Progress', data: { chunkLength: 10 } });
+        onEvent({ event: 'Finished' });
+      }),
+    });
+    relaunchMock.mockRejectedValue(new Error('relaunch blocked'));
+
+    const { result } = renderHook(() => useAppUpdater());
+
+    await act(async () => {
+      await result.current.downloadAndInstall();
+    });
+
+    expect(relaunchMock).toHaveBeenCalledTimes(1);
+    expect(result.current.downloading).toBe(false);
+    expect(result.current.progress).toBe(100);
+    expect(result.current.error).toEqual({
+      phase: 'relaunch',
+      message: 'settings:about.update.error.relaunch',
+    });
+    expect(result.current.error!.message).not.toMatch(CJK_PATTERN);
+  });
+
+  it('uses the i18n relaunch key when a post-install error is thrown after Finished', async () => {
+    checkMock.mockResolvedValue({
+      version: '99.0.0',
+      date: undefined,
+      body: undefined,
+      downloadAndInstall: vi.fn(async (onEvent: (event: any) => void) => {
+        onEvent({ event: 'Started', data: { contentLength: 10 } });
+        onEvent({ event: 'Progress', data: { chunkLength: 10 } });
+        onEvent({ event: 'Finished' });
+        throw new Error('app bundle replaced');
+      }),
+    });
+
+    const { result } = renderHook(() => useAppUpdater());
+
+    await act(async () => {
+      await result.current.downloadAndInstall();
+    });
+
+    expect(relaunchMock).not.toHaveBeenCalled();
+    expect(result.current.downloading).toBe(false);
+    expect(result.current.error).toEqual({
+      phase: 'relaunch',
+      message: 'settings:about.update.error.relaunch',
+    });
+    expect(result.current.error!.message).not.toMatch(CJK_PATTERN);
+  });
+});

--- a/src/hooks/useAppUpdater.ts
+++ b/src/hooks/useAppUpdater.ts
@@ -7,6 +7,7 @@
  * - Android/iOS 走应用商店，不使用此机制
  */
 import { useState, useCallback, useEffect, useRef } from 'react';
+import i18n from '@/i18n';
 import { isMobilePlatform } from '../utils/platform';
 import { openLink } from '../utils/urlOpener';
 
@@ -449,7 +450,7 @@ export function useAppUpdater(): AppUpdaterController {
       }
 
       if (!update) {
-        setState(prev => ({ ...prev, downloading: false, error: { phase: 'unavailable', message: '更新已不可用，请稍后重试' } }));
+        setState(prev => ({ ...prev, downloading: false, error: { phase: 'unavailable', message: i18n.t('settings:about.update.error.unavailable') } }));
         return;
       }
       pendingUpdateRef.current = null;
@@ -493,7 +494,7 @@ export function useAppUpdater(): AppUpdaterController {
           progress: 100,
           error: {
             phase: 'relaunch',
-            message: '更新已安装，请手动重启应用以完成更新',
+            message: i18n.t('settings:about.update.error.relaunch'),
           },
         }));
       }
@@ -512,7 +513,7 @@ export function useAppUpdater(): AppUpdaterController {
             downloading: false,
             error: {
               phase: 'relaunch',
-              message: '更新已安装，请手动重启应用以完成更新',
+              message: i18n.t('settings:about.update.error.relaunch'),
             },
           };
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`useAppUpdater` 在「更新已不可用」和「请手动重启」两条用户可见路径写了硬编码中文。改为使用已有 `settings:about.update.error.unavailable` / `relaunch`，不改被占用的 `settings.json`。

### Changes
- `useAppUpdater`：三处 `error.message` 改走 i18n
- 新增 i18n 路径测试（无 update / relaunch 失败）

### How to test
- `npx vitest run src/hooks/__tests__/useAppUpdater.i18n.test.ts`
- 英文界面下模拟更新不可用或安装后重启失败，错误应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

