### PR TITLE
fix(a11y): 文件夹选择器展开按钮 aria-label 走已有 i18n

### DIFF
--- a/src/features/learning-hub/components/finder/FolderPickerDialog.tsx
+++ b/src/features/learning-hub/components/finder/FolderPickerDialog.tsx
@@ -48,6 +48,7 @@ function FolderNode({
   onToggleExpand,
   parentExcluded = false,
 }: FolderNodeProps) {
+  const { t } = useTranslation('learningHub');
   const isExcluded = parentExcluded || excludeIds.has(node.folder.id);
   const isSelected = selectedId === node.folder.id;
   const isExpanded = expandedIds.has(node.folder.id);
@@ -105,7 +106,16 @@ function FolderNode({
         }}
       >
         {hasChildren ? (
-          <DsButton variant="ghost" size="icon" iconOnly tabIndex={-1} className="!h-5 !w-5 !p-0.5" onClick={(e) => { e.stopPropagation(); onToggleExpand(node.folder.id); }} aria-label="toggle">
+          <DsButton
+            variant="ghost"
+            size="icon"
+            iconOnly
+            tabIndex={-1}
+            className="!h-5 !w-5 !p-0.5"
+            onClick={(e) => { e.stopPropagation(); onToggleExpand(node.folder.id); }}
+            aria-label={isExpanded ? t('common:actions.collapse') : t('common:actions.expand')}
+            aria-expanded={isExpanded}
+          >
             <CaretRight 
               className={cn(
                 'transition-transform duration-200 ease-out',

--- a/src/features/learning-hub/components/finder/__tests__/folderPickerToggleA11y.source.test.ts
+++ b/src/features/learning-hub/components/finder/__tests__/folderPickerToggleA11y.source.test.ts
@@ -1,0 +1,43 @@
+/**
+ * FolderPickerDialog 树节点展开按钮无障碍 — source 守卫
+ *
+ * 回归防线：展开/收起按钮的 aria-label 曾硬编码英文 "toggle"，
+ * 屏幕阅读器用户（尤其非英文 locale）无法得知按钮语义与当前状态。
+ * 现约定：
+ * - aria-label 使用 common 命名空间既有 key（展开 actions.expand / 收起 actions.collapse），
+ *   不新增 locale 词条；
+ * - 按钮同时暴露 aria-expanded 反映展开状态。
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  path.join(process.cwd(), 'src/features/learning-hub/components/finder/FolderPickerDialog.tsx'),
+  'utf8'
+);
+
+describe('FolderPickerDialog tree toggle button accessibility', () => {
+  it('no longer hardcodes the english "toggle" aria-label', () => {
+    expect(source).not.toContain('aria-label="toggle"');
+  });
+
+  it('labels the toggle via existing common:actions keys, switching on expansion state', () => {
+    expect(source).toContain(
+      "aria-label={isExpanded ? t('common:actions.collapse') : t('common:actions.expand')}"
+    );
+  });
+
+  it('exposes aria-expanded on the toggle button', () => {
+    expect(source).toContain('aria-expanded={isExpanded}');
+  });
+
+  it('resolves t inside FolderNode so the label reacts to locale changes', () => {
+    const folderNodeBody = source.slice(
+      source.indexOf('function FolderNode('),
+      source.indexOf('export function FolderPickerDialog(')
+    );
+    expect(folderNodeBody).toContain("const { t } = useTranslation('learningHub');");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

文件夹选择器树节点展开按钮的 `aria-label="toggle"` 是硬编码英文。改为已有 `common:actions.expand` / `hide`，并补上 `aria-expanded`。不改 `finderStore` / `LearningHubSidebar`。

### Changes
- `FolderPickerDialog` 展开按钮 aria-label / aria-expanded
- 新增源码契约测试

### How to test
- 跑该 PR 新增的 vitest
- 中文读屏：展开/收起应念中文而不是 toggle

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

