### PR TITLE
fix(i18n): driver userPatch 摘要走 dstu:agent.user_patch

### DIFF
--- a/src/features/workbench/agent/__tests__/arbitrationConsistency.r2-06.test.ts
+++ b/src/features/workbench/agent/__tests__/arbitrationConsistency.r2-06.test.ts
@@ -10,6 +10,14 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// userPatch 摘要走 i18n（dstu:agent.user_patch.*）；此处回显 defaultValue 以断言主干原文
+vi.mock('@/i18n', () => ({
+  default: {
+    t: (key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? key,
+  },
+}));
+
 vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn(async () => () => {}),
   emit: vi.fn(async () => {}),

--- a/src/features/workbench/agent/__tests__/userPatchSummarizers.i18n.test.ts
+++ b/src/features/workbench/agent/__tests__/userPatchSummarizers.i18n.test.ts
@@ -1,0 +1,70 @@
+/**
+ * userPatch summarizer i18n — driver 摘要走 dstu:agent.user_patch.<key>
+ *
+ * mock @/i18n 为 key-echo，registerAllDrivers 后逐 typeId 断言 summarizeUserPatch
+ * 返回对应 i18n key（含未知 typeId 的缺省 key）。userPatch 用真实实现。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/i18n', () => ({ default: { t: (key: string) => key } }));
+
+const mocks = vi.hoisted(() => ({
+  setupNoteBinding: vi.fn(),
+  mindmap: vi.fn(),
+  note: vi.fn(),
+  todo: vi.fn(),
+  finder: vi.fn(),
+  fsrs: vi.fn(),
+  qbank: vi.fn(),
+  pomodoro: vi.fn(),
+  sandbox: vi.fn(),
+}));
+
+vi.mock('../noteBinding', () => ({ setupNoteBinding: mocks.setupNoteBinding }));
+vi.mock('../drivers/mindmapDriver', () => ({ registerMindmapDriver: mocks.mindmap }));
+vi.mock('../drivers/noteDriver', () => ({ registerNoteDriver: mocks.note }));
+vi.mock('../drivers/todoDriver', () => ({ registerTodoDriver: mocks.todo }));
+vi.mock('../drivers/finderDriver', () => ({ registerFinderDriver: mocks.finder }));
+vi.mock('../drivers/fsrsDriver', () => ({ registerFsrsDriver: mocks.fsrs }));
+vi.mock('../drivers/qbankDriver', () => ({ registerQbankDriver: mocks.qbank }));
+vi.mock('../drivers/pomodoroDriver', () => ({ registerPomodoroDriver: mocks.pomodoro }));
+vi.mock('../drivers/sandboxDriver', () => ({ registerSandboxDriver: mocks.sandbox }));
+
+import { disposeAllDrivers, registerAllDrivers } from '../drivers';
+import { summarizeUserPatch } from '../userPatch';
+import type { StageManagerApi } from '../types';
+
+const stage = {} as StageManagerApi;
+
+const EXPECTED_KEYS = [
+  ['mindmap', 'dstu:agent.user_patch.mindmap'],
+  ['note', 'dstu:agent.user_patch.note'],
+  ['todo', 'dstu:agent.user_patch.todo'],
+  ['files', 'dstu:agent.user_patch.files'],
+  ['flashcards', 'dstu:agent.user_patch.flashcards'],
+  ['exam', 'dstu:agent.user_patch.exam'],
+  ['pomodoro', 'dstu:agent.user_patch.pomodoro'],
+] as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.setupNoteBinding.mockImplementation(() => vi.fn());
+  for (const registration of [mocks.todo, mocks.finder, mocks.fsrs, mocks.qbank]) {
+    registration.mockImplementation(() => vi.fn());
+  }
+  registerAllDrivers(stage);
+});
+
+afterEach(() => {
+  disposeAllDrivers();
+});
+
+describe('userPatch summarizer i18n keys', () => {
+  it.each(EXPECTED_KEYS)('%s → %s', (typeId, key) => {
+    expect(summarizeUserPatch(typeId)).toBe(key);
+  });
+
+  it('未知 typeId 走缺省 key', () => {
+    expect(summarizeUserPatch('unknown-type')).toBe('dstu:agent.user_patch.default');
+  });
+});

--- a/src/features/workbench/agent/drivers/index.ts
+++ b/src/features/workbench/agent/drivers/index.ts
@@ -6,6 +6,7 @@
  *
  * 设计：docs/dev/acr/DESIGN.md；任务卡 ROUND1.md R1-16 / ROUND2.md R2-06
  */
+import i18n from '@/i18n';
 import { setupNoteBinding } from '../noteBinding';
 import type { StageManagerApi } from '../types';
 import {
@@ -27,13 +28,41 @@ let disposeDomainDrivers: Array<() => void> = [];
 
 /** R2-06：各 driver 的 userPatch diff 概述（缺省回落 DEFAULT_USER_PATCH） */
 function registerUserPatchSummarizers(): void {
-  registerUserPatchSummarizer('mindmap', () => '用户在导图中进行了手动编辑');
-  registerUserPatchSummarizer('note', () => '用户在笔记正文中进行了手动编辑');
-  registerUserPatchSummarizer('todo', () => '用户在待办列表中进行了手动编辑');
-  registerUserPatchSummarizer('files', () => '用户在文件管理器中进行了手动导航或编辑');
-  registerUserPatchSummarizer('flashcards', () => '用户在复习队列中进行了手动操作');
-  registerUserPatchSummarizer('exam', () => '用户在题库中进行了手动编辑');
-  registerUserPatchSummarizer('pomodoro', () => '用户手动操作了番茄钟');
+  registerUserPatchSummarizer('mindmap', () =>
+    i18n.t('dstu:agent.user_patch.mindmap', {
+      defaultValue: '用户在导图中进行了手动编辑',
+    }),
+  );
+  registerUserPatchSummarizer('note', () =>
+    i18n.t('dstu:agent.user_patch.note', {
+      defaultValue: '用户在笔记正文中进行了手动编辑',
+    }),
+  );
+  registerUserPatchSummarizer('todo', () =>
+    i18n.t('dstu:agent.user_patch.todo', {
+      defaultValue: '用户在待办列表中进行了手动编辑',
+    }),
+  );
+  registerUserPatchSummarizer('files', () =>
+    i18n.t('dstu:agent.user_patch.files', {
+      defaultValue: '用户在文件管理器中进行了手动导航或编辑',
+    }),
+  );
+  registerUserPatchSummarizer('flashcards', () =>
+    i18n.t('dstu:agent.user_patch.flashcards', {
+      defaultValue: '用户在复习队列中进行了手动操作',
+    }),
+  );
+  registerUserPatchSummarizer('exam', () =>
+    i18n.t('dstu:agent.user_patch.exam', {
+      defaultValue: '用户在题库中进行了手动编辑',
+    }),
+  );
+  registerUserPatchSummarizer('pomodoro', () =>
+    i18n.t('dstu:agent.user_patch.pomodoro', {
+      defaultValue: '用户手动操作了番茄钟',
+    }),
+  );
 }
 
 export function registerAllDrivers(stage: StageManagerApi): void {

--- a/src/features/workbench/agent/userPatch.ts
+++ b/src/features/workbench/agent/userPatch.ts
@@ -3,6 +3,7 @@
  * 暂停/中止回执附带用户改动概述（Devin 协议）；各 driver 可注册 diff 回调，缺省文案见 DEFAULT_USER_PATCH。
  * 见 docs/dev/acr/DESIGN.md §4.1 / ROUND2.md R2-06。
  */
+import i18n from '@/i18n';
 import type { AcrReceipt } from './types';
 
 /** 缺省：无法采集具体 diff 时的 LLM 可读摘要 */
@@ -35,7 +36,9 @@ export function summarizeUserPatch(typeId: string): string {
       /* 回落缺省 */
     }
   }
-  return DEFAULT_USER_PATCH;
+  return i18n.t('dstu:agent.user_patch.default', {
+    defaultValue: DEFAULT_USER_PATCH,
+  });
 }
 
 /**

--- a/src/locales/en-US/dstu.json
+++ b/src/locales/en-US/dstu.json
@@ -190,5 +190,17 @@
       "searchImageAttachments": "Search image attachments",
       "searchFileAttachments": "Search file attachments"
     }
+  },
+  "agent": {
+    "user_patch": {
+      "default": "The user made manual edits",
+      "mindmap": "The user made manual edits in the mind map",
+      "note": "The user made manual edits in the note body",
+      "todo": "The user made manual edits in the todo list",
+      "files": "The user manually navigated or edited in the file manager",
+      "flashcards": "The user performed manual actions in the review queue",
+      "exam": "The user made manual edits in the question bank",
+      "pomodoro": "The user manually operated the pomodoro timer"
+    }
   }
 }

--- a/src/locales/zh-CN/dstu.json
+++ b/src/locales/zh-CN/dstu.json
@@ -190,5 +190,17 @@
       "searchImageAttachments": "搜索图片附件",
       "searchFileAttachments": "搜索文件附件"
     }
+  },
+  "agent": {
+    "user_patch": {
+      "default": "用户进行了手动编辑",
+      "mindmap": "用户在导图中进行了手动编辑",
+      "note": "用户在笔记正文中进行了手动编辑",
+      "todo": "用户在待办列表中进行了手动编辑",
+      "files": "用户在文件管理器中进行了手动导航或编辑",
+      "flashcards": "用户在复习队列中进行了手动操作",
+      "exam": "用户在题库中进行了手动编辑",
+      "pomodoro": "用户手动操作了番茄钟"
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

ACR driver 的 `userPatch` 摘要（暂停/中止回执给模型看的用户改动概述）写成硬编码中文。改为 `dstu:agent.user_patch.*`，不改被占用的 `forms.json` / `todo.json` / `workbench.json` / `workspace.json` / `mindmap.json`。

### Changes
- 7 条 `registerUserPatchSummarizer` 与缺省路径走 i18n；`DEFAULT_USER_PATCH` 字面量保持不变
- zh-CN / en-US `dstu.json` 补 `agent.user_patch` 组
- 新增 key-echo 测试；`arbitrationConsistency` 用 defaultValue mock 保持原断言

### How to test
- 跑该 PR 新增/更新的 vitest
- 英文界面下中止一次带 userPatch 的 agent run，摘要应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

