### PR TITLE
fix(i18n): 内置技能自定义存储错误走 skills:storage

### DIFF
--- a/src/features/chat/skills/__tests__/builtinStorage.i18n.test.ts
+++ b/src/features/chat/skills/__tests__/builtinStorage.i18n.test.ts
@@ -1,0 +1,36 @@
+/**
+ * builtinStorage 用户可见错误 i18n key-echo 测试
+ *
+ * mock @/i18n 为 key-echo（t 直接返回 key），并保证运行时探测为非 Tauri
+ * （jsdom 下清空 window.__TAURI_INTERNALS__），断言两条 throw 走 skills:storage 键。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/i18n', () => ({
+  default: {
+    t: (key: string) => key,
+  },
+}));
+
+import {
+  resetBuiltinSkillCustomization,
+  saveBuiltinSkillCustomization,
+} from '../builtinStorage';
+
+describe('builtinStorage user-facing errors go through skills:storage i18n keys', () => {
+  beforeEach(() => {
+    delete (window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it('saveBuiltinSkillCustomization throws skills:storage.save_requires_tauri outside Tauri', async () => {
+    await expect(
+      saveBuiltinSkillCustomization('deep-student', { name: 'custom' })
+    ).rejects.toMatchObject({ message: 'skills:storage.save_requires_tauri' });
+  });
+
+  it('resetBuiltinSkillCustomization throws skills:storage.reset_requires_tauri outside Tauri', async () => {
+    await expect(
+      resetBuiltinSkillCustomization('deep-student')
+    ).rejects.toMatchObject({ message: 'skills:storage.reset_requires_tauri' });
+  });
+});

--- a/src/features/chat/skills/builtinStorage.ts
+++ b/src/features/chat/skills/builtinStorage.ts
@@ -12,6 +12,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { SkillDefinition, SkillMetadata } from './types';
 import { debugLog } from '@/debug-panel/debugMasterSwitch';
+import i18n from '@/i18n';
 
 // ============================================================================
 // 常量
@@ -140,7 +141,7 @@ export async function saveBuiltinSkillCustomization(
   customization: BuiltinSkillCustomization
 ): Promise<void> {
   if (!isTauriRuntime()) {
-    throw new Error('非 Tauri 环境，无法保存自定义');
+    throw new Error(i18n.t('skills:storage.save_requires_tauri', { defaultValue: '非 Tauri 环境，无法保存自定义' }));
   }
 
   try {
@@ -168,7 +169,7 @@ export async function resetBuiltinSkillCustomization(
   skillId: string
 ): Promise<void> {
   if (!isTauriRuntime()) {
-    throw new Error('非 Tauri 环境，无法重置自定义');
+    throw new Error(i18n.t('skills:storage.reset_requires_tauri', { defaultValue: '非 Tauri 环境，无法重置自定义' }));
   }
 
   try {

--- a/src/locales/en-US/skills.json
+++ b/src/locales/en-US/skills.json
@@ -536,5 +536,10 @@
     "description_required": "Please enter a description",
     "description_too_long": "Description cannot exceed 1024 characters",
     "description_too_short": "Description should be at least 50 characters for better LLM discovery"
+  },
+
+  "storage": {
+    "save_requires_tauri": "Cannot save customization outside the Tauri runtime",
+    "reset_requires_tauri": "Cannot reset customization outside the Tauri runtime"
   }
 }

--- a/src/locales/zh-CN/skills.json
+++ b/src/locales/zh-CN/skills.json
@@ -536,5 +536,10 @@
     "description_required": "请输入技能描述",
     "description_too_long": "描述不能超过 1024 个字符",
     "description_too_short": "建议描述至少 50 字符，以便 LLM 更好地理解何时使用此技能"
+  },
+
+  "storage": {
+    "save_requires_tauri": "非 Tauri 环境，无法保存自定义",
+    "reset_requires_tauri": "非 Tauri 环境，无法重置自定义"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

非 Tauri 环境下保存/重置内置技能自定义会 throw 硬编码中文。改为 `skills:storage.*`，不改被占用的 `forms.json` / `workbench.json`。

### Changes
- `saveBuiltinSkillCustomization` / `resetBuiltinSkillCustomization` 错误走 i18n
- zh-CN / en-US `skills.json` 补 `storage` 组
- 新增 key-echo 测试

### How to test
- 跑该 PR 新增的 vitest
- 非 Tauri 环境下保存技能自定义，错误应为当前语言

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

