### PR TITLE
fix(settings): OCR 引擎卡片上移/下移读屏与系统 OCR 描述 i18n

### DIFF
--- a/src/features/settings/components/OcrEngineCard.tsx
+++ b/src/features/settings/components/OcrEngineCard.tsx
@@ -59,7 +59,7 @@ interface OcrEngineCardProps {
 }
 
 export const OcrEngineCard: React.FC<OcrEngineCardProps> = ({ className, apiConfigs, toUnifiedModelInfo, getAllEnabledApis }) => {
-  const { t } = useTranslation(['settings', 'common']);
+  const { t } = useTranslation(['settings', 'common', 'forms']);
   
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -310,7 +310,7 @@ export const OcrEngineCard: React.FC<OcrEngineCardProps> = ({ className, apiConf
                   
                   <p className="text-2xs text-muted-foreground/50 leading-relaxed line-clamp-1">
                     {engine.engineType === 'system_ocr'
-                      ? (engine.description || '调用操作系统内置 OCR 引擎')
+                      ? (engine.description || t('forms:ocr.system_engine_description'))
                       : engine.engineType === 'generic_vlm'
                         ? engine.model
                         : (engine.description || engine.model)}
@@ -320,10 +320,10 @@ export const OcrEngineCard: React.FC<OcrEngineCardProps> = ({ className, apiConf
                 {/* 操作按钮(触屏常显) */}
                 <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 [@media(pointer:coarse)]:opacity-100 transition-opacity shrink-0">
                   {/* 触屏下放大到 ≥40px 触控目标，避免 20px 排序/删除按钮误触 */}
-                  <DsButton variant="ghost" size="icon" iconOnly onClick={() => handleMoveUp(index)} disabled={index === 0 || saving} className="!h-5 !w-5 !p-0 [@media(pointer:coarse)]:!h-10 [@media(pointer:coarse)]:!w-10 text-muted-foreground/40 hover:text-foreground disabled:invisible" title={t('settings:ocr.move_up')} aria-label="move up">
+                  <DsButton variant="ghost" size="icon" iconOnly onClick={() => handleMoveUp(index)} disabled={index === 0 || saving} className="!h-5 !w-5 !p-0 [@media(pointer:coarse)]:!h-10 [@media(pointer:coarse)]:!w-10 text-muted-foreground/40 hover:text-foreground disabled:invisible" title={t('settings:ocr.move_up')} aria-label={t('settings:ocr.move_up')}>
                     <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M6 3L9 7H3L6 3Z" fill="currentColor"/></svg>
                   </DsButton>
-                  <DsButton variant="ghost" size="icon" iconOnly onClick={() => handleMoveDown(index)} disabled={index === engines.length - 1 || saving} className="!h-5 !w-5 !p-0 [@media(pointer:coarse)]:!h-10 [@media(pointer:coarse)]:!w-10 text-muted-foreground/40 hover:text-foreground disabled:invisible" title={t('settings:ocr.move_down')} aria-label="move down">
+                  <DsButton variant="ghost" size="icon" iconOnly onClick={() => handleMoveDown(index)} disabled={index === engines.length - 1 || saving} className="!h-5 !w-5 !p-0 [@media(pointer:coarse)]:!h-10 [@media(pointer:coarse)]:!w-10 text-muted-foreground/40 hover:text-foreground disabled:invisible" title={t('settings:ocr.move_down')} aria-label={t('settings:ocr.move_down')}>
                     <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M6 9L3 5H9L6 9Z" fill="currentColor"/></svg>
                   </DsButton>
                   {engine.engineType !== 'system_ocr' && (

--- a/src/features/settings/components/__tests__/OcrEngineCard.a11y.test.tsx
+++ b/src/features/settings/components/__tests__/OcrEngineCard.a11y.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * OcrEngineCard 可访问性 / i18n 契约测试
+ *
+ * 背景（两处用户可见/读屏问题）：
+ * 1. 上移/下移图标按钮的 title 走 settings:ocr.move_up / move_down，
+ *    但 aria-label 曾是硬编码英文 "move up" / "move down"，读屏用户听到的
+ *    与界面提示语言不一致。
+ * 2. 系统 OCR 引擎缺省描述曾是源码硬编码中文「调用操作系统内置 OCR 引擎」，
+ *    英文用户也只能看到中文。现改走 forms:ocr.system_engine_description。
+ */
+
+import React from 'react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import zhSettings from '@/locales/zh-CN/settings.json';
+import zhForms from '@/locales/zh-CN/forms.json';
+import enForms from '@/locales/en-US/forms.json';
+
+function lookup(obj: Record<string, unknown>, key: string): unknown {
+  return key.split('.').reduce<unknown>((acc, part) => {
+    if (acc && typeof acc === 'object' && part in (acc as object)) {
+      return (acc as Record<string, unknown>)[part];
+    }
+    return undefined;
+  }, obj);
+}
+
+// settings 用 zh-CN、forms 故意用 en-US：
+// 旧实现的硬编码 fallback 恰好等于 zh-CN 的 forms 文案，
+// 用 en-US 才能区分「走了 i18n」和「渲染了源码硬编码中文」。
+const NS_BUNDLES: Record<string, Record<string, unknown>> = {
+  settings: zhSettings as Record<string, unknown>,
+  forms: enForms as Record<string, unknown>,
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown> | string) => {
+      const [ns, bare] = key.includes(':') ? key.split(':', 2) : ['settings', key];
+      const bundle = NS_BUNDLES[ns];
+      const value = bundle ? lookup(bundle, bare) : undefined;
+      if (typeof value === 'string') return value;
+      if (typeof options === 'string') return options;
+      if (typeof options === 'object' && typeof options?.defaultValue === 'string') {
+        return options.defaultValue;
+      }
+      return key;
+    },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => undefined },
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: async (command: string) => {
+    switch (command) {
+      case 'get_available_ocr_models':
+        return [
+          {
+            configId: 'system-ocr',
+            model: 'system',
+            engineType: 'system_ocr',
+            name: 'System OCR',
+            isFree: true,
+            // 关键：无 description，触发 fallback 文案
+            supportsGrounding: false,
+            enabled: true,
+            priority: 0,
+          },
+          {
+            configId: 'vlm-1',
+            model: 'qwen-vl-max',
+            engineType: 'generic_vlm',
+            name: 'Qwen VL',
+            isFree: false,
+            supportsGrounding: true,
+            enabled: true,
+            priority: 1,
+          },
+        ];
+      case 'get_ocr_engines':
+        return [];
+      case 'get_ocr_thinking_enabled':
+        return false;
+      default:
+        return null;
+    }
+  },
+}));
+
+vi.mock('@/components/UnifiedNotification', () => ({
+  showGlobalNotification: vi.fn(),
+}));
+
+vi.mock('../OcrEngineTestPanel', () => ({
+  OcrEngineTestPanel: () => <div data-testid="ocr-test-panel" />,
+}));
+
+vi.mock('@/components/shared/UnifiedModelSelector', () => ({
+  UnifiedModelSelector: () => <div data-testid="unified-model-selector" />,
+}));
+
+vi.mock('@/components/ui/SiliconFlowLogo', () => ({
+  SiliconFlowLogo: () => <span data-testid="siliconflow-logo" />,
+}));
+
+import { OcrEngineCard } from '../OcrEngineCard';
+
+const zhOcr = (zhSettings as { ocr: Record<string, string> }).ocr;
+
+function renderCard() {
+  return render(
+    <OcrEngineCard
+      apiConfigs={[]}
+      toUnifiedModelInfo={() => []}
+      getAllEnabledApis={() => []}
+    />
+  );
+}
+
+describe('OcrEngineCard a11y & i18n', () => {
+  it('move up/down buttons expose localized aria-labels, not hardcoded English', async () => {
+    renderCard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Qwen VL')).toBeInTheDocument();
+    });
+
+    // aria-label 与 title 使用同一份 i18n 文案（每个引擎行各一对按钮）
+    expect(screen.getAllByRole('button', { name: zhOcr.move_up })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: zhOcr.move_down })).toHaveLength(2);
+
+    // 不再暴露硬编码英文可访问名
+    expect(screen.queryByRole('button', { name: 'move up' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'move down' })).toBeNull();
+  });
+
+  it('system OCR engine without description falls back to the forms i18n text', async () => {
+    renderCard();
+
+    await waitFor(() => {
+      expect(screen.getByText('System OCR')).toBeInTheDocument();
+    });
+
+    // forms 命名空间挂的是 en-US，因此渲染英文文案即证明走了 i18n
+    expect(
+      screen.getByText((enForms as typeof enForms).ocr.system_engine_description)
+    ).toBeInTheDocument();
+    // 源码硬编码中文不得再出现
+    expect(screen.queryByText('调用操作系统内置 OCR 引擎')).toBeNull();
+  });
+
+  it('both locales define forms:ocr.system_engine_description', () => {
+    expect(zhForms.ocr.system_engine_description).toBe('调用操作系统内置 OCR 引擎');
+    expect(enForms.ocr.system_engine_description).toBe(
+      'Uses the operating system built-in OCR engine'
+    );
+  });
+
+  it('source contract: no hardcoded a11y strings remain in OcrEngineCard.tsx', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/features/settings/components/OcrEngineCard.tsx'),
+      'utf-8'
+    );
+
+    expect(source).not.toContain('"move up"');
+    expect(source).not.toContain('"move down"');
+    expect(source).not.toContain('调用操作系统内置 OCR 引擎');
+
+    expect(source).toContain("aria-label={t('settings:ocr.move_up')}");
+    expect(source).toContain("aria-label={t('settings:ocr.move_down')}");
+    expect(source).toContain("t('forms:ocr.system_engine_description')");
+  });
+});

--- a/src/locales/en-US/forms.json
+++ b/src/locales/en-US/forms.json
@@ -3,6 +3,8 @@
     "configured": "Configured",
     "not_configured": "Not configured",
     "to_be_configured": "Pending configuration"
+  },
+  "ocr": {
+    "system_engine_description": "Uses the operating system built-in OCR engine"
   }
 }
-

--- a/src/locales/zh-CN/forms.json
+++ b/src/locales/zh-CN/forms.json
@@ -3,7 +3,8 @@
     "not_configured": "未配置",
     "configured": "已配置",
     "to_be_configured": "待配置"
+  },
+  "ocr": {
+    "system_engine_description": "调用操作系统内置 OCR 引擎"
   }
 }
-
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

OCR 引擎卡片上移/下移按钮的 `title` 已 i18n，但 `aria-label` 仍是 `"move up"` / `"move down"`；系统 OCR 无 description 时 fallback 是硬编码中文。读屏与英文界面分别漏出英文/中文。不改被占用的 `settings.json`。

### Changes
- 上移/下移 `aria-label` 与 `title` 共用 `settings:ocr.move_up` / `move_down`
- 系统 OCR 描述 fallback 走 `forms:ocr.system_engine_description`
- 新增 a11y 测试

### How to test
- `npx vitest run src/features/settings/components/__tests__/OcrEngineCard.a11y.test.tsx`
- 中文读屏：上移/下移应念「上移/下移」而不是 move up

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

