### PR TITLE
fix(i18n): 多模态检索空查询错误走 enhanced_rag

### DIFF
--- a/src/locales/en-US/enhanced_rag.json
+++ b/src/locales/en-US/enhanced_rag.json
@@ -146,6 +146,9 @@
     "upload_partial": "Upload complete: {{success}} succeeded, {{failed}} failed",
     "processing_large_files": "Processing {{count}} large file(s), please wait..."
   },
+  "retrieve": {
+    "empty_query": "A retrieval request must include text, an image, or both"
+  },
   "rag_search": {
     "title": "Smart Search",
     "query_placeholder": "Enter search query...",

--- a/src/locales/zh-CN/enhanced_rag.json
+++ b/src/locales/zh-CN/enhanced_rag.json
@@ -146,6 +146,9 @@
     "loading_more": "加载中...",
     "processing_documents": "处理中 ({{count}} 个文档)"
   },
+  "retrieve": {
+    "empty_query": "检索请求必须包含文本、图片或两者"
+  },
   "rag_search": {
     "title": "智能检索",
     "query_placeholder": "输入检索查询...",

--- a/src/services/__tests__/multimodalRagService.i18n.test.ts
+++ b/src/services/__tests__/multimodalRagService.i18n.test.ts
@@ -1,0 +1,69 @@
+/**
+ * multimodalRagService 空查询错误 i18n key-echo 测试
+ *
+ * mock `@/i18n` 让 t 原样回显 key，走公开入口（retrieve / retrieveDetailed /
+ * searchByText）触发 buildLegacySearchInput 的空查询校验，断言：
+ * - throw 的 message 就是 i18n key（证明错误文案走了 i18n 而非硬编码中文）；
+ * - t 被以正确的 key + defaultValue（主干原文）调用；
+ * - 校验失败时不会发起后端检索。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { tMock, vfsMultimodalSearch, vfsMultimodalSearchDetailed } = vi.hoisted(() => ({
+  tMock: vi.fn((key: string) => key),
+  vfsMultimodalSearch: vi.fn(),
+  vfsMultimodalSearchDetailed: vi.fn(),
+}));
+
+vi.mock('@/i18n', () => ({
+  default: { t: tMock },
+}));
+
+vi.mock('@/api/vfsRagApi', () => ({
+  vfsMultimodalIndex: vi.fn(),
+  vfsInspectRetrievalCapabilities: vi.fn(),
+  vfsMultimodalSearch,
+  vfsMultimodalSearchDetailed,
+  vfsMultimodalStats: vi.fn(),
+  vfsMultimodalDelete: vi.fn(),
+  vfsMultimodalIndexResource: vi.fn(),
+  parseRetrievalProvenance: vi.fn(() => []),
+}));
+
+import { retrieve, retrieveDetailed, searchByText } from '../multimodalRagService';
+
+const EMPTY_QUERY_KEY = 'enhanced_rag:retrieve.empty_query';
+const EMPTY_QUERY_FALLBACK = '检索请求必须包含文本、图片或两者';
+
+describe('multimodalRagService empty-query error i18n', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('retrieve rejects with the i18n key when both text and image are missing', async () => {
+    await expect(retrieve()).rejects.toThrow(EMPTY_QUERY_KEY);
+
+    expect(tMock).toHaveBeenCalledWith(EMPTY_QUERY_KEY, {
+      defaultValue: EMPTY_QUERY_FALLBACK,
+    });
+    expect(vfsMultimodalSearch).not.toHaveBeenCalled();
+  });
+
+  it('retrieveDetailed rejects with the i18n key for a whitespace-only query', async () => {
+    await expect(retrieveDetailed('   ')).rejects.toThrow(EMPTY_QUERY_KEY);
+
+    expect(tMock).toHaveBeenCalledWith(EMPTY_QUERY_KEY, {
+      defaultValue: EMPTY_QUERY_FALLBACK,
+    });
+    expect(vfsMultimodalSearchDetailed).not.toHaveBeenCalled();
+  });
+
+  it('searchByText rejects with the i18n key for an empty string', async () => {
+    await expect(searchByText('')).rejects.toThrow(EMPTY_QUERY_KEY);
+
+    expect(tMock).toHaveBeenCalledWith(EMPTY_QUERY_KEY, {
+      defaultValue: EMPTY_QUERY_FALLBACK,
+    });
+    expect(vfsMultimodalSearch).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/multimodalRagService.ts
+++ b/src/services/multimodalRagService.ts
@@ -31,6 +31,7 @@ import {
   type VfsRetrievalHitProvenance,
   type VfsMultimodalIndexResourceOutput,
 } from '@/api/vfsRagApi';
+import i18n from '@/i18n';
 
 // 供调用方直接复用后端 DTO 类型，避免在服务层重复声明形状。
 export type { VfsMultimodalIndexResourceOutput, VfsCapabilityState } from '@/api/vfsRagApi';
@@ -143,7 +144,9 @@ function buildLegacySearchInput(
   const hasText = Boolean(queryText?.trim());
   const hasImage = Boolean(queryImageBase64?.trim());
   if (!hasText && !hasImage) {
-    throw new Error('检索请求必须包含文本、图片或两者');
+    throw new Error(
+      i18n.t('enhanced_rag:retrieve.empty_query', { defaultValue: '检索请求必须包含文本、图片或两者' })
+    );
   }
 
   const queryMode: VfsMultimodalQueryMode = hasText && hasImage


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

多模态检索在空查询时 throw 硬编码中文「检索请求必须包含文本、图片或两者」。改为 `enhanced_rag:retrieve.empty_query`，不改 #209 的既有测试文件。

### Changes
- `buildLegacySearchInput` 空查询错误走 i18n
- zh-CN / en-US `enhanced_rag.json` 补 `retrieve.empty_query`
- 新增 key-echo 测试

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下发起空检索，错误应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

