### PR TITLE
fix(a11y): 聊天窗展开沙箱按钮 aria-label 走已有 i18n

### DIFF
--- a/src/features/workbench/apps/chat/ChatSessionSurface.tsx
+++ b/src/features/workbench/apps/chat/ChatSessionSurface.tsx
@@ -20,6 +20,7 @@
  *   data-wb-chat-active 状态见 ChatSessionSurface.css。
  */
 import React, { useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { SidebarSimple } from '@phosphor-icons/react';
 import { cn } from '@/utils/cn';
 import { DsButton } from '@/components/ui/DsButton';
@@ -59,6 +60,7 @@ export const ChatSessionSurface: React.FC<ChatSessionSurfaceProps> = ({
   renderThrottleMs = 0,
   className,
 }) => {
+  const { t } = useTranslation('chatV2');
   const rootRef = useRef<HTMLDivElement>(null);
   const sandboxOwnerKey = createChatSandboxOwnerKey(sessionId);
   const sandboxActiveSession = useSandboxWorkbenchStore(
@@ -116,8 +118,8 @@ export const ChatSessionSurface: React.FC<ChatSessionSurfaceProps> = ({
             iconOnly
             className="wb-chat-sandbox-expand absolute right-2 top-2 !h-8 !w-8"
             onClick={() => openSandboxWorkbench(sandboxOwnerKey)}
-            aria-label="展开沙箱工作台"
-            title="展开沙箱工作台"
+            aria-label={t('page.expandSandboxWorkbench')}
+            title={t('page.expandSandboxWorkbench')}
           >
             <SidebarSimple size={18} />
           </DsButton>

--- a/src/features/workbench/apps/chat/__tests__/ChatSessionSurface.sandboxExpand.a11y.test.ts
+++ b/src/features/workbench/apps/chat/__tests__/ChatSessionSurface.sandboxExpand.a11y.test.ts
@@ -1,0 +1,38 @@
+/**
+ * a11y / i18n 防回归：聊天窗「展开沙箱工作台」图标按钮。
+ *
+ * ChatSessionSurface 的展开按钮 aria-label / title 必须复用 chatV2 命名空间
+ * 里已有的 `page.expandSandboxWorkbench`（与 ChatV2Page 对齐），
+ * 禁止回退到硬编码中文字面量。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SOURCE_PATH = path.join(
+  process.cwd(),
+  'src',
+  'features',
+  'workbench',
+  'apps',
+  'chat',
+  'ChatSessionSurface.tsx',
+);
+
+describe('ChatSessionSurface sandbox expand button a11y i18n', () => {
+  const src = fs.readFileSync(SOURCE_PATH, 'utf8');
+
+  it('aria-label 与 title 走已有 i18n key page.expandSandboxWorkbench', () => {
+    expect(src).toContain("aria-label={t('page.expandSandboxWorkbench')}");
+    expect(src).toContain("title={t('page.expandSandboxWorkbench')}");
+  });
+
+  it('useTranslation 绑定 chatV2 命名空间且来自 react-i18next', () => {
+    expect(src).toMatch(/import \{ useTranslation \} from 'react-i18next';/);
+    expect(src).toContain("useTranslation('chatV2')");
+  });
+
+  it('不再出现硬编码字面量「展开沙箱工作台」', () => {
+    expect(src).not.toContain('展开沙箱工作台');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

聊天窗内展开沙箱工作台的图标按钮把 `aria-label` / `title` 写成硬编码中文。改为复用已有 `chatV2:page.expandSandboxWorkbench`（与 `ChatV2Page` 对齐），不改被占用的 `chatV2.json` / `workbench.json`。

### Changes
- `ChatSessionSurface` 展开按钮走已有 i18n key
- 新增源码契约测试，锁定不再出现字面量中文

### How to test
- 跑该 PR 新增/更新的 vitest
- 英文界面下打开带沙箱会话的聊天窗，展开按钮读屏应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

