### PR TITLE
fix(skills): 技能列表图标按钮 aria-label 走已有 i18n

### DIFF
--- a/src/components/skills-management/SkillsList.tsx
+++ b/src/components/skills-management/SkillsList.tsx
@@ -181,7 +181,8 @@ export const SkillsList: React.FC<SkillsListProps> = ({
                   <DsButton variant="ghost" size="icon" iconOnly
                     onClick={(e) => { e.stopPropagation(); toggleFavorite(skill.id); }}
                     className={cn('!h-auto !w-auto !p-0 max-lg:!h-10 max-lg:!w-10 max-lg:-my-3 max-lg:-mx-1.5 flex-shrink-0 transition-opacity duration-200', isFavorite(skill.id) ? 'opacity-100 text-[color:hsl(var(--warning))]' : cn(isTouchPrimary ? 'opacity-100' : 'opacity-0 group-hover:opacity-100', 'text-muted-foreground/40 hover:text-[color:hsl(var(--warning))]'))}
-                    aria-label="favorite"
+                    title={isFavorite(skill.id) ? t('skills:favorite.remove') : t('skills:favorite.add')}
+                    aria-label={isFavorite(skill.id) ? t('skills:favorite.remove') : t('skills:favorite.add')}
                   >
                     <Star size={14} className={isFavorite(skill.id) ? 'fill-current' : ''} />
                   </DsButton>
@@ -267,19 +268,23 @@ export const SkillsList: React.FC<SkillsListProps> = ({
                       ? t('skills:package.enable')
                       : t('skills:package.disable')
                   }
-                  aria-label={isDisabledSkill ? 'enable-skill' : 'disable-skill'}
+                  aria-label={
+                    isDisabledSkill
+                      ? t('skills:package.enable')
+                      : t('skills:package.disable')
+                  }
                 >
                   {isDisabledSkill
                     ? t('skills:package.enable')
                     : t('skills:package.disable')}
                 </DsButton>
-                <DsButton variant="ghost" size="icon" iconOnly className="!p-1.5 text-muted-foreground/60 hover:text-foreground" onClick={() => { const cardEl = cardRefs.current[skill.id]; const rect = cardEl?.getBoundingClientRect(); onEdit(skill, rect); }} title={t('common:actions.edit')} aria-label="edit">
+                <DsButton variant="ghost" size="icon" iconOnly className="!p-1.5 text-muted-foreground/60 hover:text-foreground" onClick={() => { const cardEl = cardRefs.current[skill.id]; const rect = cardEl?.getBoundingClientRect(); onEdit(skill, rect); }} title={t('common:actions.edit')} aria-label={t('common:actions.edit')}>
                   <Pencil size={14} />
                 </DsButton>
 
                 <AppMenu>
                   <AppMenuTrigger asChild>
-                    <DsButton variant="ghost" size="icon" iconOnly className="!p-1.5 text-muted-foreground/60 hover:text-foreground" aria-label="more">
+                    <DsButton variant="ghost" size="icon" iconOnly className="!p-1.5 text-muted-foreground/60 hover:text-foreground" aria-label={t('common:more')}>
                       <DotsThree size={14} />
                     </DsButton>
                   </AppMenuTrigger>

--- a/src/components/skills-management/__tests__/SkillsList.a11y.test.ts
+++ b/src/components/skills-management/__tests__/SkillsList.a11y.test.ts
@@ -1,0 +1,69 @@
+/**
+ * SkillsList 图标按钮 aria-label i18n 契约测试
+ *
+ * 背景：可见 title/文本早已 i18n，但 aria-label 曾是英文硬编码
+ * （"favorite" / "enable-skill" / "disable-skill" / "edit" / "more"），
+ * 读屏在中文界面会念英文。本测试锁定 aria-label 走既有 i18n key，
+ * 防止硬编码字面量回归。
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(path.join(here, '../SkillsList.tsx'), 'utf8');
+
+const zhSkills = JSON.parse(
+  readFileSync(path.join(here, '../../../locales/zh-CN/skills.json'), 'utf8'),
+);
+const enSkills = JSON.parse(
+  readFileSync(path.join(here, '../../../locales/en-US/skills.json'), 'utf8'),
+);
+const zhCommon = JSON.parse(
+  readFileSync(path.join(here, '../../../locales/zh-CN/common.json'), 'utf8'),
+);
+const enCommon = JSON.parse(
+  readFileSync(path.join(here, '../../../locales/en-US/common.json'), 'utf8'),
+);
+
+describe('SkillsList icon button aria-label i18n contract', () => {
+  it('no longer hardcodes English aria-label literals', () => {
+    expect(source).not.toContain('aria-label="favorite"');
+    expect(source).not.toContain("'enable-skill'");
+    expect(source).not.toContain("'disable-skill'");
+    expect(source).not.toContain('aria-label="edit"');
+    expect(source).not.toContain('aria-label="more"');
+  });
+
+  it('favorite button aria-label switches between skills:favorite.add/remove', () => {
+    expect(source).toMatch(
+      /aria-label=\{isFavorite\(skill\.id\)\s*\?\s*t\('skills:favorite\.remove'\)\s*:\s*t\('skills:favorite\.add'\)\}/,
+    );
+  });
+
+  it('enable/disable toggle aria-label reuses skills:package.enable/disable', () => {
+    expect(source).toMatch(
+      /aria-label=\{\s*isDisabledSkill\s*\?\s*t\('skills:package\.enable'\)\s*:\s*t\('skills:package\.disable'\)\s*\}/,
+    );
+  });
+
+  it('edit and more buttons aria-label reuse common namespace keys', () => {
+    expect(source).toContain("aria-label={t('common:actions.edit')}");
+    expect(source).toContain("aria-label={t('common:more')}");
+  });
+
+  it('all referenced keys resolve to non-empty strings in zh-CN and en-US', () => {
+    for (const locale of [zhSkills, enSkills]) {
+      expect(locale.favorite.add).toBeTruthy();
+      expect(locale.favorite.remove).toBeTruthy();
+      expect(locale.package.enable).toBeTruthy();
+      expect(locale.package.disable).toBeTruthy();
+    }
+    for (const locale of [zhCommon, enCommon]) {
+      expect(locale.actions.edit).toBeTruthy();
+      expect(locale.more).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

技能列表收藏/启停/编辑/更多按钮的可见文案已 i18n，但 `aria-label` 仍是英文硬编码。改为复用已有 `skills:favorite.*`、`skills:package.enable/disable`、`common:actions.edit`、`common:more`，不改 locale 文件。

### Changes
- `SkillsList` 四处 aria-label 接线
- 新增源码契约测试

### How to test
- `npx vitest run src/components/skills-management/__tests__/SkillsList.a11y.test.ts`
- 中文读屏：收藏/编辑/更多应念中文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

