### PR TITLE
fix(settings): 系统设置校验错误 i18n 并展示明细

### DIFF
--- a/src/features/settings/components/SystemSettingsSection.tsx
+++ b/src/features/settings/components/SystemSettingsSection.tsx
@@ -194,7 +194,8 @@ export const SystemSettingsSection: React.FC = () => {
   const handleSaveAll = async () => {
     const errors = validateSettings(settings);
     if (errors.length > 0) {
-      showGlobalNotification('warning', t('common:system_settings.validation_failed', { errors: errors.join(', ') }));
+      // common:system_settings.validation_failed 没有 {{errors}} 插值，明细需在此手动拼接
+      showGlobalNotification('warning', `${t('common:system_settings.validation_failed')} ${errors.join('；')}`);
       return;
     }
 

--- a/src/hooks/__tests__/useSystemSettings.validation.test.ts
+++ b/src/hooks/__tests__/useSystemSettings.validation.test.ts
@@ -1,0 +1,104 @@
+/**
+ * useSystemSettings.validateSettings i18n 合同测试
+ *
+ * 校验失败文案必须来自 forms:system_validation.* 命名空间（随当前语言解析），
+ * 而不是源码里的中文硬编码。
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// mock 掉真实 i18n 初始化；t(key) 原样返回 key，便于断言 hook 引用了 forms 命名空间
+vi.mock('@/i18n', () => ({ default: { t: (key: string) => key } }));
+
+import { useSystemSettings } from '../useSystemSettings';
+import zhForms from '@/locales/zh-CN/forms.json';
+import enForms from '@/locales/en-US/forms.json';
+
+const VALIDATION_KEYS = {
+  maxChatHistory: 'forms:system_validation.max_chat_history',
+  theme: 'forms:system_validation.theme',
+  language: 'forms:system_validation.language',
+  markdownRendererMode: 'forms:system_validation.markdown_renderer_mode',
+} as const;
+
+const renderValidateSettings = () => {
+  const { result, unmount } = renderHook(() => useSystemSettings());
+  return { validateSettings: result.current.validateSettings, unmount };
+};
+
+describe('useSystemSettings.validateSettings i18n', () => {
+  it('returns the forms i18n key (not hardcoded Chinese) for out-of-range maxChatHistory', () => {
+    const { validateSettings, unmount } = renderValidateSettings();
+
+    expect(validateSettings({ maxChatHistory: 5 })).toEqual([VALIDATION_KEYS.maxChatHistory]);
+    expect(validateSettings({ maxChatHistory: 2000 })).toEqual([VALIDATION_KEYS.maxChatHistory]);
+    // 边界值合法
+    expect(validateSettings({ maxChatHistory: 10 })).toEqual([]);
+    expect(validateSettings({ maxChatHistory: 1000 })).toEqual([]);
+
+    unmount();
+  });
+
+  it('returns the forms i18n key for an unsupported theme', () => {
+    const { validateSettings, unmount } = renderValidateSettings();
+
+    expect(validateSettings({ theme: 'neon' })).toEqual([VALIDATION_KEYS.theme]);
+    for (const theme of ['light', 'dark', 'auto']) {
+      expect(validateSettings({ theme })).toEqual([]);
+    }
+
+    unmount();
+  });
+
+  it('returns the forms i18n keys for unsupported language / markdown renderer mode', () => {
+    const { validateSettings, unmount } = renderValidateSettings();
+
+    expect(validateSettings({ language: 'fr-FR' })).toEqual([VALIDATION_KEYS.language]);
+    expect(
+      validateSettings({ markdownRendererMode: 'fancy' as unknown as 'legacy' }),
+    ).toEqual([VALIDATION_KEYS.markdownRendererMode]);
+
+    unmount();
+  });
+
+  it('accumulates all errors and never emits source-hardcoded text', () => {
+    const { validateSettings, unmount } = renderValidateSettings();
+
+    const errors = validateSettings({
+      maxChatHistory: 0,
+      theme: 'sepia',
+      language: 'ja-JP',
+      markdownRendererMode: 'fancy' as unknown as 'enhanced',
+    });
+
+    expect(errors).toEqual([
+      VALIDATION_KEYS.maxChatHistory,
+      VALIDATION_KEYS.theme,
+      VALIDATION_KEYS.language,
+      VALIDATION_KEYS.markdownRendererMode,
+    ]);
+    // key-echo mock 下若源码仍硬编码中文会在这里泄漏
+    expect(errors.join('')).not.toMatch(/必须/);
+
+    unmount();
+  });
+
+  it('has zh-CN and en-US translations for every validation key', () => {
+    const zh = (zhForms as Record<string, Record<string, string>>).system_validation;
+    const en = (enForms as Record<string, Record<string, string>>).system_validation;
+
+    for (const fullKey of Object.values(VALIDATION_KEYS)) {
+      const leaf = fullKey.replace('forms:system_validation.', '');
+      expect(zh?.[leaf], `zh-CN forms.json missing system_validation.${leaf}`).toBeTruthy();
+      expect(en?.[leaf], `en-US forms.json missing system_validation.${leaf}`).toBeTruthy();
+      expect(zh[leaf]).not.toBe(en[leaf]);
+    }
+
+    // 语义抽查：范围与枚举值保持不变（10–1000 / light|dark|auto / zh-CN|en-US / legacy|enhanced）
+    expect(zh.max_chat_history).toMatch(/10-1000/);
+    expect(en.max_chat_history).toMatch(/10 and 1000/);
+    expect(en.theme).toMatch(/light, dark, or auto/);
+    expect(en.language).toMatch(/zh-CN or en-US/);
+    expect(en.markdown_renderer_mode).toMatch(/legacy or enhanced/);
+  });
+});

--- a/src/hooks/useSystemSettings.ts
+++ b/src/hooks/useSystemSettings.ts
@@ -5,6 +5,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { invoke as tauriInvoke } from '@tauri-apps/api/core';
+import i18n from '@/i18n';
 import { useEventRegistry } from './useEventRegistry';
 
 // 系统设置接口
@@ -175,32 +176,32 @@ export const useSystemSettings = () => {
     return success;
   }, [saveSetting]);
 
-  // 验证设置
+  // 验证设置（返回当前语言的 i18n 文案，见 forms:system_validation.*）
   const validateSettings = useCallback((settingsToValidate: Partial<SystemSettings>) => {
     const errors: string[] = [];
     
     if (settingsToValidate.maxChatHistory !== undefined) {
       if (settingsToValidate.maxChatHistory < 10 || settingsToValidate.maxChatHistory > 1000) {
-        errors.push('最大聊天历史记录数量必须在10-1000之间');
+        errors.push(i18n.t('forms:system_validation.max_chat_history'));
       }
     }
     
     if (settingsToValidate.theme !== undefined) {
       // 支持所有主题模式
       if (!['light', 'dark', 'auto'].includes(settingsToValidate.theme)) {
-        errors.push('主题必须是 light、dark 或 auto');
+        errors.push(i18n.t('forms:system_validation.theme'));
       }
     }
     
     if (settingsToValidate.language !== undefined) {
       if (!['zh-CN', 'en-US'].includes(settingsToValidate.language)) {
-        errors.push('语言必须是zh-CN或en-US');
+        errors.push(i18n.t('forms:system_validation.language'));
       }
     }
 
     if (settingsToValidate.markdownRendererMode !== undefined) {
       if (!['legacy', 'enhanced'].includes(settingsToValidate.markdownRendererMode)) {
-        errors.push('Markdown 渲染模式必须是 legacy 或 enhanced');
+        errors.push(i18n.t('forms:system_validation.markdown_renderer_mode'));
       }
     }
     

--- a/src/locales/en-US/forms.json
+++ b/src/locales/en-US/forms.json
@@ -3,6 +3,11 @@
     "configured": "Configured",
     "not_configured": "Not configured",
     "to_be_configured": "Pending configuration"
+  },
+  "system_validation": {
+    "language": "Language must be zh-CN or en-US",
+    "markdown_renderer_mode": "Markdown renderer mode must be legacy or enhanced",
+    "max_chat_history": "Max chat history must be between 10 and 1000",
+    "theme": "Theme must be light, dark, or auto"
   }
 }
-

--- a/src/locales/zh-CN/forms.json
+++ b/src/locales/zh-CN/forms.json
@@ -3,7 +3,11 @@
     "not_configured": "未配置",
     "configured": "已配置",
     "to_be_configured": "待配置"
+  },
+  "system_validation": {
+    "max_chat_history": "最大聊天历史记录数量必须在10-1000之间",
+    "theme": "主题必须是 light、dark 或 auto",
+    "language": "语言必须是 zh-CN 或 en-US",
+    "markdown_renderer_mode": "Markdown 渲染模式必须是 legacy 或 enhanced"
   }
 }
-
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

「保存全部」校验失败时，明细是硬编码中文，且 `common:system_settings.validation_failed` 没有 `{{errors}}`，用户看不到具体原因。校验文案改走空闲的 `forms` 命名空间，通知里直接拼接明细。不改被占用的 `common.json` / `settings.json`。

### Changes
- `useSystemSettings.validateSettings` 改走 `forms:system_validation.*`
- `SystemSettingsSection` 保存失败通知附带具体错误
- zh-CN / en-US `forms.json` 补四个 key
- 新增校验合同测试

### How to test
- `npx vitest run src/hooks/__tests__/useSystemSettings.validation.test.ts`
- 把会话消息上限改到范围外后点「保存全部」，通知应包含具体校验说明；英文界面应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

