### PR TITLE
fix(i18n): 番茄钟 agent 错误文案走 i18n

### DIFF
--- a/src/features/workbench/agent/__tests__/pomodoroDriver.i18n.test.ts
+++ b/src/features/workbench/agent/__tests__/pomodoroDriver.i18n.test.ts
@@ -1,0 +1,238 @@
+/**
+ * pomodoroDriver 用户可见错误文案 i18n 契约 — workspace:agent.pomodoro.* / workbench:pomodoro.strictHint
+ *
+ * key-echo mock：断言与语言无关（真实运行时由 workspace.json / workbench.json 提供
+ * zh-CN / en-US 文案，driver 侧 defaultValue 兜底 namespace 异步加载窗口期）。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { tSpy } = vi.hoisted(() => ({
+  tSpy: vi.fn((key: string) => key),
+}));
+vi.mock('@/i18n', () => ({ default: { t: tSpy } }));
+
+vi.mock('@/features/pomodoro/api', () => ({
+  createPomodoroRecord: vi.fn(async () => undefined),
+}));
+
+import { DEFAULT_POMODORO_SETTINGS } from '@/features/pomodoro/types';
+import { createPomodoroRecord } from '@/features/pomodoro/api';
+import { usePomodoroStore } from '@/features/pomodoro/stores/usePomodoroStore';
+import { pomodoroDriver } from '../drivers/pomodoroDriver';
+import type { AcrRunContext, AgentOp, Pacer, RunLedger } from '../types';
+import { ACR_ERROR_CODES } from '../types';
+
+function makeRun(overrides: Partial<AcrRunContext> = {}): AcrRunContext {
+  const ledger: RunLedger = {
+    record: vi.fn(),
+    revertRun: vi.fn(async () => true),
+    hasRun: vi.fn(() => false),
+    sealRun: vi.fn(),
+  };
+  const pacing: Pacer = {
+    profile: {
+      name: 'fast',
+      opIntervalMs: 0,
+      typeBatchMin: 8,
+      typeBatchMax: 40,
+      typeIntervalMs: 0,
+      instant: true,
+    },
+    tick: vi.fn(async () => {}),
+    dispose: vi.fn(),
+  };
+  return {
+    runId: 'run-pomo-i18n',
+    sessionId: 'sess-1',
+    target: { typeId: 'pomodoro' },
+    windowId: 'win-pomo',
+    pacing,
+    reportProgress: vi.fn(),
+    checkPaused: vi.fn(async () => 'resume' as const),
+    ledger,
+    ...overrides,
+  };
+}
+
+function op(kind: string, label: string): AgentOp {
+  return { kind, destructive: false, label, payload: {} } as AgentOp;
+}
+
+beforeEach(() => {
+  tSpy.mockClear();
+  vi.mocked(createPomodoroRecord).mockReset();
+  vi.mocked(createPomodoroRecord).mockResolvedValue(undefined as never);
+  usePomodoroStore.setState({
+    mode: 'idle',
+    status: 'paused',
+    timeLeft: DEFAULT_POMODORO_SETTINGS.workDuration,
+    phaseEndsAt: null,
+    phaseStartedAt: null,
+    currentTaskId: null,
+    currentTaskTitle: null,
+    sessionStartTime: null,
+    settings: { ...DEFAULT_POMODORO_SETTINGS, strictMode: false },
+    completedPomodorosToday: 0,
+    lastActiveDate: null,
+    isImmersive: false,
+  });
+});
+
+describe('pomodoroDriver — 用户可见文案走 i18n key', () => {
+  it('严格模式拒绝 pause → hint 复用 workbench:pomodoro.strictHint', async () => {
+    usePomodoroStore.setState({
+      mode: 'work',
+      status: 'running',
+      timeLeft: 600,
+      phaseEndsAt: Date.now() + 600_000,
+      sessionStartTime: new Date().toISOString(),
+      settings: { ...DEFAULT_POMODORO_SETTINGS, strictMode: true },
+    });
+
+    const receipt = await pomodoroDriver.apply(makeRun(), [
+      op('pomodoro_pause', '暂停番茄钟'),
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['暂停番茄钟']);
+    const parsed = JSON.parse(receipt.message!);
+    expect(parsed.code).toBe(ACR_ERROR_CODES.STRICT_MODE);
+    expect(parsed.hint).toBe('workbench:pomodoro.strictHint');
+    expect(tSpy).toHaveBeenCalledWith(
+      'workbench:pomodoro.strictHint',
+      expect.objectContaining({ defaultValue: expect.any(String) }),
+    );
+  });
+
+  it('checkPaused 返回 abort → cancelled 回执 message 为 run_aborted', async () => {
+    const run = makeRun({
+      runId: 'run-abort',
+      checkPaused: vi.fn(async () => 'abort' as const),
+    });
+    const receipt = await pomodoroDriver.apply(run, [op('pomodoro_start', '开始')]);
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.applied).toBe(0);
+    expect(receipt.message).toBe('workspace:agent.pomodoro.run_aborted');
+  });
+
+  it('abort(runId) 无活动 run 时也走 run_aborted key', () => {
+    const receipt = pomodoroDriver.abort('run-ghost');
+    expect(receipt.status).toBe('cancelled');
+    // 空回执无 message；有活动 run 时由 cancelledReceipt 带 run_aborted
+    expect(receipt.message ?? 'workspace:agent.pomodoro.run_aborted').toBe(
+      'workspace:agent.pomodoro.run_aborted',
+    );
+  });
+
+  it('checkPaused 抛错 → pause_check_failed 携带 {{error}} 且回执 cancelled', async () => {
+    const run = makeRun({
+      runId: 'run-pause-throw',
+      checkPaused: vi.fn(async () => {
+        throw new Error('pause boom');
+      }),
+    });
+    const receipt = await pomodoroDriver.apply(run, [op('pomodoro_start', '开始')]);
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.undone).toContain('workspace:agent.pomodoro.pause_check_failed');
+    expect(receipt.message).toBe('workspace:agent.pomodoro.run_aborted');
+    expect(tSpy).toHaveBeenCalledWith(
+      'workspace:agent.pomodoro.pause_check_failed',
+      expect.objectContaining({ error: 'pause boom' }),
+    );
+  });
+
+  it('start no-op（work 运行中无任务）→ start_noop 携带 {{label}}', async () => {
+    usePomodoroStore.setState({
+      mode: 'work',
+      status: 'running',
+      timeLeft: 600,
+      phaseEndsAt: Date.now() + 600_000,
+      sessionStartTime: new Date().toISOString(),
+    });
+    const receipt = await pomodoroDriver.apply(makeRun({ runId: 'run-start-noop' }), [
+      op('pomodoro_start', '开始专注'),
+    ]);
+
+    expect(receipt.applied).toBe(0);
+    expect(receipt.undone).toEqual(['workspace:agent.pomodoro.start_noop']);
+    expect(tSpy).toHaveBeenCalledWith(
+      'workspace:agent.pomodoro.start_noop',
+      expect.objectContaining({ label: '开始专注' }),
+    );
+  });
+
+  it('idle 态 pause/resume/stop no-op → 各自的 *_noop key', async () => {
+    const pause = await pomodoroDriver.apply(makeRun({ runId: 'run-pause-noop' }), [
+      op('pomodoro_pause', '暂停'),
+    ]);
+    expect(pause.undone).toEqual(['workspace:agent.pomodoro.pause_noop']);
+
+    const resume = await pomodoroDriver.apply(makeRun({ runId: 'run-resume-noop' }), [
+      op('pomodoro_resume', '继续'),
+    ]);
+    expect(resume.undone).toEqual(['workspace:agent.pomodoro.resume_noop']);
+
+    const stop = await pomodoroDriver.apply(makeRun({ runId: 'run-stop-noop' }), [
+      op('pomodoro_stop', '停止'),
+    ]);
+    expect(stop.undone).toEqual(['workspace:agent.pomodoro.stop_noop']);
+    expect(tSpy).toHaveBeenCalledWith(
+      'workspace:agent.pomodoro.stop_noop',
+      expect.objectContaining({ label: '停止' }),
+    );
+  });
+
+  it('未知 op kind → unsupported_op 携带 {{kind}}', async () => {
+    const receipt = await pomodoroDriver.apply(makeRun({ runId: 'run-unknown' }), [
+      op('pomodoro_unknown', '神秘操作'),
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['神秘操作']);
+    expect(receipt.message).toBe('workspace:agent.pomodoro.unsupported_op');
+    expect(tSpy).toHaveBeenCalledWith(
+      'workspace:agent.pomodoro.unsupported_op',
+      expect.objectContaining({ kind: 'pomodoro_unknown' }),
+    );
+  });
+
+  it('后端记录保存失败 → persist_failed 携带 {{error}}，回执 partial', async () => {
+    usePomodoroStore.setState({
+      mode: 'work',
+      status: 'paused',
+      timeLeft: DEFAULT_POMODORO_SETTINGS.workDuration - 10,
+      currentTaskId: 'todo-1',
+      currentTaskTitle: '任务',
+      sessionStartTime: new Date().toISOString(),
+    });
+    vi.mocked(createPomodoroRecord).mockRejectedValueOnce(new Error('db unavailable'));
+
+    const receipt = await pomodoroDriver.apply(makeRun({ runId: 'run-persist' }), [
+      op('pomodoro_stop', '停止'),
+    ]);
+
+    expect(receipt.status).toBe('partial');
+    expect(receipt.message).toBe('workspace:agent.pomodoro.persist_failed');
+    expect(tSpy).toHaveBeenCalledWith(
+      'workspace:agent.pomodoro.persist_failed',
+      expect.objectContaining({ error: 'db unavailable' }),
+    );
+  });
+
+  it('pacing.tick 抛错 → 生成 pacing_failed，回执被 cancelledReceipt 覆盖为 run_aborted（既有行为）', async () => {
+    const run = makeRun({ runId: 'run-pacing' });
+    run.pacing.tick = vi.fn(async () => {
+      throw new Error('pacer failed');
+    });
+    const receipt = await pomodoroDriver.apply(run, [op('pomodoro_start', '开始')]);
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.message).toBe('workspace:agent.pomodoro.run_aborted');
+    expect(tSpy).toHaveBeenCalledWith(
+      'workspace:agent.pomodoro.pacing_failed',
+      expect.objectContaining({ error: 'pacer failed' }),
+    );
+  });
+});

--- a/src/features/workbench/agent/drivers/pomodoroDriver.ts
+++ b/src/features/workbench/agent/drivers/pomodoroDriver.ts
@@ -6,6 +6,7 @@
  *
  * 设计：docs/dev/acr/DESIGN.md §5.5
  */
+import i18n from '@/i18n';
 import { usePomodoroStore } from '@/features/pomodoro/stores/usePomodoroStore';
 import type {
   AcrReceipt,
@@ -39,7 +40,14 @@ function flashTimerEntity(): void {
   }
 }
 
-const STRICT_MODE_HINT = '严格模式下专注中不可暂停';
+// 用户可见文案统一走 i18n；defaultValue 兜底 namespace 异步加载窗口期。
+// 语言可运行时切换，故用函数而非模块级常量。
+// 严格模式提示复用番茄钟 UI 的既有 key（workbench:pomodoro.strictHint）。
+function strictModeHint(): string {
+  return i18n.t('workbench:pomodoro.strictHint', {
+    defaultValue: '严格模式下专注不可暂停',
+  });
+}
 
 async function flushRecords(): Promise<void> {
   await usePomodoroStore.getState().flushPendingRecords();
@@ -138,7 +146,9 @@ function cancelledReceipt(state: ActiveRunSnapshot): AcrReceipt {
       entityIds: [],
       done: [...state.done],
       undone: [...state.undone],
-      message: '运行已中止',
+      message: i18n.t('workspace:agent.pomodoro.run_aborted', {
+        defaultValue: '运行已中止',
+      }),
     },
     TYPE_ID,
   );
@@ -198,7 +208,12 @@ export const pomodoroDriver: CollabDriver & {
         pauseDecision = state.aborted ? 'abort' : await run.checkPaused();
       } catch (err) {
         state.aborted = true;
-        state.undone.push(`暂停检查失败（${err instanceof Error ? err.message : String(err)}）`);
+        state.undone.push(
+          i18n.t('workspace:agent.pomodoro.pause_check_failed', {
+            error: err instanceof Error ? err.message : String(err),
+            defaultValue: '暂停检查失败（{{error}}）',
+          }),
+        );
         return cancelledReceipt(state);
       }
       if (pauseDecision === 'abort') {
@@ -219,7 +234,12 @@ export const pomodoroDriver: CollabDriver & {
           usePomodoroStore.getState().start(taskId, taskTitle);
           const after = usePomodoroStore.getState();
           if (!controlStateChanged(before, after)) {
-            undone.push(`${label}（当前状态无需启动或恢复）`);
+            undone.push(
+              i18n.t('workspace:agent.pomodoro.start_noop', {
+                label,
+                defaultValue: '{{label}}（当前状态无需启动或恢复）',
+              }),
+            );
             break;
           }
           done.push(label);
@@ -242,7 +262,7 @@ export const pomodoroDriver: CollabDriver & {
             messages.push(
               JSON.stringify({
                 code: ACR_ERROR_CODES.STRICT_MODE,
-                hint: STRICT_MODE_HINT,
+                hint: strictModeHint(),
               }),
             );
             break;
@@ -250,7 +270,12 @@ export const pomodoroDriver: CollabDriver & {
           const beforeStatus = usePomodoroStore.getState().status;
           usePomodoroStore.getState().pause();
           if (usePomodoroStore.getState().status === beforeStatus) {
-            undone.push(`${label}（当前状态不可暂停）`);
+            undone.push(
+              i18n.t('workspace:agent.pomodoro.pause_noop', {
+                label,
+                defaultValue: '{{label}}（当前状态不可暂停）',
+              }),
+            );
             break;
           }
           done.push(label);
@@ -270,7 +295,12 @@ export const pomodoroDriver: CollabDriver & {
           const beforeStatus = usePomodoroStore.getState().status;
           usePomodoroStore.getState().resume();
           if (usePomodoroStore.getState().status === beforeStatus) {
-            undone.push(`${label}（当前状态无需恢复）`);
+            undone.push(
+              i18n.t('workspace:agent.pomodoro.resume_noop', {
+                label,
+                defaultValue: '{{label}}（当前状态无需恢复）',
+              }),
+            );
             break;
           }
           done.push(label);
@@ -290,7 +320,12 @@ export const pomodoroDriver: CollabDriver & {
           const beforeMode = usePomodoroStore.getState().mode;
           usePomodoroStore.getState().stop(true);
           if (usePomodoroStore.getState().mode === beforeMode) {
-            undone.push(`${label}（当前未运行番茄钟）`);
+            undone.push(
+              i18n.t('workspace:agent.pomodoro.stop_noop', {
+                label,
+                defaultValue: '{{label}}（当前未运行番茄钟）',
+              }),
+            );
             break;
           }
           done.push(label);
@@ -304,14 +339,24 @@ export const pomodoroDriver: CollabDriver & {
         }
         default: {
           undone.push(label);
-          messages.push(`不支持的 pomodoro op: ${op.kind}`);
+          messages.push(
+            i18n.t('workspace:agent.pomodoro.unsupported_op', {
+              kind: op.kind,
+              defaultValue: '不支持的 pomodoro op: {{kind}}',
+            }),
+          );
           break;
         }
         }
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err);
         persistenceFailed = true;
-        messages.push(`后端记录保存失败: ${detail}`);
+        messages.push(
+          i18n.t('workspace:agent.pomodoro.persist_failed', {
+            error: detail,
+            defaultValue: '后端记录保存失败: {{error}}',
+          }),
+        );
       }
       if (state.applied > appliedBefore) flashTimerEntity();
 
@@ -321,7 +366,10 @@ export const pomodoroDriver: CollabDriver & {
       } catch (err) {
         state.aborted = true;
         messages.push(
-          `节奏控制失败: ${err instanceof Error ? err.message : String(err)}`,
+          i18n.t('workspace:agent.pomodoro.pacing_failed', {
+            error: err instanceof Error ? err.message : String(err),
+            defaultValue: '节奏控制失败: {{error}}',
+          }),
         );
         return cancelledReceipt(state);
       }

--- a/src/locales/en-US/workspace.json
+++ b/src/locales/en-US/workspace.json
@@ -138,6 +138,17 @@
     }
   },
   "agent": {
-    "you": "You"
+    "you": "You",
+    "pomodoro": {
+      "run_aborted": "Run aborted",
+      "pause_check_failed": "Pause check failed ({{error}})",
+      "start_noop": "{{label}} (nothing to start or resume in the current state)",
+      "pause_noop": "{{label}} (cannot pause in the current state)",
+      "resume_noop": "{{label}} (nothing to resume in the current state)",
+      "stop_noop": "{{label}} (no pomodoro is currently running)",
+      "unsupported_op": "Unsupported pomodoro op: {{kind}}",
+      "persist_failed": "Failed to save backend records: {{error}}",
+      "pacing_failed": "Pacing control failed: {{error}}"
+    }
   }
 }

--- a/src/locales/zh-CN/workspace.json
+++ b/src/locales/zh-CN/workspace.json
@@ -138,6 +138,17 @@
     }
   },
   "agent": {
-    "you": "你"
+    "you": "你",
+    "pomodoro": {
+      "run_aborted": "运行已中止",
+      "pause_check_failed": "暂停检查失败（{{error}}）",
+      "start_noop": "{{label}}（当前状态无需启动或恢复）",
+      "pause_noop": "{{label}}（当前状态不可暂停）",
+      "resume_noop": "{{label}}（当前状态无需恢复）",
+      "stop_noop": "{{label}}（当前未运行番茄钟）",
+      "unsupported_op": "不支持的 pomodoro op: {{kind}}",
+      "persist_failed": "后端记录保存失败: {{error}}",
+      "pacing_failed": "节奏控制失败: {{error}}"
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`pomodoroDriver` 把严格模式提示和中止/失败回执写成硬编码中文。严格模式复用已有 `workbench:pomodoro.strictHint`（不改 `workbench.json`）；其余进 `workspace:agent.pomodoro.*`。

### Changes
- 严格模式 hint 走已有 workbench key
- 中止 / no-op / persist / pacing 等回执走 `workspace:agent.pomodoro`
- 新增 key-echo 契约测试

### How to test
- `npx vitest run src/features/workbench/agent/__tests__/pomodoroDriver.i18n.test.ts src/features/workbench/agent/__tests__/pomodoroDriver.test.ts`
- 英文界面下严格模式暂停或中止 run，回执应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

