### PR TITLE
fix(i18n): Finder agent hint 走 learningHub:agent

### DIFF
--- a/src/features/workbench/agent/__tests__/finderDriver.i18n.test.ts
+++ b/src/features/workbench/agent/__tests__/finderDriver.i18n.test.ts
@@ -1,0 +1,240 @@
+/**
+ * finderDriver 用户/agent 可见错误文案 i18n 契约 — learningHub:agent.*
+ *
+ * key-echo mock：断言与语言无关（真实运行时由 learningHub.json 提供 zh-CN / en-US 文案，
+ * driver 侧 defaultValue 兜底 namespace 异步加载窗口期）。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { tSpy } = vi.hoisted(() => ({
+  tSpy: vi.fn((key: string) => key),
+}));
+vi.mock('@/i18n', () => ({ default: { t: tSpy } }));
+
+const { finderState, enterFolder, navigateTo } = vi.hoisted(() => {
+  const finderState = {
+    currentPath: { folderId: 'root-old' } as { folderId: string },
+    inlineEdit: { editingId: null as string | null },
+  };
+  return {
+    finderState,
+    enterFolder: vi.fn(async (id: string) => {
+      finderState.currentPath = { folderId: id };
+    }),
+    navigateTo: vi.fn((path: { folderId: string }) => {
+      finderState.currentPath = path;
+    }),
+  };
+});
+
+vi.mock('@/features/learning-hub/stores/finderStore', () => ({
+  useFinderStore: {
+    getState: () => ({
+      enterFolder,
+      navigateTo,
+      ...finderState,
+    }),
+  },
+}));
+
+import { finderDriver } from '../drivers/finderDriver';
+import type { AcrRunContext, AgentOp, Pacer, RunLedger } from '../types';
+
+function makeRun(runId: string): AcrRunContext {
+  const pacing: Pacer = {
+    profile: {
+      name: 'fast',
+      opIntervalMs: 0,
+      typeBatchMin: 1,
+      typeBatchMax: 1,
+      typeIntervalMs: 0,
+      instant: true,
+    },
+    tick: vi.fn(async () => undefined),
+    dispose: vi.fn(),
+  };
+  const ledger: RunLedger = {
+    record: vi.fn(),
+    revertRun: vi.fn(async () => true),
+    hasRun: vi.fn(() => false),
+    sealRun: vi.fn(),
+  };
+  return {
+    runId,
+    sessionId: 'session',
+    target: { typeId: 'files' },
+    windowId: 'window',
+    pacing,
+    reportProgress: vi.fn(),
+    checkPaused: vi.fn(async () => 'resume'),
+    ledger,
+  };
+}
+
+function openFolder(folderId: string, label = '打开目录'): AgentOp {
+  return { kind: 'openFolder', destructive: false, label, payload: { folderId } };
+}
+
+beforeEach(() => {
+  tSpy.mockClear();
+  enterFolder.mockClear();
+  enterFolder.mockImplementation(async (id: string) => {
+    finderState.currentPath = { folderId: id };
+  });
+  navigateTo.mockClear();
+  finderState.currentPath = { folderId: 'root-old' };
+  finderState.inlineEdit.editingId = null;
+});
+
+describe('finderDriver apply — 错误文案走 learningHub:agent.* key', () => {
+  it('非导航 op → unsupported_hint 出现在 undone 与 message', async () => {
+    const receipt = await finderDriver.apply(makeRun('run-unsupported'), [
+      { kind: 'dstu_write', destructive: true, label: '写数据', payload: {} },
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['写数据 — learningHub:agent.unsupported_hint']);
+    expect(receipt.message).toBe('learningHub:agent.unsupported_hint');
+    expect(tSpy).toHaveBeenCalledWith(
+      'learningHub:agent.unsupported_hint',
+      expect.objectContaining({ defaultValue: expect.any(String) }),
+    );
+  });
+
+  it('部分成功 + 非导航 op → sawUnsupported 标志驱动 message（不再嗅探 undone 字符串）', async () => {
+    const receipt = await finderDriver.apply(makeRun('run-partial'), [
+      openFolder('folder-new'),
+      { kind: 'dstu_write', destructive: true, label: '写数据', payload: {} },
+    ]);
+
+    expect(receipt.status).toBe('partial');
+    expect(receipt.done).toEqual(['打开目录']);
+    expect(receipt.undone).toEqual(['写数据 — learningHub:agent.unsupported_hint']);
+    expect(receipt.message).toBe('learningHub:agent.unsupported_hint');
+  });
+
+  it('缺少 folderId → op_missing_folder_id（label 作插值参数）', async () => {
+    const receipt = await finderDriver.apply(makeRun('run-missing-id'), [
+      { kind: 'openFolder', destructive: false, label: '进目录', payload: {} },
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['learningHub:agent.op_missing_folder_id']);
+    expect(tSpy).toHaveBeenCalledWith(
+      'learningHub:agent.op_missing_folder_id',
+      expect.objectContaining({ label: '进目录' }),
+    );
+  });
+
+  it('enterFolder 抛错 → op_failed 携带 label 与底层错误', async () => {
+    enterFolder.mockImplementation(async () => {
+      throw new Error('store 拒绝导航');
+    });
+    const receipt = await finderDriver.apply(makeRun('run-op-failed'), [
+      openFolder('folder-x'),
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['learningHub:agent.op_failed']);
+    expect(tSpy).toHaveBeenCalledWith(
+      'learningHub:agent.op_failed',
+      expect.objectContaining({ label: '打开目录', error: 'store 拒绝导航' }),
+    );
+    // 全部失败时 message 回落到 unsupported hint（既有行为，仅文案换 key）
+    expect(receipt.message).toBe('learningHub:agent.unsupported_hint');
+  });
+
+  it('op 无 label → done 与逆操作 label 用 open_folder_label（folderId 作插值参数）', async () => {
+    const run = makeRun('run-default-label');
+    const receipt = await finderDriver.apply(run, [
+      { kind: 'openFolder', destructive: false, label: '', payload: { folderId: 'folder-new' } },
+    ]);
+
+    expect(receipt.status).toBe('completed');
+    expect(receipt.done).toEqual(['learningHub:agent.open_folder_label']);
+    expect(tSpy).toHaveBeenCalledWith(
+      'learningHub:agent.open_folder_label',
+      expect.objectContaining({ folderId: 'folder-new' }),
+    );
+    expect(run.ledger.record).toHaveBeenCalledWith(
+      'run-default-label',
+      expect.any(Function),
+      'learningHub:agent.open_folder_label',
+    );
+  });
+
+  it('导航逻辑不变：openFolder 成功后可经 ledger 逆操作恢复原路径', async () => {
+    const run = makeRun('run-nav-intact');
+    const receipt = await finderDriver.apply(run, [openFolder('folder-new')]);
+
+    expect(receipt.status).toBe('completed');
+    expect(enterFolder).toHaveBeenCalledWith('folder-new');
+    expect(finderState.currentPath.folderId).toBe('folder-new');
+    expect(run.ledger.record).toHaveBeenCalledTimes(1);
+    await vi.mocked(run.ledger.record).mock.calls[0]![1]();
+    expect(finderState.currentPath.folderId).toBe('root-old');
+  });
+
+  it('pacing 失败 → pacing_failed 携带底层错误', async () => {
+    const run = makeRun('run-pacing');
+    run.pacing.tick = vi.fn(async () => {
+      throw new Error('pacer failed');
+    });
+    const receipt = await finderDriver.apply(run, [openFolder('folder-a')]);
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.message).toBe('learningHub:agent.pacing_failed');
+    expect(tSpy).toHaveBeenCalledWith(
+      'learningHub:agent.pacing_failed',
+      expect.objectContaining({ error: 'pacer failed' }),
+    );
+  });
+
+  it('暂停检查失败 → pause_check_failed 携带底层错误', async () => {
+    const run = makeRun('run-pause');
+    run.checkPaused = vi.fn(async () => {
+      throw new Error('pause boom');
+    });
+    const receipt = await finderDriver.apply(run, [openFolder('folder-a')]);
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.message).toBe('learningHub:agent.pause_check_failed');
+    expect(tSpy).toHaveBeenCalledWith(
+      'learningHub:agent.pause_check_failed',
+      expect.objectContaining({ error: 'pause boom' }),
+    );
+  });
+});
+
+describe('finderDriver abort — 回执文案走 learningHub:agent.* key', () => {
+  it('运行中 abort → nav_aborted', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    enterFolder.mockImplementationOnce(async (id: string) => {
+      await gate;
+      finderState.currentPath = { folderId: id };
+    });
+
+    const run = makeRun('run-abort-live');
+    const applying = finderDriver.apply(run, [openFolder('folder-a')]);
+    // 等 apply 走进 enterFolder 的 gate
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const abortReceipt = finderDriver.abort('run-abort-live');
+    expect(abortReceipt.status).toBe('cancelled');
+    expect(abortReceipt.message).toBe('learningHub:agent.nav_aborted');
+
+    release();
+    const finalReceipt = await applying;
+    expect(finalReceipt.status).toBe('cancelled');
+  });
+
+  it('run 不存在 → run_not_found + run_ended', () => {
+    const receipt = finderDriver.abort('run-ghost');
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.message).toBe('learningHub:agent.run_not_found');
+    expect(receipt.undone).toEqual(['learningHub:agent.run_ended']);
+  });
+});

--- a/src/features/workbench/agent/drivers/finderDriver.ts
+++ b/src/features/workbench/agent/drivers/finderDriver.ts
@@ -6,6 +6,7 @@
  * 见 docs/dev/acr/DESIGN.md §5.3。
  */
 
+import i18n from '@/i18n';
 import type {
   AcrProbeState,
   AcrReceipt,
@@ -25,8 +26,14 @@ import type { FinderPath } from '@/features/learning-hub/stores/finderStore';
 
 const TYPE_ID = 'files';
 
-const UNSUPPORTED_HINT =
-  '请用资源/DSTU 领域工具修改文件数据；本驱动仅支持导航类 op（openFolder）';
+// 用户/agent 可见文案统一走 i18n（learningHub:agent.*）；defaultValue 兜底
+// learningHub namespace 尚未完成异步加载的窗口期。语言可运行时切换，故用函数而非模块级常量。
+function unsupportedHint(): string {
+  return i18n.t('learningHub:agent.unsupported_hint', {
+    defaultValue:
+      '请用资源/DSTU 领域工具修改文件数据；本驱动仅支持导航类 op（openFolder）',
+  });
+}
 
 interface ActiveRun {
   runId: string;
@@ -38,6 +45,8 @@ interface ActiveRun {
   applied: number;
   totalOps: number;
   nextOpIndex: number;
+  /** 出现过非导航 op（message 文案已本地化，不能再靠字符串嗅探回执内容判断） */
+  sawUnsupported: boolean;
   inversesCommitted: boolean;
   pendingInverses: Array<{ invert: () => Promise<void>; label: string }>;
   ledger: AcrRunContext['ledger'];
@@ -152,6 +161,7 @@ export const finderDriver: CollabDriver & {
       applied: 0,
       totalOps: ops.length,
       nextOpIndex: 0,
+      sawUnsupported: false,
       inversesCommitted: false,
       pendingInverses: [],
       ledger: run.ledger,
@@ -172,7 +182,10 @@ export const finderDriver: CollabDriver & {
         pause = await run.checkPaused();
       } catch (err) {
         state.aborted = true;
-        state.errorMessage = `暂停检查失败：${err instanceof Error ? err.message : String(err)}`;
+        state.errorMessage = i18n.t('learningHub:agent.pause_check_failed', {
+          error: err instanceof Error ? err.message : String(err),
+          defaultValue: '暂停检查失败：{{error}}',
+        });
         markRemaining(state);
         break;
       }
@@ -188,18 +201,29 @@ export const finderDriver: CollabDriver & {
       if (isOpenFolderOp(op)) {
         const folderId = payloadFolderId(op.payload);
         if (!folderId) {
-          state.undone.push(`${op.label || op.kind}（缺少 folderId）`);
+          state.undone.push(
+            i18n.t('learningHub:agent.op_missing_folder_id', {
+              label: op.label || op.kind,
+              defaultValue: '{{label}}（缺少 folderId）',
+            }),
+          );
         } else {
           try {
             const previousPath = useFinderStore.getState().currentPath;
             await applyOpenFolder(folderId);
-            state.done.push(op.label || `打开文件夹 ${folderId}`);
+            const doneLabel =
+              op.label ||
+              i18n.t('learningHub:agent.open_folder_label', {
+                folderId,
+                defaultValue: '打开文件夹 {{folderId}}',
+              });
+            state.done.push(doneLabel);
             state.entityIds.push(folderId);
             state.applied += 1;
             if (previousPath?.folderId !== folderId) {
               state.pendingInverses.push({
                 invert: () => restoreFolder(previousPath),
-                label: op.label || `打开文件夹 ${folderId}`,
+                label: doneLabel,
               });
             }
             // 当前导航已经完成；pacing 失败或此时 abort 不得把它重复计入 undone。
@@ -208,18 +232,26 @@ export const finderDriver: CollabDriver & {
               await run.pacing.tick(listTickCost(run.pacing.profile));
             } catch (err) {
               state.aborted = true;
-              state.errorMessage = `节奏控制失败：${err instanceof Error ? err.message : String(err)}`;
+              state.errorMessage = i18n.t('learningHub:agent.pacing_failed', {
+                error: err instanceof Error ? err.message : String(err),
+                defaultValue: '节奏控制失败：{{error}}',
+              });
               markRemaining(state);
               break;
             }
           } catch (err) {
             state.undone.push(
-              `${op.label || op.kind}（失败: ${err instanceof Error ? err.message : String(err)}）`,
+              i18n.t('learningHub:agent.op_failed', {
+                label: op.label || op.kind,
+                error: err instanceof Error ? err.message : String(err),
+                defaultValue: '{{label}}（失败: {{error}}）',
+              }),
             );
           }
         }
       } else {
-        state.undone.push(`${op.label || op.kind} — ${UNSUPPORTED_HINT}`);
+        state.sawUnsupported = true;
+        state.undone.push(`${op.label || op.kind} — ${unsupportedHint()}`);
       }
       state.nextOpIndex = i + 1;
     }
@@ -245,9 +277,9 @@ export const finderDriver: CollabDriver & {
         undone: state.undone,
         message:
           state.errorMessage ?? (state.undone.length > 0 && state.applied === 0
-            ? UNSUPPORTED_HINT
-            : state.undone.some((u) => u.includes('DSTU'))
-              ? UNSUPPORTED_HINT
+            ? unsupportedHint()
+            : state.sawUnsupported
+              ? unsupportedHint()
               : undefined),
       }),
       TYPE_ID,
@@ -268,7 +300,9 @@ export const finderDriver: CollabDriver & {
           entityIds: state.entityIds,
           done: [...state.done],
           undone: [...state.undone],
-          message: 'files 导航已中止',
+          message: i18n.t('learningHub:agent.nav_aborted', {
+            defaultValue: 'files 导航已中止',
+          }),
         }),
         TYPE_ID,
       );
@@ -276,8 +310,10 @@ export const finderDriver: CollabDriver & {
     return withUserPatch(
       emptyReceipt({
         status: 'cancelled',
-        message: 'files run 不存在或已结束',
-        undone: ['run 已结束'],
+        message: i18n.t('learningHub:agent.run_not_found', {
+          defaultValue: 'files run 不存在或已结束',
+        }),
+        undone: [i18n.t('learningHub:agent.run_ended', { defaultValue: 'run 已结束' })],
       }),
       TYPE_ID,
     );

--- a/src/locales/en-US/learningHub.json
+++ b/src/locales/en-US/learningHub.json
@@ -1397,5 +1397,16 @@
     "lanceHasPageIndex": "has pageIndex",
     "lanceSampleMetadata": "Sample metadata",
     "lanceRows": "rows"
+  },
+  "agent": {
+    "unsupported_hint": "Use the resource/DSTU domain tools to modify file data; this driver only supports navigation ops (openFolder)",
+    "pause_check_failed": "Pause check failed: {{error}}",
+    "pacing_failed": "Pacing control failed: {{error}}",
+    "op_missing_folder_id": "{{label}} (missing folderId)",
+    "op_failed": "{{label}} (failed: {{error}})",
+    "open_folder_label": "Open folder {{folderId}}",
+    "nav_aborted": "Files navigation aborted",
+    "run_not_found": "Files run does not exist or has already finished",
+    "run_ended": "Run already finished"
   }
 }

--- a/src/locales/zh-CN/learningHub.json
+++ b/src/locales/zh-CN/learningHub.json
@@ -1397,5 +1397,16 @@
     "lanceHasPageIndex": "有 pageIndex",
     "lanceSampleMetadata": "抽样 metadata",
     "lanceRows": "行"
+  },
+  "agent": {
+    "unsupported_hint": "请用资源/DSTU 领域工具修改文件数据；本驱动仅支持导航类 op（openFolder）",
+    "pause_check_failed": "暂停检查失败：{{error}}",
+    "pacing_failed": "节奏控制失败：{{error}}",
+    "op_missing_folder_id": "{{label}}（缺少 folderId）",
+    "op_failed": "{{label}}（失败: {{error}}）",
+    "open_folder_label": "打开文件夹 {{folderId}}",
+    "nav_aborted": "files 导航已中止",
+    "run_not_found": "files run 不存在或已结束",
+    "run_ended": "run 已结束"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`finderDriver` 的 unsupported hint 是硬编码中文。改为 `learningHub:agent.*`，不改 `finderStore` / `LearningHubSidebar`。

### Changes
- `finderDriver` 用户可见 hint 走 i18n
- zh-CN / en-US `learningHub.json` 补 `agent` 组
- 新增契约测试

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下对 files 驱动发非导航 op，提示应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

