### PR TITLE
fix(i18n): 待办 agent 错误文案走 todo:agent

### DIFF
--- a/src/features/workbench/agent/__tests__/todoDriver.i18n.test.ts
+++ b/src/features/workbench/agent/__tests__/todoDriver.i18n.test.ts
@@ -1,0 +1,235 @@
+/**
+ * todoDriver 用户/agent 可见错误文案 i18n 契约 — todo:agent.*
+ *
+ * key-echo mock：断言与语言无关（真实运行时由 todo.json 提供 zh-CN / en-US 文案，
+ * driver 侧 defaultValue 兜底 namespace 异步加载窗口期）。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { tSpy } = vi.hoisted(() => ({
+  tSpy: vi.fn((key: string) => key),
+}));
+vi.mock('@/i18n', () => ({ default: { t: tSpy } }));
+
+const { todoState, setActiveList, reloadCurrentView } = vi.hoisted(() => {
+  const todoState = {
+    activeListId: null as string | null,
+    selectedItemId: null as string | null,
+    error: null as string | null,
+    items: [] as unknown[],
+    lists: [] as unknown[],
+    overdueCount: 0,
+    filter: { view: 'all', search: '' },
+    isLoadingLists: false,
+    isLoadingItems: false,
+  };
+  return {
+    todoState,
+    setActiveList: vi.fn((id: string | null) => {
+      todoState.activeListId = id;
+    }),
+    reloadCurrentView: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock('@/features/todo/stores/useTodoStore', () => ({
+  useTodoStore: {
+    getState: () => ({
+      setActiveList,
+      reloadCurrentView,
+      selectItem: vi.fn(),
+      ...todoState,
+    }),
+  },
+}));
+
+import { todoDriver } from '../drivers/todoDriver';
+import type { AcrRunContext, AgentOp, Pacer, RunLedger } from '../types';
+
+function makeRun(runId: string): AcrRunContext {
+  const pacing: Pacer = {
+    profile: {
+      name: 'fast',
+      opIntervalMs: 0,
+      typeBatchMin: 1,
+      typeBatchMax: 1,
+      typeIntervalMs: 0,
+      instant: true,
+    },
+    tick: vi.fn(async () => undefined),
+    dispose: vi.fn(),
+  };
+  const ledger: RunLedger = {
+    record: vi.fn(),
+    revertRun: vi.fn(async () => true),
+    hasRun: vi.fn(() => false),
+    sealRun: vi.fn(),
+  };
+  return {
+    runId,
+    sessionId: 'session',
+    target: { typeId: 'todo' },
+    windowId: 'window',
+    pacing,
+    reportProgress: vi.fn(),
+    checkPaused: vi.fn(async () => 'resume'),
+    ledger,
+  };
+}
+
+function showList(listId: string, label = '打开清单'): AgentOp {
+  return { kind: 'todo_show_list', destructive: false, label, payload: { listId } };
+}
+
+beforeEach(() => {
+  tSpy.mockClear();
+  setActiveList.mockClear();
+  setActiveList.mockImplementation((id: string | null) => {
+    todoState.activeListId = id;
+  });
+  reloadCurrentView.mockClear();
+  reloadCurrentView.mockImplementation(async () => undefined);
+  todoState.activeListId = null;
+  todoState.error = null;
+});
+
+describe('todoDriver apply — 错误文案走 todo:agent.* key', () => {
+  it('目标清单未激活 → list_not_activated 包进 op_failed，不再硬编码中文', async () => {
+    setActiveList.mockImplementation(() => {
+      /* 清单激活失败：activeListId 保持 null */
+    });
+    const receipt = await todoDriver.apply(makeRun('run-not-activated'), [
+      showList('list-a'),
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['todo:agent.op_failed']);
+    expect(tSpy).toHaveBeenCalledWith(
+      'todo:agent.list_not_activated',
+      expect.objectContaining({ defaultValue: expect.any(String) }),
+    );
+    expect(tSpy).toHaveBeenCalledWith(
+      'todo:agent.op_failed',
+      expect.objectContaining({
+        label: '打开清单',
+        error: 'todo:agent.list_not_activated',
+      }),
+    );
+    // 全部失败时 message 回落到 unsupported hint（既有行为，仅文案换 key）
+    expect(receipt.message).toBe('todo:agent.unsupported_hint');
+  });
+
+  it('撤销失败：原清单未恢复 → undo_list_not_restored', async () => {
+    todoState.activeListId = 'list-old';
+    const run = makeRun('run-undo-not-restored');
+    const receipt = await todoDriver.apply(run, [showList('list-new')]);
+    expect(receipt.status).toBe('completed');
+    expect(run.ledger.record).toHaveBeenCalledTimes(1);
+
+    setActiveList.mockImplementation(() => {
+      /* 撤销时恢复失败：activeListId 停留在 list-new */
+    });
+    const inverse = vi.mocked(run.ledger.record).mock.calls[0]![1];
+    await expect(inverse()).rejects.toThrow('todo:agent.undo_list_not_restored');
+  });
+
+  it('撤销失败：store error → undo_failed 携带 {{error}}', async () => {
+    todoState.activeListId = 'list-old';
+    const run = makeRun('run-undo-failed');
+    await todoDriver.apply(run, [showList('list-new')]);
+    expect(run.ledger.record).toHaveBeenCalledTimes(1);
+
+    todoState.error = 'store 拒绝写入';
+    const inverse = vi.mocked(run.ledger.record).mock.calls[0]![1];
+    await expect(inverse()).rejects.toThrow('todo:agent.undo_failed');
+    expect(tSpy).toHaveBeenCalledWith(
+      'todo:agent.undo_failed',
+      expect.objectContaining({ error: 'store 拒绝写入' }),
+    );
+  });
+
+  it('缺少 listId → op_missing_list_id（label 作插值参数）', async () => {
+    const receipt = await todoDriver.apply(makeRun('run-missing-id'), [
+      { kind: 'todo_show_list', destructive: false, label: '切清单', payload: {} },
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['todo:agent.op_missing_list_id']);
+    expect(tSpy).toHaveBeenCalledWith(
+      'todo:agent.op_missing_list_id',
+      expect.objectContaining({ label: '切清单' }),
+    );
+  });
+
+  it('非导航 op → unsupported_hint 出现在 undone 与 message', async () => {
+    const receipt = await todoDriver.apply(makeRun('run-unsupported'), [
+      { kind: 'todo_create', destructive: true, label: '写数据', payload: {} },
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['写数据 — todo:agent.unsupported_hint']);
+    expect(receipt.message).toBe('todo:agent.unsupported_hint');
+  });
+
+  it('pacing 失败 → pacing_failed 携带底层错误', async () => {
+    const run = makeRun('run-pacing');
+    run.pacing.tick = vi.fn(async () => {
+      throw new Error('pacer failed');
+    });
+    const receipt = await todoDriver.apply(run, [showList('list-a')]);
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.message).toBe('todo:agent.pacing_failed');
+    expect(tSpy).toHaveBeenCalledWith(
+      'todo:agent.pacing_failed',
+      expect.objectContaining({ error: 'pacer failed' }),
+    );
+  });
+
+  it('暂停检查失败 → pause_check_failed 携带底层错误', async () => {
+    const run = makeRun('run-pause');
+    run.checkPaused = vi.fn(async () => {
+      throw new Error('pause boom');
+    });
+    const receipt = await todoDriver.apply(run, [showList('list-a')]);
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.message).toBe('todo:agent.pause_check_failed');
+    expect(tSpy).toHaveBeenCalledWith(
+      'todo:agent.pause_check_failed',
+      expect.objectContaining({ error: 'pause boom' }),
+    );
+  });
+});
+
+describe('todoDriver abort — 回执文案走 todo:agent.* key', () => {
+  it('运行中 abort → nav_aborted', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    reloadCurrentView.mockImplementationOnce(async () => {
+      await gate;
+    });
+
+    const run = makeRun('run-abort-live');
+    const applying = todoDriver.apply(run, [showList('list-a')]);
+    // 等 apply 走进 reloadCurrentView 的 gate
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const abortReceipt = todoDriver.abort('run-abort-live');
+    expect(abortReceipt.status).toBe('cancelled');
+    expect(abortReceipt.message).toBe('todo:agent.nav_aborted');
+
+    release();
+    const finalReceipt = await applying;
+    expect(finalReceipt.status).toBe('cancelled');
+  });
+
+  it('run 不存在 → run_not_found + run_ended', () => {
+    const receipt = todoDriver.abort('run-ghost');
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.message).toBe('todo:agent.run_not_found');
+    expect(receipt.undone).toEqual(['todo:agent.run_ended']);
+  });
+});

--- a/src/features/workbench/agent/drivers/todoDriver.ts
+++ b/src/features/workbench/agent/drivers/todoDriver.ts
@@ -6,6 +6,7 @@
  * 见 docs/dev/acr/DESIGN.md §5.3。
  */
 
+import i18n from '@/i18n';
 import { useTodoStore } from '@/features/todo/stores/useTodoStore';
 import type {
   AcrProbeState,
@@ -24,8 +25,14 @@ import { agentFlashMany } from '../visuals/agentFlash';
 
 const TYPE_ID = 'todo';
 
-const UNSUPPORTED_HINT =
-  '请用 user_todo 领域工具修改待办数据；本驱动仅支持导航类 op（todo_show_list）';
+// 用户/agent 可见文案统一走 i18n（todo:agent.*）；defaultValue 兜底
+// todo namespace 尚未完成异步加载的窗口期。语言可运行时切换，故用函数而非模块级常量。
+function unsupportedHint(): string {
+  return i18n.t('todo:agent.unsupported_hint', {
+    defaultValue:
+      '请用 user_todo 领域工具修改待办数据；本驱动仅支持导航类 op（todo_show_list）',
+  });
+}
 
 interface ActiveRun {
   runId: string;
@@ -37,6 +44,8 @@ interface ActiveRun {
   applied: number;
   totalOps: number;
   nextOpIndex: number;
+  /** 出现过非导航 op（message 文案已本地化，不能再靠字符串嗅探回执内容判断） */
+  sawUnsupported: boolean;
   inversesCommitted: boolean;
   pendingInverses: Array<{ invert: () => Promise<void>; label: string }>;
   ledger: AcrRunContext['ledger'];
@@ -87,7 +96,9 @@ async function applyShowList(listId: string): Promise<void> {
   }
   const after = useTodoStore.getState();
   if ('activeListId' in after && after.activeListId !== listId) {
-    throw new Error('目标清单未激活');
+    throw new Error(
+      i18n.t('todo:agent.list_not_activated', { defaultValue: '目标清单未激活' }),
+    );
   }
   if ('error' in after && after.error) {
     throw new Error(after.error);
@@ -101,10 +112,19 @@ async function restoreList(listId: string | null): Promise<void> {
   if (typeof store.reloadCurrentView === 'function') await store.reloadCurrentView();
   const after = useTodoStore.getState();
   if ('activeListId' in after && after.activeListId !== listId) {
-    throw new Error('撤销失败：原清单未恢复');
+    throw new Error(
+      i18n.t('todo:agent.undo_list_not_restored', {
+        defaultValue: '撤销失败：原清单未恢复',
+      }),
+    );
   }
   if ('error' in after && after.error) {
-    throw new Error(`撤销失败：${after.error}`);
+    throw new Error(
+      i18n.t('todo:agent.undo_failed', {
+        error: after.error,
+        defaultValue: '撤销失败：{{error}}',
+      }),
+    );
   }
 }
 
@@ -163,6 +183,7 @@ export const todoDriver: CollabDriver & {
       applied: 0,
       totalOps: ops.length,
       nextOpIndex: 0,
+      sawUnsupported: false,
       inversesCommitted: false,
       pendingInverses: [],
       ledger: run.ledger,
@@ -181,7 +202,10 @@ export const todoDriver: CollabDriver & {
         pause = await run.checkPaused();
       } catch (err) {
         state.aborted = true;
-        state.errorMessage = `暂停检查失败：${err instanceof Error ? err.message : String(err)}`;
+        state.errorMessage = i18n.t('todo:agent.pause_check_failed', {
+          error: err instanceof Error ? err.message : String(err),
+          defaultValue: '暂停检查失败：{{error}}',
+        });
         markRemaining(state);
         break;
       }
@@ -197,7 +221,12 @@ export const todoDriver: CollabDriver & {
       if (isNavShowList(op)) {
         const listId = payloadListId(op.payload);
         if (!listId) {
-          state.undone.push(`${op.label || op.kind}（缺少 listId）`);
+          state.undone.push(
+            i18n.t('todo:agent.op_missing_list_id', {
+              label: op.label || op.kind,
+              defaultValue: '{{label}}（缺少 listId）',
+            }),
+          );
         } else {
           try {
             const { useTodoStore } = await import(
@@ -220,18 +249,26 @@ export const todoDriver: CollabDriver & {
               await run.pacing.tick(listTickCost(run.pacing.profile));
             } catch (err) {
               state.aborted = true;
-              state.errorMessage = `节奏控制失败：${err instanceof Error ? err.message : String(err)}`;
+              state.errorMessage = i18n.t('todo:agent.pacing_failed', {
+                error: err instanceof Error ? err.message : String(err),
+                defaultValue: '节奏控制失败：{{error}}',
+              });
               markRemaining(state);
               break;
             }
           } catch (err) {
             state.undone.push(
-              `${op.label || op.kind}（失败: ${err instanceof Error ? err.message : String(err)}）`,
+              i18n.t('todo:agent.op_failed', {
+                label: op.label || op.kind,
+                error: err instanceof Error ? err.message : String(err),
+                defaultValue: '{{label}}（失败: {{error}}）',
+              }),
             );
           }
         }
       } else {
-        state.undone.push(`${op.label || op.kind} — ${UNSUPPORTED_HINT}`);
+        state.sawUnsupported = true;
+        state.undone.push(`${op.label || op.kind} — ${unsupportedHint()}`);
       }
       state.nextOpIndex = i + 1;
     }
@@ -257,9 +294,9 @@ export const todoDriver: CollabDriver & {
         undone: state.undone,
         message:
           state.errorMessage ?? (state.undone.length > 0 && state.applied === 0
-            ? UNSUPPORTED_HINT
-            : state.undone.some((u) => u.includes('user_todo'))
-              ? UNSUPPORTED_HINT
+            ? unsupportedHint()
+            : state.sawUnsupported
+              ? unsupportedHint()
               : undefined),
       }),
       TYPE_ID,
@@ -280,7 +317,9 @@ export const todoDriver: CollabDriver & {
           entityIds: state.entityIds,
           done: [...state.done],
           undone: [...state.undone],
-          message: 'todo 导航已中止',
+          message: i18n.t('todo:agent.nav_aborted', {
+            defaultValue: 'todo 导航已中止',
+          }),
         }),
         TYPE_ID,
       );
@@ -288,8 +327,10 @@ export const todoDriver: CollabDriver & {
     return withUserPatch(
       emptyReceipt({
         status: 'cancelled',
-        message: 'todo run 不存在或已结束',
-        undone: ['run 已结束'],
+        message: i18n.t('todo:agent.run_not_found', {
+          defaultValue: 'todo run 不存在或已结束',
+        }),
+        undone: [i18n.t('todo:agent.run_ended', { defaultValue: 'run 已结束' })],
       }),
       TYPE_ID,
     );

--- a/src/locales/en-US/todo.json
+++ b/src/locales/en-US/todo.json
@@ -819,5 +819,18 @@
   },
   "quickAdd": {
     "removeToken": "Remove"
+  },
+  "agent": {
+    "list_not_activated": "Target list was not activated",
+    "undo_list_not_restored": "Undo failed: the original list was not restored",
+    "undo_failed": "Undo failed: {{error}}",
+    "pause_check_failed": "Pause check failed: {{error}}",
+    "pacing_failed": "Pacing control failed: {{error}}",
+    "op_missing_list_id": "{{label}} (missing listId)",
+    "op_failed": "{{label}} (failed: {{error}})",
+    "unsupported_hint": "Use the user_todo domain tool to modify todo data; this driver only supports navigation ops (todo_show_list)",
+    "nav_aborted": "Todo navigation aborted",
+    "run_not_found": "Todo run does not exist or has already finished",
+    "run_ended": "Run already finished"
   }
 }

--- a/src/locales/zh-CN/todo.json
+++ b/src/locales/zh-CN/todo.json
@@ -819,5 +819,18 @@
   },
   "quickAdd": {
     "removeToken": "移除"
+  },
+  "agent": {
+    "list_not_activated": "目标清单未激活",
+    "undo_list_not_restored": "撤销失败：原清单未恢复",
+    "undo_failed": "撤销失败：{{error}}",
+    "pause_check_failed": "暂停检查失败：{{error}}",
+    "pacing_failed": "节奏控制失败：{{error}}",
+    "op_missing_list_id": "{{label}}（缺少 listId）",
+    "op_failed": "{{label}}（失败: {{error}}）",
+    "unsupported_hint": "请用 user_todo 领域工具修改待办数据；本驱动仅支持导航类 op（todo_show_list）",
+    "nav_aborted": "todo 导航已中止",
+    "run_not_found": "todo run 不存在或已结束",
+    "run_ended": "run 已结束"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`todoDriver` 把「目标清单未激活 / 撤销失败」等用户可见错误写成硬编码中文。改为 `todo:agent.*`，不改被占用的 `workbench.json` / `forms.json` / `common.json`。

### Changes
- `todoDriver` 用户可见 throw/error 走 i18n
- zh-CN / en-US `todo.json` 补 `agent` 组
- 新增或更新 key-echo 测试

### How to test
- 跑该 PR 新增/更新的 vitest
- 英文界面下触发清单切换失败，错误应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

