### PR TITLE
fix(i18n): 题库 agent 回执文案走 exam_sheet:agent

### DIFF
--- a/src/features/workbench/agent/__tests__/qbankDriver.i18n.test.ts
+++ b/src/features/workbench/agent/__tests__/qbankDriver.i18n.test.ts
@@ -1,0 +1,228 @@
+/**
+ * qbankDriver 用户/agent 可见回执文案 i18n 契约 — exam_sheet:agent.*
+ *
+ * key-echo mock：断言与语言无关（真实运行时由 exam_sheet.json 提供 zh-CN / en-US 文案，
+ * driver 侧 defaultValue 兜底 namespace 异步加载窗口期）。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { tSpy } = vi.hoisted(() => ({
+  tSpy: vi.fn((key: string) => key),
+}));
+vi.mock('@/i18n', () => ({ default: { t: tSpy } }));
+
+const { qbankState, setCurrentQuestion } = vi.hoisted(() => {
+  const qbankState = { currentQuestionId: null as string | null };
+  return {
+    qbankState,
+    setCurrentQuestion: vi.fn((id: string | null) => {
+      qbankState.currentQuestionId = id;
+    }),
+  };
+});
+
+vi.mock('@/stores/questionBankStore', () => ({
+  useQuestionBankStore: {
+    getState: () => ({
+      currentQuestionId: qbankState.currentQuestionId,
+      setCurrentQuestion,
+    }),
+  },
+}));
+
+vi.mock('../visuals/agentFlash', () => ({
+  agentFlash: vi.fn(),
+  agentFlashMany: vi.fn(),
+}));
+
+import {
+  QBANK_FOCUS_EVENT,
+  qbankDriver,
+  type QbankFocusEventDetail,
+} from '../drivers/qbankDriver';
+import type { AcrRunContext, AgentOp, Pacer, RunLedger } from '../types';
+
+function makeRun(runId: string): AcrRunContext {
+  const pacing: Pacer = {
+    profile: {
+      name: 'fast',
+      opIntervalMs: 0,
+      typeBatchMin: 1,
+      typeBatchMax: 1,
+      typeIntervalMs: 0,
+      instant: true,
+    },
+    tick: vi.fn(async () => undefined),
+    dispose: vi.fn(),
+  };
+  const ledger: RunLedger = {
+    record: vi.fn(),
+    revertRun: vi.fn(async () => true),
+    hasRun: vi.fn(() => false),
+    sealRun: vi.fn(),
+  };
+  return {
+    runId,
+    sessionId: 'session',
+    target: { typeId: 'exam' },
+    windowId: 'window',
+    pacing,
+    reportProgress: vi.fn(),
+    checkPaused: vi.fn(async () => 'resume'),
+    ledger,
+  };
+}
+
+function focusOp(questionId: string, label?: string): AgentOp {
+  return {
+    kind: 'qbank_focus_question',
+    destructive: false,
+    ...(label ? { label } : {}),
+    payload: { questionId },
+  };
+}
+
+/** 挂一个焦点监听器并保证用例结束后移除 */
+async function withFocusListener(
+  respond: (detail: QbankFocusEventDetail) => void,
+  body: () => Promise<void>,
+): Promise<void> {
+  const onFocus = (event: Event) => {
+    respond((event as CustomEvent<QbankFocusEventDetail>).detail);
+  };
+  window.addEventListener(QBANK_FOCUS_EVENT, onFocus);
+  try {
+    await body();
+  } finally {
+    window.removeEventListener(QBANK_FOCUS_EVENT, onFocus);
+  }
+}
+
+beforeEach(() => {
+  tSpy.mockClear();
+  setCurrentQuestion.mockClear();
+  qbankState.currentQuestionId = null;
+});
+
+describe('qbankDriver apply — 回执文案走 exam_sheet:agent.* key', () => {
+  it('可见题库未找到该题 → question_not_visible（label 作插值参数）', async () => {
+    await withFocusListener(
+      (detail) => detail.acknowledge?.({ handled: false, previousQuestionId: 'q-keep' }),
+      async () => {
+        const receipt = await qbankDriver.apply(makeRun('run-not-visible'), [
+          focusOp('q-missing', 'focus missing'),
+        ]);
+
+        expect(receipt.status).toBe('failed');
+        expect(receipt.undone).toEqual(['exam_sheet:agent.question_not_visible']);
+        expect(tSpy).toHaveBeenCalledWith(
+          'exam_sheet:agent.question_not_visible',
+          expect.objectContaining({
+            label: 'focus missing',
+            defaultValue: expect.any(String),
+          }),
+        );
+      },
+    );
+  });
+
+  it('无 label 的聚焦成功 → focus_question_done（questionId 作插值参数）', async () => {
+    await withFocusListener(
+      (detail) => detail.acknowledge?.({ handled: true, previousQuestionId: null }),
+      async () => {
+        const receipt = await qbankDriver.apply(makeRun('run-focus-done'), [
+          focusOp('q-new'),
+        ]);
+
+        expect(receipt.status).toBe('completed');
+        expect(receipt.done).toEqual(['exam_sheet:agent.focus_question_done']);
+        expect(tSpy).toHaveBeenCalledWith(
+          'exam_sheet:agent.focus_question_done',
+          expect.objectContaining({ questionId: 'q-new' }),
+        );
+      },
+    );
+  });
+
+  it('撤销时恢复目标已不可见 → undo_question_missing', async () => {
+    let firstDispatch = true;
+    const run = makeRun('run-undo-missing');
+    await withFocusListener(
+      (detail) => {
+        if (firstDispatch) {
+          firstDispatch = false;
+          detail.acknowledge?.({ handled: true, previousQuestionId: 'q-old' });
+        } else {
+          detail.acknowledge?.({ handled: false, previousQuestionId: 'q-new' });
+        }
+      },
+      async () => {
+        const receipt = await qbankDriver.apply(run, [focusOp('q-new')]);
+        expect(receipt.status).toBe('completed');
+        expect(run.ledger.record).toHaveBeenCalledTimes(1);
+
+        const invert = vi.mocked(run.ledger.record).mock.calls[0]![1] as () => void;
+        expect(() => invert()).toThrow('exam_sheet:agent.undo_question_missing');
+        expect(tSpy).toHaveBeenCalledWith(
+          'exam_sheet:agent.undo_question_missing',
+          expect.objectContaining({ questionId: 'q-old' }),
+        );
+      },
+    );
+  });
+
+  it('非导航 op 全部失败 → unsupported_hint 作为 message', async () => {
+    const receipt = await qbankDriver.apply(makeRun('run-unsupported'), [
+      { kind: 'qbank_update', destructive: true, label: '写数据', payload: {} },
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['写数据']);
+    expect(receipt.message).toBe('exam_sheet:agent.unsupported_hint');
+    expect(tSpy).toHaveBeenCalledWith(
+      'exam_sheet:agent.unsupported_hint',
+      expect.objectContaining({ defaultValue: expect.any(String) }),
+    );
+  });
+});
+
+describe('qbankDriver abort — 回执文案走 exam_sheet:agent.* key', () => {
+  it('运行中 abort → nav_aborted', async () => {
+    const run = makeRun('run-abort-live');
+    let abortReceipt: ReturnType<typeof qbankDriver.abort> | null = null;
+    vi.mocked(run.pacing.tick).mockImplementation(async () => {
+      if (!abortReceipt) abortReceipt = qbankDriver.abort(run.runId);
+    });
+
+    await withFocusListener(
+      (detail) => detail.acknowledge?.({ handled: true, previousQuestionId: null }),
+      async () => {
+        const receipt = await qbankDriver.apply(run, [
+          focusOp('q-1', 'first'),
+          focusOp('q-2', 'second'),
+        ]);
+
+        expect(abortReceipt).toMatchObject({
+          status: 'cancelled',
+          message: 'exam_sheet:agent.nav_aborted',
+        });
+        expect(receipt.status).toBe('cancelled');
+        expect(tSpy).toHaveBeenCalledWith(
+          'exam_sheet:agent.nav_aborted',
+          expect.objectContaining({ defaultValue: expect.any(String) }),
+        );
+      },
+    );
+  });
+
+  it('run 不存在 → run_not_found（runId 作插值参数）', () => {
+    const receipt = qbankDriver.abort('run-ghost');
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.message).toBe('exam_sheet:agent.run_not_found');
+    expect(tSpy).toHaveBeenCalledWith(
+      'exam_sheet:agent.run_not_found',
+      expect.objectContaining({ runId: 'run-ghost' }),
+    );
+  });
+});

--- a/src/features/workbench/agent/drivers/qbankDriver.ts
+++ b/src/features/workbench/agent/drivers/qbankDriver.ts
@@ -7,6 +7,7 @@
  *
  * 见 docs/dev/acr/DESIGN.md §5.4 / ROUND1.md R1-15。
  */
+import i18n from '@/i18n';
 import { useQuestionBankStore } from '@/stores/questionBankStore';
 import { collectDomainEntityIds, registerDomainListener } from '../domainEvents';
 import { listTickCost } from '../pacing';
@@ -326,7 +327,12 @@ export const qbankDriver: CollabDriver & {
           const store = useQuestionBankStore.getState();
           const focusResult = dispatchFocusEvent(questionId);
           if (!focusResult?.handled) {
-            state.undone.push(`${op.label || op.kind}（可见题库未找到该题）`);
+            state.undone.push(
+              i18n.t('exam_sheet:agent.question_not_visible', {
+                label: op.label || op.kind,
+                defaultValue: '{{label}}（可见题库未找到该题）',
+              }),
+            );
             state.nextOpIndex = i + 1;
             await run.pacing.tick(listTickCost(run.pacing.profile));
             continue;
@@ -335,7 +341,13 @@ export const qbankDriver: CollabDriver & {
           store.setCurrentQuestion(questionId);
           agentFlash(TYPE_ID, questionId);
           state.entityIds.push(questionId);
-          state.done.push(op.label || `聚焦题目 ${questionId}`);
+          state.done.push(
+            op.label ||
+              i18n.t('exam_sheet:agent.focus_question_done', {
+                questionId,
+                defaultValue: '聚焦题目 {{questionId}}',
+              }),
+          );
           state.applied += 1;
           // 没有前选中项时，记录一个只恢复 store 却无法恢复视图的 inverse 会让撤销撒谎。
           if (previousQuestionId && previousQuestionId !== questionId) {
@@ -344,7 +356,12 @@ export const qbankDriver: CollabDriver & {
               () => {
                 const reverted = dispatchFocusEvent(previousQuestionId);
                 if (!reverted?.handled) {
-                  throw new Error(`无法恢复已不存在的题目 ${previousQuestionId}`);
+                  throw new Error(
+                    i18n.t('exam_sheet:agent.undo_question_missing', {
+                      questionId: previousQuestionId,
+                      defaultValue: '无法恢复已不存在的题目 {{questionId}}',
+                    }),
+                  );
                 }
                 useQuestionBankStore.getState().setCurrentQuestion(previousQuestionId);
               },
@@ -382,7 +399,10 @@ export const qbankDriver: CollabDriver & {
       undone: state.undone,
       message:
         status === 'failed'
-          ? 'qbank driver 仅支持导航 op（qbank_focus_question）；数据修改请用领域工具'
+          ? i18n.t('exam_sheet:agent.unsupported_hint', {
+              defaultValue:
+                'qbank driver 仅支持导航 op（qbank_focus_question）；数据修改请用领域工具',
+            })
           : undefined,
     };
   },
@@ -391,11 +411,17 @@ export const qbankDriver: CollabDriver & {
     const state = qbankActiveRuns.get(runId);
     if (state) {
       state.aborted = true;
-      return qbankCancelledReceipt(state, 'qbank 导航已中止');
+      return qbankCancelledReceipt(
+        state,
+        i18n.t('exam_sheet:agent.nav_aborted', { defaultValue: 'qbank 导航已中止' }),
+      );
     }
     return withUserPatch(
       emptyReceipt('cancelled', 0, {
-        message: `run ${runId} aborted`,
+        message: i18n.t('exam_sheet:agent.run_not_found', {
+          runId,
+          defaultValue: 'run {{runId}} aborted',
+        }),
       }),
       TYPE_ID,
     );

--- a/src/locales/en-US/exam_sheet.json
+++ b/src/locales/en-US/exam_sheet.json
@@ -619,5 +619,13 @@
   "editor": {
     "discardDraftDescription": "Discard Draft Description",
     "discardDraftTitle": "Discard Draft Title"
+  },
+  "agent": {
+    "question_not_visible": "{{label}} (question not found in the visible question bank)",
+    "focus_question_done": "Focus question {{questionId}}",
+    "undo_question_missing": "Cannot restore question {{questionId}}: it no longer exists",
+    "unsupported_hint": "The qbank driver only supports navigation ops (qbank_focus_question); use domain tools to modify data",
+    "nav_aborted": "Qbank navigation aborted",
+    "run_not_found": "run {{runId}} aborted"
   }
 }

--- a/src/locales/zh-CN/exam_sheet.json
+++ b/src/locales/zh-CN/exam_sheet.json
@@ -619,5 +619,13 @@
   "editor": {
     "discardDraftDescription": "离开当前视图会清除尚未提交或保存的内容。",
     "discardDraftTitle": "放弃未提交的内容？"
+  },
+  "agent": {
+    "question_not_visible": "{{label}}（可见题库未找到该题）",
+    "focus_question_done": "聚焦题目 {{questionId}}",
+    "undo_question_missing": "无法恢复已不存在的题目 {{questionId}}",
+    "unsupported_hint": "qbank driver 仅支持导航 op（qbank_focus_question）；数据修改请用领域工具",
+    "nav_aborted": "qbank 导航已中止",
+    "run_not_found": "run {{runId}} aborted"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`qbankDriver` 把「可见题库未找到该题 / 导航已中止」等用户与 agent 可见回执写成硬编码中文。改为 `exam_sheet:agent.*`，不改被占用的 `forms.json` / `todo.json` / `workbench.json` / `workspace.json`。

### Changes
- `qbankDriver` 用户可见 throw/error/回执走 i18n
- zh-CN / en-US `exam_sheet.json` 补 `agent` 组
- 新增 key-echo 测试；现有 `fsrsQbankDriver` 断言靠 defaultValue 保持原文

### How to test
- 跑该 PR 新增/更新的 vitest
- 英文界面下触发题库导航失败，错误应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

