### PR TITLE
fix(i18n): 笔记 agent 错误文案走 forms 命名空间

### DIFF
--- a/src/features/workbench/agent/__tests__/noteDriver.test.ts
+++ b/src/features/workbench/agent/__tests__/noteDriver.test.ts
@@ -4,6 +4,10 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CrepeEditorApi } from '@/components/crepe/types';
+
+// error 文案走 i18n（forms:note_driver.*）：key-echo mock 让断言与语言无关
+vi.mock('@/i18n', () => ({ default: { t: (key: string) => key } }));
+
 import {
   __resetContentDirtyRegistry,
   registerContentDirtyChecker,
@@ -242,12 +246,12 @@ describe('computeDestructiveMarkdown', () => {
     ).toEqual({ content: 'hi world hi' });
   });
 
-  it('note_replace 空 search → error', () => {
+  it('note_replace 空 search → error（forms key，非硬编码文案）', () => {
     const r = computeDestructiveMarkdown('x', {
       kind: 'note_replace',
       payload: { search: '', replace: 'y' },
     });
-    expect(r.error).toBeTruthy();
+    expect(r.error).toBe('forms:note_driver.empty_search_pattern');
   });
 
   it('note_replace 零命中 → error，不伪造 applied', () => {
@@ -255,13 +259,19 @@ describe('computeDestructiveMarkdown', () => {
       kind: 'note_replace',
       payload: { search: 'missing', replace: 'new' },
     });
-    expect(literal).toEqual({ content: 'hello', error: '未找到要替换的内容' });
+    expect(literal).toEqual({
+      content: 'hello',
+      error: 'forms:note_driver.replacement_not_found',
+    });
 
     const regex = computeDestructiveMarkdown('hello', {
       kind: 'note_replace',
       payload: { search: 'z+', replace: 'new', isRegex: true },
     });
-    expect(regex).toEqual({ content: 'hello', error: '未找到要替换的内容' });
+    expect(regex).toEqual({
+      content: 'hello',
+      error: 'forms:note_driver.replacement_not_found',
+    });
   });
 });
 
@@ -757,6 +767,47 @@ describe('noteDriver apply — suggestion / clean destructive / typewriter', () 
     expect(receipt.status).toBe('completed');
     expect(api.getFullMarkdown()).toBe(`${visible}${hidden}\ntrue-end`);
     expect(api.getFullMarkdown()).toContain('hidden-602');
+  });
+
+  it('窗口化长笔记 offset / 缺标题锚点 → 上报 forms key 而非硬编码文案', async () => {
+    const visible = 'visible prefix';
+    const full = `${visible}\nhidden tail`;
+    const api = makeEditorApi({ markdown: visible, windowedFullMarkdown: full });
+    registerNoteEditor(NOTE_ID, api as unknown as CrepeEditorApi);
+    const run = makeRun();
+
+    const receipt = await noteDriver.apply(run, [
+      {
+        kind: 'note_insert',
+        destructive: false,
+        label: 'offset 插入',
+        anchor: { position: 'offset', offset: 3 },
+        payload: { content: 'x' },
+      },
+      {
+        kind: 'note_insert',
+        destructive: false,
+        label: '缺标题插入',
+        anchor: { position: 'afterHeading' },
+        payload: { content: 'y' },
+      },
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['offset 插入', '缺标题插入']);
+    expect(run.reportProgress).toHaveBeenCalledWith(
+      1,
+      2,
+      'forms:note_driver.windowed_offset_unsupported',
+      NOTE_ID,
+    );
+    expect(run.reportProgress).toHaveBeenCalledWith(
+      2,
+      2,
+      'forms:note_driver.after_heading_missing_title',
+      NOTE_ID,
+    );
+    expect(api.getFullMarkdown()).toBe(full);
   });
 
   it('用户在 Agent 写入后继续编辑时，inverse 以 OCC 冲突拒绝且不覆盖用户内容', async () => {

--- a/src/features/workbench/agent/drivers/noteDriver.ts
+++ b/src/features/workbench/agent/drivers/noteDriver.ts
@@ -12,6 +12,7 @@
  * 锚点对齐 R1-03：{ heading?, position: 'end'|'afterHeading' }
  */
 import { editorViewCtx } from '@milkdown/kit/core';
+import i18n from '@/i18n';
 import type { CrepeEditorApi } from '@/components/crepe/types';
 import {
   agentHighlightKey,
@@ -493,7 +494,7 @@ export function computeDestructiveMarkdown(
     const searchPattern = payload.search ?? '';
     const replaceWith = payload.replace ?? '';
     if (!searchPattern) {
-      return { content: original, error: '搜索模式为空' };
+      return { content: original, error: i18n.t('forms:note_driver.empty_search_pattern') };
     }
     if (payload.isRegex) {
       try {
@@ -505,21 +506,28 @@ export function computeDestructiveMarkdown(
         });
         return replaceCount > 0
           ? { content }
-          : { content: original, error: '未找到要替换的内容' };
+          : { content: original, error: i18n.t('forms:note_driver.replacement_not_found') };
       } catch (err) {
         return {
           content: original,
-          error: `无效的正则表达式: ${err instanceof Error ? err.message : '语法错误'}`,
+          error: i18n.t('forms:note_driver.invalid_regex', {
+            message: err instanceof Error
+              ? err.message
+              : i18n.t('forms:note_driver.regex_syntax_error'),
+          }),
         };
       }
     }
     if (!original.includes(searchPattern)) {
-      return { content: original, error: '未找到要替换的内容' };
+      return { content: original, error: i18n.t('forms:note_driver.replacement_not_found') };
     }
     return { content: original.split(searchPattern).join(replaceWith) };
   }
 
-  return { content: original, error: `不支持的破坏类 op：${op.kind}` };
+  return {
+    content: original,
+    error: i18n.t('forms:note_driver.unsupported_destructive_op', { kind: op.kind }),
+  };
 }
 
 /** 仅编辑器 DOM 真实持焦时视为 hot；失焦后保留的 selection 快照不算。 */
@@ -971,12 +979,14 @@ function computeWindowedInsertion(
   if (position === 'offset') {
     return {
       content: original,
-      error: '窗口化长笔记不支持 ProseMirror offset 锚点，请使用 end 或 afterHeading',
+      error: i18n.t('forms:note_driver.windowed_offset_unsupported'),
     };
   }
 
   const heading = (anchor?.heading ?? anchor?.section ?? '').trim();
-  if (!heading) return { content: original, error: 'afterHeading 缺少标题' };
+  if (!heading) {
+    return { content: original, error: i18n.t('forms:note_driver.after_heading_missing_title') };
+  }
 
   let offset = 0;
   for (const line of original.split('\n')) {
@@ -992,7 +1002,7 @@ function computeWindowedInsertion(
     }
     offset += line.length + 1;
   }
-  return { content: original, error: `未找到标题「${heading}」` };
+  return { content: original, error: i18n.t('forms:note_driver.heading_not_found', { heading }) };
 }
 
 async function applyWindowedNoteInsert(

--- a/src/locales/en-US/forms.json
+++ b/src/locales/en-US/forms.json
@@ -3,6 +3,15 @@
     "configured": "Configured",
     "not_configured": "Not configured",
     "to_be_configured": "Pending configuration"
+  },
+  "note_driver": {
+    "empty_search_pattern": "Search pattern is empty",
+    "replacement_not_found": "No matching content found to replace",
+    "invalid_regex": "Invalid regular expression: {{message}}",
+    "regex_syntax_error": "syntax error",
+    "unsupported_destructive_op": "Unsupported destructive op: {{kind}}",
+    "windowed_offset_unsupported": "Windowed long notes do not support ProseMirror offset anchors; use end or afterHeading instead",
+    "after_heading_missing_title": "afterHeading anchor is missing a heading",
+    "heading_not_found": "Heading \"{{heading}}\" not found"
   }
 }
-

--- a/src/locales/zh-CN/forms.json
+++ b/src/locales/zh-CN/forms.json
@@ -3,7 +3,15 @@
     "not_configured": "未配置",
     "configured": "已配置",
     "to_be_configured": "待配置"
+  },
+  "note_driver": {
+    "empty_search_pattern": "搜索模式为空",
+    "replacement_not_found": "未找到要替换的内容",
+    "invalid_regex": "无效的正则表达式: {{message}}",
+    "regex_syntax_error": "语法错误",
+    "unsupported_destructive_op": "不支持的破坏类 op：{{kind}}",
+    "windowed_offset_unsupported": "窗口化长笔记不支持 ProseMirror offset 锚点，请使用 end 或 afterHeading",
+    "after_heading_missing_title": "afterHeading 缺少标题",
+    "heading_not_found": "未找到标题「{{heading}}」"
   }
 }
-
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`noteDriver` 把搜索/替换/锚点失败原因写成硬编码中文，英文界面的桌面笔记 AI 编辑会漏出中文。改为 `forms:note_driver.*`，不改被占用的 `notes.json` / `workbench.json`。

### Changes
- 8 处用户可见 `error` 改走 i18n（含插值：正则、op、标题）
- zh-CN / en-US `forms.json` 补 `note_driver` 组
- 更新既有失败路径测试为 key-echo，并补窗口化 offset / 缺标题用例

### How to test
- `npx vitest run src/features/workbench/agent/__tests__/noteDriver.test.ts`
- 英文界面下对笔记做一次会失败的替换/锚点编辑，错误应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

