### PR TITLE
fix(i18n): 沙箱 agent 回执文案走 console:agent

### DIFF
--- a/src/features/workbench/agent/__tests__/sandboxDriver.i18n.test.ts
+++ b/src/features/workbench/agent/__tests__/sandboxDriver.i18n.test.ts
@@ -1,0 +1,230 @@
+/**
+ * sandboxDriver 用户/agent 可见回执文案 i18n 契约 — console:agent.*
+ *
+ * key-echo mock：断言与语言无关（真实运行时由 console.json 提供 zh-CN / en-US 文案，
+ * driver 侧 defaultValue 兜底 namespace 异步加载窗口期）。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { tSpy } = vi.hoisted(() => ({
+  tSpy: vi.fn((key: string) => key),
+}));
+vi.mock('@/i18n', () => ({ default: { t: tSpy } }));
+
+const { sandboxOwnerState, storeApi } = vi.hoisted(() => {
+  const sandboxOwnerState = {
+    activeSession: null as { id: string; title: string } | null,
+    viewportPreset: 'desktop',
+    inspectorOpen: false,
+    isOpen: false,
+  };
+  const storeApi = {
+    refreshSession: vi.fn(),
+    setViewportPreset: vi.fn(),
+    setInspectorOpen: vi.fn(),
+  };
+  return { sandboxOwnerState, storeApi };
+});
+
+vi.mock('@/features/sandbox/store/useSandboxWorkbenchStore', () => ({
+  LEGACY_SANDBOX_OWNER_KEY: 'legacy-sandbox-owner',
+  selectSandboxWorkbenchOwnerState: vi.fn(() => sandboxOwnerState),
+  useSandboxWorkbenchStore: {
+    getState: () => ({ ...storeApi }),
+  },
+}));
+
+import { SET_MODE_UNSUPPORTED, sandboxDriver } from '../drivers/sandboxDriver';
+import type { AcrRunContext, AgentOp, Pacer, RunLedger } from '../types';
+
+function makeRun(runId: string): AcrRunContext {
+  const pacing: Pacer = {
+    profile: {
+      name: 'fast',
+      opIntervalMs: 0,
+      typeBatchMin: 1,
+      typeBatchMax: 1,
+      typeIntervalMs: 0,
+      instant: true,
+    },
+    tick: vi.fn(async () => undefined),
+    dispose: vi.fn(),
+  };
+  const ledger: RunLedger = {
+    record: vi.fn(),
+    revertRun: vi.fn(async () => true),
+    hasRun: vi.fn(() => false),
+    sealRun: vi.fn(),
+  };
+  return {
+    runId,
+    sessionId: 'session',
+    target: { typeId: 'sandbox' },
+    windowId: 'window',
+    pacing,
+    reportProgress: vi.fn(),
+    checkPaused: vi.fn(async () => 'resume'),
+    ledger,
+  };
+}
+
+function op(kind: string, label: string, payload?: unknown): AgentOp {
+  return { kind, destructive: false, label, payload } as AgentOp;
+}
+
+beforeEach(() => {
+  tSpy.mockClear();
+  storeApi.refreshSession.mockClear();
+  storeApi.setViewportPreset.mockClear();
+  storeApi.setInspectorOpen.mockClear();
+  sandboxOwnerState.activeSession = null;
+});
+
+describe('sandboxDriver apply — 回执文案走 console:agent.* key', () => {
+  it('sandbox_refresh 无活动会话 → no_active_session（label 作插值参数）', async () => {
+    const receipt = await sandboxDriver.apply(makeRun('run-no-session'), [
+      op('sandbox_refresh', '刷新预览'),
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['console:agent.no_active_session']);
+    expect(storeApi.refreshSession).not.toHaveBeenCalled();
+    expect(tSpy).toHaveBeenCalledWith(
+      'console:agent.no_active_session',
+      expect.objectContaining({ label: '刷新预览', defaultValue: expect.any(String) }),
+    );
+  });
+
+  it('sandbox_set_viewport 非法预设 → viewport_invalid', async () => {
+    const receipt = await sandboxDriver.apply(makeRun('run-bad-viewport'), [
+      op('sandbox_set_viewport', '切换视口', { viewport: 'watch' }),
+    ]);
+
+    expect(receipt.undone).toEqual(['console:agent.viewport_invalid']);
+    expect(storeApi.setViewportPreset).not.toHaveBeenCalled();
+    expect(tSpy).toHaveBeenCalledWith(
+      'console:agent.viewport_invalid',
+      expect.objectContaining({ label: '切换视口', defaultValue: expect.any(String) }),
+    );
+  });
+
+  it('sandbox_set_inspector open 非布尔 → open_invalid', async () => {
+    const receipt = await sandboxDriver.apply(makeRun('run-bad-open'), [
+      op('sandbox_set_inspector', '打开检查器', { open: 'yes' }),
+    ]);
+
+    expect(receipt.undone).toEqual(['console:agent.open_invalid']);
+    expect(storeApi.setInspectorOpen).not.toHaveBeenCalled();
+    expect(tSpy).toHaveBeenCalledWith(
+      'console:agent.open_invalid',
+      expect.objectContaining({ label: '打开检查器', defaultValue: expect.any(String) }),
+    );
+  });
+
+  it('sandbox_set_mode → set_mode_undone（label + reason 插值），message 用 set_mode_unsupported', async () => {
+    const receipt = await sandboxDriver.apply(makeRun('run-set-mode'), [
+      op('sandbox_set_mode', '切换运行模式', { mode: 'sandbox-run' }),
+    ]);
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.undone).toEqual(['console:agent.set_mode_undone']);
+    expect(receipt.message).toBe('console:agent.set_mode_unsupported');
+    // defaultValue 必须沿用导出的原中文常量，保证 namespace 未就绪时文案不缺失
+    expect(tSpy).toHaveBeenCalledWith(
+      'console:agent.set_mode_unsupported',
+      expect.objectContaining({ defaultValue: SET_MODE_UNSUPPORTED }),
+    );
+    expect(tSpy).toHaveBeenCalledWith(
+      'console:agent.set_mode_undone',
+      expect.objectContaining({
+        label: '切换运行模式',
+        reason: 'console:agent.set_mode_unsupported',
+      }),
+    );
+  });
+
+  it('未知 sandbox op → unsupported_op', async () => {
+    const receipt = await sandboxDriver.apply(makeRun('run-unknown-op'), [
+      op('sandbox_explode', '未知操作'),
+    ]);
+
+    expect(receipt.undone).toEqual(['console:agent.unsupported_op']);
+    expect(tSpy).toHaveBeenCalledWith(
+      'console:agent.unsupported_op',
+      expect.objectContaining({ label: '未知操作', defaultValue: expect.any(String) }),
+    );
+  });
+
+  it('checkPaused 抛错 → pause_check_failed（error 作插值参数）', async () => {
+    const run = makeRun('run-pause-fail');
+    run.checkPaused = vi.fn(async () => {
+      throw new Error('boom');
+    });
+
+    const receipt = await sandboxDriver.apply(run, [op('sandbox_refresh', '刷新预览')]);
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.message).toBe('console:agent.pause_check_failed');
+    expect(tSpy).toHaveBeenCalledWith(
+      'console:agent.pause_check_failed',
+      expect.objectContaining({ error: 'boom', defaultValue: expect.any(String) }),
+    );
+  });
+
+  it('pacing.tick 抛错 → pacing_failed（error 作插值参数）', async () => {
+    sandboxOwnerState.activeSession = { id: 'session-1', title: 'Preview' };
+    const run = makeRun('run-pacing-fail');
+    vi.mocked(run.pacing.tick).mockRejectedValueOnce(new Error('tick down'));
+
+    const receipt = await sandboxDriver.apply(run, [op('sandbox_refresh', '刷新预览')]);
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.message).toBe('console:agent.pacing_failed');
+    expect(tSpy).toHaveBeenCalledWith(
+      'console:agent.pacing_failed',
+      expect.objectContaining({ error: 'tick down', defaultValue: expect.any(String) }),
+    );
+  });
+});
+
+describe('sandboxDriver abort — 回执文案走 console:agent.* key', () => {
+  it('运行中 abort → op_aborted', async () => {
+    sandboxOwnerState.activeSession = { id: 'session-1', title: 'Preview' };
+    const run = makeRun('run-abort-live');
+    let abortReceipt: ReturnType<typeof sandboxDriver.abort> | null = null;
+    vi.mocked(run.pacing.tick).mockImplementation(async () => {
+      if (!abortReceipt) abortReceipt = sandboxDriver.abort(run.runId);
+    });
+
+    const receipt = await sandboxDriver.apply(run, [
+      op('sandbox_refresh', '第一次刷新'),
+      op('sandbox_refresh', '第二次刷新'),
+    ]);
+
+    expect(abortReceipt).toMatchObject({
+      status: 'cancelled',
+      message: 'console:agent.op_aborted',
+    });
+    expect(receipt.status).toBe('cancelled');
+    expect(tSpy).toHaveBeenCalledWith(
+      'console:agent.op_aborted',
+      expect.objectContaining({ defaultValue: expect.any(String) }),
+    );
+  });
+
+  it('run 不存在 → undone 用 run_ended、message 用 run_not_found', () => {
+    const receipt = sandboxDriver.abort('run-ghost');
+
+    expect(receipt.status).toBe('cancelled');
+    expect(receipt.undone).toEqual(['console:agent.run_ended']);
+    expect(receipt.message).toBe('console:agent.run_not_found');
+    expect(tSpy).toHaveBeenCalledWith(
+      'console:agent.run_ended',
+      expect.objectContaining({ defaultValue: expect.any(String) }),
+    );
+    expect(tSpy).toHaveBeenCalledWith(
+      'console:agent.run_not_found',
+      expect.objectContaining({ defaultValue: expect.any(String) }),
+    );
+  });
+});

--- a/src/features/workbench/agent/drivers/sandboxDriver.ts
+++ b/src/features/workbench/agent/drivers/sandboxDriver.ts
@@ -8,6 +8,7 @@
  * - abort 运行追踪：参照 finderDriver 的 activeRuns 表，abort 返回真实 applied
  *   前缀（done/undone 为当刻已知状态），不再返回空回执。
  */
+import i18n from '@/i18n';
 import {
   LEGACY_SANDBOX_OWNER_KEY,
   selectSandboxWorkbenchOwnerState,
@@ -25,7 +26,7 @@ import type {
 const TYPE_ID = 'sandbox';
 const VIEWPORTS = new Set<SandboxViewportPreset>(['desktop', 'tablet', 'mobile']);
 
-const SET_MODE_UNSUPPORTED =
+export const SET_MODE_UNSUPPORTED =
   'Sandbox 渲染面固定为安全预览（safe-preview），不存在可切换的运行模式；能力已从清单撤除';
 
 interface ActiveRun {
@@ -120,7 +121,10 @@ export const sandboxDriver: CollabDriver & {
         pause = await run.checkPaused();
       } catch (err) {
         state.aborted = true;
-        state.errorMessage = `暂停检查失败：${err instanceof Error ? err.message : String(err)}`;
+        state.errorMessage = i18n.t('console:agent.pause_check_failed', {
+          error: err instanceof Error ? err.message : String(err),
+          defaultValue: '暂停检查失败：{{error}}',
+        });
         markRemaining(state);
         break;
       }
@@ -138,16 +142,28 @@ export const sandboxDriver: CollabDriver & {
       run.reportProgress(index + 1, ops.length, label);
 
       if (op.kind === 'sandbox_refresh') {
-        if (!before.activeSession) state.undone.push(`${label}（无活动会话）`);
-        else {
+        if (!before.activeSession) {
+          state.undone.push(
+            i18n.t('console:agent.no_active_session', {
+              label,
+              defaultValue: '{{label}}（无活动会话）',
+            }),
+          );
+        } else {
           store.refreshSession(LEGACY_SANDBOX_OWNER_KEY);
           state.done.push(label);
           state.applied += 1;
         }
       } else if (op.kind === 'sandbox_set_viewport') {
         const viewport = payload.viewport as SandboxViewportPreset;
-        if (!VIEWPORTS.has(viewport)) state.undone.push(`${label}（viewport 无效）`);
-        else {
+        if (!VIEWPORTS.has(viewport)) {
+          state.undone.push(
+            i18n.t('console:agent.viewport_invalid', {
+              label,
+              defaultValue: '{{label}}（viewport 无效）',
+            }),
+          );
+        } else {
           store.setViewportPreset(viewport, LEGACY_SANDBOX_OWNER_KEY);
           run.ledger.record(
             run.runId,
@@ -161,8 +177,14 @@ export const sandboxDriver: CollabDriver & {
           state.applied += 1;
         }
       } else if (op.kind === 'sandbox_set_inspector') {
-        if (typeof payload.open !== 'boolean') state.undone.push(`${label}（open 无效）`);
-        else {
+        if (typeof payload.open !== 'boolean') {
+          state.undone.push(
+            i18n.t('console:agent.open_invalid', {
+              label,
+              defaultValue: '{{label}}（open 无效）',
+            }),
+          );
+        } else {
           store.setInspectorOpen(payload.open, LEGACY_SANDBOX_OWNER_KEY);
           run.ledger.record(
             run.runId,
@@ -177,10 +199,24 @@ export const sandboxDriver: CollabDriver & {
         }
       } else if (op.kind === 'sandbox_set_mode') {
         // 诚实回执：不改 store、不记 inverse、不按 store 判成功
-        state.undone.push(`${label} — ${SET_MODE_UNSUPPORTED}`);
-        state.errorMessage ??= SET_MODE_UNSUPPORTED;
+        const reason = i18n.t('console:agent.set_mode_unsupported', {
+          defaultValue: SET_MODE_UNSUPPORTED,
+        });
+        state.undone.push(
+          i18n.t('console:agent.set_mode_undone', {
+            label,
+            reason,
+            defaultValue: '{{label}} — {{reason}}',
+          }),
+        );
+        state.errorMessage ??= reason;
       } else {
-        state.undone.push(`${label}（不支持的 sandbox op）`);
+        state.undone.push(
+          i18n.t('console:agent.unsupported_op', {
+            label,
+            defaultValue: '{{label}}（不支持的 sandbox op）',
+          }),
+        );
       }
 
       state.nextOpIndex = index + 1;
@@ -188,7 +224,10 @@ export const sandboxDriver: CollabDriver & {
         await run.pacing.tick();
       } catch (err) {
         state.aborted = true;
-        state.errorMessage = `节奏控制失败：${err instanceof Error ? err.message : String(err)}`;
+        state.errorMessage = i18n.t('console:agent.pacing_failed', {
+          error: err instanceof Error ? err.message : String(err),
+          defaultValue: '节奏控制失败：{{error}}',
+        });
         markRemaining(state);
         break;
       }
@@ -211,7 +250,11 @@ export const sandboxDriver: CollabDriver & {
     if (state) {
       state.aborted = true;
       markRemaining(state);
-      return buildReceipt(state, 'cancelled', 'sandbox 操作已中止');
+      return buildReceipt(
+        state,
+        'cancelled',
+        i18n.t('console:agent.op_aborted', { defaultValue: 'sandbox 操作已中止' }),
+      );
     }
     return {
       status: 'cancelled',
@@ -220,8 +263,10 @@ export const sandboxDriver: CollabDriver & {
       totalOps: 0,
       entityIds: [],
       done: [],
-      undone: ['run 已结束'],
-      message: 'sandbox run 不存在或已结束',
+      undone: [i18n.t('console:agent.run_ended', { defaultValue: 'run 已结束' })],
+      message: i18n.t('console:agent.run_not_found', {
+        defaultValue: 'sandbox run 不存在或已结束',
+      }),
     };
   },
 };

--- a/src/locales/en-US/console.json
+++ b/src/locales/en-US/console.json
@@ -1,4 +1,16 @@
 {
-  "processing_failed": "Console processing failed: {{error}}"
+  "processing_failed": "Console processing failed: {{error}}",
+  "agent": {
+    "set_mode_unsupported": "The sandbox rendering surface is fixed to safe-preview; there is no switchable run mode, and the capability has been removed from the manifest",
+    "set_mode_undone": "{{label}} — {{reason}}",
+    "pause_check_failed": "Pause check failed: {{error}}",
+    "pacing_failed": "Pacing control failed: {{error}}",
+    "no_active_session": "{{label}} (no active session)",
+    "viewport_invalid": "{{label}} (invalid viewport)",
+    "open_invalid": "{{label}} (invalid open)",
+    "unsupported_op": "{{label}} (unsupported sandbox op)",
+    "op_aborted": "Sandbox operation aborted",
+    "run_ended": "Run has ended",
+    "run_not_found": "Sandbox run does not exist or has already ended"
+  }
 }
-

--- a/src/locales/zh-CN/console.json
+++ b/src/locales/zh-CN/console.json
@@ -1,4 +1,16 @@
 {
-  "processing_failed": "控制台处理失败：{{error}}"
+  "processing_failed": "控制台处理失败：{{error}}",
+  "agent": {
+    "set_mode_unsupported": "Sandbox 渲染面固定为安全预览（safe-preview），不存在可切换的运行模式；能力已从清单撤除",
+    "set_mode_undone": "{{label}} — {{reason}}",
+    "pause_check_failed": "暂停检查失败：{{error}}",
+    "pacing_failed": "节奏控制失败：{{error}}",
+    "no_active_session": "{{label}}（无活动会话）",
+    "viewport_invalid": "{{label}}（viewport 无效）",
+    "open_invalid": "{{label}}（open 无效）",
+    "unsupported_op": "{{label}}（不支持的 sandbox op）",
+    "op_aborted": "sandbox 操作已中止",
+    "run_ended": "run 已结束",
+    "run_not_found": "sandbox run 不存在或已结束"
+  }
 }
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`sandboxDriver` 把「安全预览不可切换 / 无活动会话 / 操作已中止」等用户与 agent 可见回执写成硬编码中文。改为 `console:agent.*`，不改被占用的 `workbench.json` / `chatV2.json`。

### Changes
- `sandboxDriver` 用户可见 error/回执走 i18n；`SET_MODE_UNSUPPORTED` 常量保留原文作 defaultValue
- zh-CN / en-US `console.json` 补 `agent` 组
- 新增 key-echo 测试；现有 `sandboxDriver` 断言靠 defaultValue 保持原文

### How to test
- 跑该 PR 新增/更新的 vitest
- 英文界面下对沙箱执行 `sandbox_set_mode`，回执应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

