### PR TITLE
fix(i18n): FSRS agent 回执文案走 workspace:agent.fsrs

### DIFF
--- a/src/features/workbench/agent/__tests__/fsrsDriver.i18n.test.ts
+++ b/src/features/workbench/agent/__tests__/fsrsDriver.i18n.test.ts
@@ -1,0 +1,209 @@
+/**
+ * fsrsDriver 用户/agent 可见错误文案 i18n 契约 — workspace:agent.fsrs.*
+ *
+ * key-echo mock：断言与语言无关（真实运行时由 workspace.json 提供 zh-CN / en-US 文案，
+ * driver 侧 defaultValue 兜底 namespace 异步加载窗口期）。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { tSpy } = vi.hoisted(() => ({
+  tSpy: vi.fn((key: string) => key),
+}));
+vi.mock('@/i18n', () => ({ default: { t: tSpy } }));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async () => []),
+}));
+
+vi.mock('@/components/UnifiedNotification', () => ({
+  showGlobalNotification: vi.fn(),
+}));
+
+vi.mock('../visuals/agentFlash', () => ({
+  agentFlash: vi.fn(),
+  agentFlashMany: vi.fn(),
+}));
+
+import { useFsrsReviewStore, type ReviewCard } from '@/features/flashcards/store/fsrsReviewStore';
+import zhWorkspace from '@/locales/zh-CN/workspace.json';
+import enWorkspace from '@/locales/en-US/workspace.json';
+import { fsrsDriver } from '../drivers/fsrsDriver';
+import type { AcrRunContext, AgentOp, Pacer, RunLedger } from '../types';
+
+const card = (id: string, front = id): ReviewCard => ({
+  id,
+  ankiCardId: id,
+  front,
+  back: `back-${id}`,
+});
+
+function makeRun(runId: string): AcrRunContext {
+  const pacing: Pacer = {
+    profile: {
+      name: 'fast',
+      opIntervalMs: 0,
+      typeBatchMin: 1,
+      typeBatchMax: 1,
+      typeIntervalMs: 0,
+      instant: true,
+    },
+    tick: vi.fn(async () => undefined),
+    dispose: vi.fn(),
+  };
+  const ledger: RunLedger = {
+    record: vi.fn(),
+    revertRun: vi.fn(async () => true),
+    hasRun: vi.fn(() => false),
+    sealRun: vi.fn(),
+  };
+  return {
+    runId,
+    sessionId: 'session',
+    target: { typeId: 'flashcards' },
+    windowId: 'window',
+    pacing,
+    reportProgress: vi.fn(),
+    checkPaused: vi.fn(async () => 'resume'),
+    ledger,
+  };
+}
+
+function enqueueOp(cards: ReviewCard[], label = ''): AgentOp {
+  return { kind: 'fsrs_enqueue', destructive: false, label, payload: { cards } };
+}
+
+beforeEach(() => {
+  tSpy.mockClear();
+  useFsrsReviewStore.setState({
+    screen: 'session',
+    queue: [card('a')],
+    queueIndex: 0,
+    flipped: false,
+    loading: false,
+    ratingBusy: false,
+    usingMock: true,
+    error: null,
+    errorKind: null,
+    lastRated: null,
+    lastReview: null,
+    lastSuspended: null,
+    dueCards: [],
+  });
+});
+
+describe('fsrsDriver apply — 回执文案走 workspace:agent.fsrs.* key', () => {
+  it('checkPaused → abort：cancelled 回执 message 为 queue_not_reset，不再硬编码中文', async () => {
+    const run = makeRun('run-abort-pause');
+    run.checkPaused = vi.fn(async () => 'abort');
+
+    const receipt = await fsrsDriver.apply(run, [enqueueOp([card('d')], '入队新卡')]);
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.message).toBe('workspace:agent.fsrs.queue_not_reset');
+    expect(receipt.undone).toEqual(['入队新卡']);
+    expect(tSpy).toHaveBeenCalledWith(
+      'workspace:agent.fsrs.queue_not_reset',
+      expect.objectContaining({ defaultValue: '用户中断，复习队列未重置' }),
+    );
+  });
+
+  it('screen ≠ session：failed 回执 message 为 enqueue_requires_session', async () => {
+    useFsrsReviewStore.setState({ screen: 'today' });
+
+    const receipt = await fsrsDriver.apply(makeRun('run-not-session'), [
+      enqueueOp([card('d')], '入队新卡'),
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.message).toBe('workspace:agent.fsrs.enqueue_requires_session');
+    expect(tSpy).toHaveBeenCalledWith(
+      'workspace:agent.fsrs.enqueue_requires_session',
+      expect.objectContaining({
+        defaultValue: '无可应用的 fsrs_enqueue（需处于复习 session）',
+      }),
+    );
+  });
+
+  it('op.label 缺省时 done 兜底为 enqueued_cards（携带 count）', async () => {
+    const receipt = await fsrsDriver.apply(makeRun('run-done-fallback'), [
+      enqueueOp([card('d'), card('e')]),
+    ]);
+
+    expect(receipt.status).toBe('completed');
+    expect(receipt.done).toEqual(['workspace:agent.fsrs.enqueued_cards']);
+    expect(tSpy).toHaveBeenCalledWith(
+      'workspace:agent.fsrs.enqueued_cards',
+      expect.objectContaining({ count: 2 }),
+    );
+  });
+
+  it('全部卡已在队列时 undone 兜底为 already_in_queue（携带 kind）', async () => {
+    const receipt = await fsrsDriver.apply(makeRun('run-dup'), [
+      enqueueOp([card('a')]),
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['workspace:agent.fsrs.already_in_queue']);
+    expect(tSpy).toHaveBeenCalledWith(
+      'workspace:agent.fsrs.already_in_queue',
+      expect.objectContaining({ kind: 'fsrs_enqueue' }),
+    );
+  });
+});
+
+describe('fsrsDriver abort — 回执文案走 workspace:agent.fsrs.* key', () => {
+  it('运行中 abort → abort_queue_not_reset；apply 收尾回执为 queue_not_reset', async () => {
+    let release!: (value: 'resume' | 'abort') => void;
+    const gate = new Promise<'resume' | 'abort'>((resolve) => {
+      release = resolve;
+    });
+    const run = makeRun('run-abort-live');
+    run.checkPaused = vi.fn(() => gate);
+
+    const applying = fsrsDriver.apply(run, [enqueueOp([card('d')], '入队新卡')]);
+    // 等 apply 走进 checkPaused 的 gate
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const abortReceipt = fsrsDriver.abort('run-abort-live');
+    expect(abortReceipt.status).toBe('cancelled');
+    expect(abortReceipt.message).toBe('workspace:agent.fsrs.abort_queue_not_reset');
+    expect(tSpy).toHaveBeenCalledWith(
+      'workspace:agent.fsrs.abort_queue_not_reset',
+      expect.objectContaining({ defaultValue: 'flashcards 入队已中止（队列未重置）' }),
+    );
+
+    release('abort');
+    const finalReceipt = await applying;
+    expect(finalReceipt.status).toBe('cancelled');
+    expect(finalReceipt.message).toBe('workspace:agent.fsrs.queue_not_reset');
+  });
+
+  it('run 不存在 → abort_run_not_found（runId 作插值参数）', () => {
+    const receipt = fsrsDriver.abort('run-ghost');
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.message).toBe('workspace:agent.fsrs.abort_run_not_found');
+    expect(tSpy).toHaveBeenCalledWith(
+      'workspace:agent.fsrs.abort_run_not_found',
+      expect.objectContaining({ runId: 'run-ghost' }),
+    );
+  });
+});
+
+describe('workspace.json 契约 — agent.fsrs 键在 zh-CN / en-US 均存在', () => {
+  const keys = [
+    'queue_not_reset',
+    'enqueue_requires_session',
+    'enqueued_cards',
+    'already_in_queue',
+    'abort_queue_not_reset',
+    'abort_run_not_found',
+  ] as const;
+
+  it.each(keys)('agent.fsrs.%s', (key) => {
+    const zh = (zhWorkspace as { agent: { fsrs: Record<string, string> } }).agent.fsrs;
+    const en = (enWorkspace as { agent: { fsrs: Record<string, string> } }).agent.fsrs;
+    expect(zh[key], `zh-CN 缺少 agent.fsrs.${key}`).toBeTruthy();
+    expect(en[key], `en-US 缺少 agent.fsrs.${key}`).toBeTruthy();
+  });
+});

--- a/src/features/workbench/agent/drivers/fsrsDriver.ts
+++ b/src/features/workbench/agent/drivers/fsrsDriver.ts
@@ -167,6 +167,16 @@ function cardsFromCardMutationPayload(payload: unknown): ReviewCard[] {
   }));
 }
 
+/**
+ * 用户/agent 可见文案统一走 i18n（workspace:agent.fsrs.*）；defaultValue 兜底
+ * workspace namespace 尚未完成异步加载的窗口期。语言可运行时切换，故用函数而非模块级常量。
+ */
+function queueNotResetMessage(): string {
+  return i18n.t('workspace:agent.fsrs.queue_not_reset', {
+    defaultValue: '用户中断，复习队列未重置',
+  });
+}
+
 function notifyAppended(count: number): void {
   if (count <= 0) return;
   const message = i18n.t('workbench:agent.apps.flashcards.appended', {
@@ -303,7 +313,7 @@ export const fsrsDriver: CollabDriver & {
       const pause = state.aborted ? 'abort' : await run.checkPaused();
       if (pause === 'abort') {
         state.aborted = true;
-        return fsrsCancelledReceipt(state, '用户中断，复习队列未重置');
+        return fsrsCancelledReceipt(state, queueNotResetMessage());
       }
 
       const op = ops[i]!;
@@ -327,7 +337,13 @@ export const fsrsDriver: CollabDriver & {
               .queue.filter((card) => !beforeIds.has(card.id));
             if (added > 0 && addedCards.length === added) {
               state.applied += 1;
-              state.done.push(op.label || `入队 ${added} 张卡片`);
+              state.done.push(
+                op.label
+                  || i18n.t('workspace:agent.fsrs.enqueued_cards', {
+                    count: added,
+                    defaultValue: '入队 {{count}} 张卡片',
+                  }),
+              );
               for (const card of addedCards) {
                 if (!state.entityIds.includes(card.id)) state.entityIds.push(card.id);
               }
@@ -336,7 +352,13 @@ export const fsrsDriver: CollabDriver & {
               await awaitFrame();
               flashEntityIds(addedCards.map((card) => card.ankiCardId ?? card.id));
             } else {
-              state.undone.push(op.label || `${op.kind}（全部已在队列）`);
+              state.undone.push(
+                op.label
+                  || i18n.t('workspace:agent.fsrs.already_in_queue', {
+                    kind: op.kind,
+                    defaultValue: '{{kind}}（全部已在队列）',
+                  }),
+              );
             }
           }
         }
@@ -349,7 +371,7 @@ export const fsrsDriver: CollabDriver & {
     }
 
     if (state.aborted) {
-      return fsrsCancelledReceipt(state, '用户中断，复习队列未重置');
+      return fsrsCancelledReceipt(state, queueNotResetMessage());
     }
     fsrsActiveRuns.delete(run.runId);
 
@@ -372,7 +394,9 @@ export const fsrsDriver: CollabDriver & {
       undone: state.undone,
       message:
         status === 'failed'
-          ? '无可应用的 fsrs_enqueue（需处于复习 session）'
+          ? i18n.t('workspace:agent.fsrs.enqueue_requires_session', {
+              defaultValue: '无可应用的 fsrs_enqueue（需处于复习 session）',
+            })
           : undefined,
     };
   },
@@ -381,11 +405,19 @@ export const fsrsDriver: CollabDriver & {
     const state = fsrsActiveRuns.get(runId);
     if (state) {
       state.aborted = true;
-      return fsrsCancelledReceipt(state, 'flashcards 入队已中止（队列未重置）');
+      return fsrsCancelledReceipt(
+        state,
+        i18n.t('workspace:agent.fsrs.abort_queue_not_reset', {
+          defaultValue: 'flashcards 入队已中止（队列未重置）',
+        }),
+      );
     }
     return withUserPatch(
       emptyReceipt('cancelled', 0, {
-        message: `run ${runId} aborted（flashcards 队列未重置）`,
+        message: i18n.t('workspace:agent.fsrs.abort_run_not_found', {
+          runId,
+          defaultValue: 'run {{runId}} aborted（flashcards 队列未重置）',
+        }),
       }),
       TYPE_ID,
     );

--- a/src/locales/en-US/workspace.json
+++ b/src/locales/en-US/workspace.json
@@ -138,6 +138,14 @@
     }
   },
   "agent": {
-    "you": "You"
+    "you": "You",
+    "fsrs": {
+      "queue_not_reset": "Interrupted by user; the review queue was not reset",
+      "enqueue_requires_session": "No applicable fsrs_enqueue (requires an active review session)",
+      "enqueued_cards": "Enqueued {{count}} cards",
+      "already_in_queue": "{{kind}} (all cards already in queue)",
+      "abort_queue_not_reset": "Flashcards enqueue aborted (queue was not reset)",
+      "abort_run_not_found": "Run {{runId}} aborted (flashcards queue was not reset)"
+    }
   }
 }

--- a/src/locales/zh-CN/workspace.json
+++ b/src/locales/zh-CN/workspace.json
@@ -138,6 +138,14 @@
     }
   },
   "agent": {
-    "you": "你"
+    "you": "你",
+    "fsrs": {
+      "queue_not_reset": "用户中断，复习队列未重置",
+      "enqueue_requires_session": "无可应用的 fsrs_enqueue（需处于复习 session）",
+      "enqueued_cards": "入队 {{count}} 张卡片",
+      "already_in_queue": "{{kind}}（全部已在队列）",
+      "abort_queue_not_reset": "flashcards 入队已中止（队列未重置）",
+      "abort_run_not_found": "run {{runId}} aborted（flashcards 队列未重置）"
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`fsrsDriver` 把中断/enqueue 等用户可见回执写成硬编码中文。改为 `workspace:agent.fsrs.*`，不改被占用的 `flashcards.json` / `review.json`。

### Changes
- `fsrsDriver` 用户可见 receipt 文案走 i18n
- zh-CN / en-US `workspace.json` 补 `agent.fsrs` 组
- 新增 key-echo 契约测试

### How to test
- `npx vitest run src/features/workbench/agent/__tests__/fsrsDriver.i18n.test.ts`
- 英文界面下中断复习入队，回执应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

