### PR TITLE
fix(a11y): 安全状态刷新按钮 aria-label 走已有 i18n

### DIFF
--- a/src/components/SecurityStatusIndicator.tsx
+++ b/src/components/SecurityStatusIndicator.tsx
@@ -110,7 +110,7 @@ export const SecurityStatusIndicator: React.FC<SecurityStatusIndicatorProps> = (
             <h3 className={`text-sm font-medium ${textClass}`}>
               {t('securityStatus.title')}
             </h3>
-            <DsButton variant="ghost" size="icon" iconOnly onClick={loadSecurityStatus} disabled={loading} className="!p-1 hover:bg-[var(--overlay-control-hover)]" title={t('securityStatus.refresh')} aria-label="refresh">
+            <DsButton variant="ghost" size="icon" iconOnly onClick={loadSecurityStatus} disabled={loading} className="!p-1 hover:bg-[var(--overlay-control-hover)]" title={t('securityStatus.refresh')} aria-label={t('securityStatus.refresh')}>
               <ArrowClockwise className={`w-3 h-3 ${loading ? 'animate-spin' : ''} ${textClass}`} />
             </DsButton>
           </div>

--- a/src/components/__tests__/SecurityStatusIndicator.a11y.test.ts
+++ b/src/components/__tests__/SecurityStatusIndicator.a11y.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const securityStatusIndicatorSource = readFileSync(
+  resolve(process.cwd(), 'src/components/SecurityStatusIndicator.tsx'),
+  'utf-8'
+);
+
+describe('SecurityStatusIndicator refresh button accessibility', () => {
+  it('localizes the refresh button aria-label with the same key as its title', () => {
+    expect(securityStatusIndicatorSource).toContain(
+      "title={t('securityStatus.refresh')} aria-label={t('securityStatus.refresh')}"
+    );
+  });
+
+  it('does not hardcode an English aria-label on the refresh button', () => {
+    expect(securityStatusIndicatorSource).not.toContain('aria-label="refresh"');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

安全状态指示器刷新按钮的 `title` 已是 `t('securityStatus.refresh')`，但 `aria-label` 仍是硬编码 `"refresh"`。改为共用同一 key，不改 locale。

### Changes
- `SecurityStatusIndicator` 刷新按钮 `aria-label` 接线
- 新增源码契约测试

### How to test
- `npx vitest run src/components/__tests__/SecurityStatusIndicator.a11y.test.ts`
- 中文读屏：刷新按钮应念「刷新状态」而不是 refresh

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

