### PR TITLE
fix(i18n): 画布 AI 编辑失败文案走 vfs:canvas_edit

### DIFF
--- a/src/features/notes/hooks/__tests__/useCanvasAIEditHandler.i18n.test.ts
+++ b/src/features/notes/hooks/__tests__/useCanvasAIEditHandler.i18n.test.ts
@@ -1,0 +1,167 @@
+/**
+ * 画布 AI 编辑失败文案 i18n key-echo 契约测试。
+ *
+ * mock `@/i18n` 为 (key) => key，触发 apply / rollback 失败路径，
+ * 断言用户/agent 可见错误走 `vfs:canvas_edit.*`，且回执（sendResult）
+ * 中携带的是 i18n 输出而非硬编码中文。
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { CrepeEditorApi } from '@/components/crepe';
+
+const i18nMock = vi.hoisted(() => ({
+  t: vi.fn((key: string) => key),
+}));
+vi.mock('@/i18n', () => ({ default: i18nMock }));
+
+const invokeMock = vi.hoisted(() => vi.fn(async (_cmd: string, _args?: Record<string, unknown>) => null));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => () => undefined),
+}));
+
+import { useCanvasAIEditHandler } from '../useCanvasAIEditHandler';
+
+const NOTE_ID = 'note-1';
+const ORIGINAL = '# Note\n\noriginal content';
+
+interface FakeEditorOptions {
+  /** replaceFullMarkdown 是否报告失败（内容仍会被写入，模拟"已应用但回报失败"） */
+  failReplace?: boolean;
+}
+
+function createFakeEditor(options: FakeEditorOptions = {}) {
+  const state = { content: ORIGINAL, failReplace: options.failReplace ?? false };
+  const editor = {
+    getMarkdown: () => state.content,
+    getFullMarkdown: () => state.content,
+    setMarkdown: (markdown: string) => {
+      state.content = markdown;
+      return true;
+    },
+    replaceFullMarkdown: async (markdown: string) => {
+      state.content = markdown;
+      return !state.failReplace;
+    },
+    focus: () => {},
+    isReadonly: () => false,
+  };
+  return { editor: editor as unknown as CrepeEditorApi, state };
+}
+
+function dispatchEditRequest(requestId: string) {
+  window.dispatchEvent(
+    new CustomEvent('canvas:ai-edit-request', {
+      detail: {
+        requestId,
+        noteId: NOTE_ID,
+        operation: 'set',
+        content: 'PROPOSED CONTENT',
+      },
+    })
+  );
+}
+
+function sentResults(): Array<{ requestId: string; success: boolean; error?: string }> {
+  return invokeMock.mock.calls
+    .filter(([cmd]) => cmd === 'chat_v2_canvas_edit_result')
+    .map(([, args]) => (args as { result: { requestId: string; success: boolean; error?: string } }).result);
+}
+
+describe('useCanvasAIEditHandler i18n key-echo', () => {
+  beforeEach(() => {
+    i18nMock.t.mockClear();
+    invokeMock.mockClear();
+  });
+
+  it('apply 失败：拒绝应用与恢复失败文案走 vfs:canvas_edit.*，回执携带 i18n 输出', async () => {
+    const { editor } = createFakeEditor({ failReplace: true });
+    const { result } = renderHook(() =>
+      useCanvasAIEditHandler({ noteId: NOTE_ID, editorApi: editor, enabled: true })
+    );
+
+    await act(async () => {
+      dispatchEditRequest('req-apply-fail');
+    });
+    await waitFor(() => expect(result.current.aiEditState.isActive).toBe(true));
+
+    await act(async () => {
+      await result.current.handleAccept();
+    });
+
+    // replaceFullMarkdown 返回 false → 抛出 apply_rejected；
+    // 失败后内容已是建议内容 → 尝试恢复，再次失败 → restore_rejected。
+    expect(i18nMock.t).toHaveBeenCalledWith(
+      'vfs:canvas_edit.apply_rejected',
+      expect.objectContaining({ defaultValue: '编辑器拒绝应用建议' })
+    );
+    expect(i18nMock.t).toHaveBeenCalledWith(
+      'vfs:canvas_edit.restore_rejected',
+      expect.objectContaining({ defaultValue: '编辑器拒绝恢复建议前内容' })
+    );
+
+    const failure = sentResults().find((r) => r.requestId === 'req-apply-fail');
+    expect(failure).toBeDefined();
+    expect(failure!.success).toBe(false);
+    expect(failure!.error).toBe('vfs:canvas_edit.apply_rejected');
+  });
+
+  it('rollback 失败：回滚检查点失败文案走 vfs:canvas_edit.rollback_rejected', async () => {
+    const { editor, state } = createFakeEditor();
+    const { result } = renderHook(() =>
+      useCanvasAIEditHandler({ noteId: NOTE_ID, editorApi: editor, enabled: true })
+    );
+
+    await act(async () => {
+      dispatchEditRequest('req-rollback');
+    });
+    await waitFor(() => expect(result.current.aiEditState.isActive).toBe(true));
+
+    // 先成功接受，产生检查点
+    await act(async () => {
+      await result.current.handleAccept();
+    });
+    expect(result.current.checkpoint).not.toBeNull();
+
+    // 再让编辑器拒绝回滚
+    state.failReplace = true;
+    await act(async () => {
+      await result.current.rollbackCheckpoint();
+    });
+
+    expect(i18nMock.t).toHaveBeenCalledWith(
+      'vfs:canvas_edit.rollback_rejected',
+      expect.objectContaining({ defaultValue: '编辑器拒绝回滚检查点' })
+    );
+    // 回滚失败时保留检查点，允许重试
+    expect(result.current.checkpoint).not.toBeNull();
+  });
+
+  it('编辑器只读：回执错误为 vfs:canvas_edit.editor_readonly', async () => {
+    const { editor } = createFakeEditor();
+    const readonlyRef = { value: false };
+    (editor as unknown as { isReadonly: () => boolean }).isReadonly = () => readonlyRef.value;
+
+    const { result } = renderHook(() =>
+      useCanvasAIEditHandler({ noteId: NOTE_ID, editorApi: editor, enabled: true })
+    );
+
+    await act(async () => {
+      dispatchEditRequest('req-readonly');
+    });
+    await waitFor(() => expect(result.current.aiEditState.isActive).toBe(true));
+
+    readonlyRef.value = true;
+    await act(async () => {
+      await result.current.handleAccept();
+    });
+
+    expect(i18nMock.t).toHaveBeenCalledWith(
+      'vfs:canvas_edit.editor_readonly',
+      expect.objectContaining({ defaultValue: '编辑器不可写，修改未应用' })
+    );
+    const failure = sentResults().find((r) => r.requestId === 'req-readonly');
+    expect(failure).toBeDefined();
+    expect(failure!.error).toBe('vfs:canvas_edit.editor_readonly');
+  });
+});

--- a/src/features/notes/hooks/useCanvasAIEditHandler.ts
+++ b/src/features/notes/hooks/useCanvasAIEditHandler.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
+import i18n from '@/i18n';
 import type { CrepeEditorApi } from '@/components/crepe';
 import {
   useAIEditState,
@@ -137,7 +138,7 @@ export function useCanvasAIEditHandler({
         await sendResult({
           requestId: result.requestId,
           success: false,
-          error: '编辑器不可写，修改未应用',
+          error: i18n.t('vfs:canvas_edit.editor_readonly', { defaultValue: '编辑器不可写，修改未应用' }),
         });
         return;
       }
@@ -155,7 +156,10 @@ export function useCanvasAIEditHandler({
           await sendResult({
             requestId: result.requestId,
             success: false,
-            error: `文档在等待确认期间已被修改，建议无法应用：${recomputed.error}`,
+            error: i18n.t('vfs:canvas_edit.doc_changed_while_pending', {
+              defaultValue: '文档在等待确认期间已被修改，建议无法应用：{{error}}',
+              error: recomputed.error,
+            }),
           });
           return;
         }
@@ -171,11 +175,11 @@ export function useCanvasAIEditHandler({
             expectedMarkdown: contentBeforeApply,
           });
           if (!replaced) {
-            throw new Error('编辑器拒绝应用建议');
+            throw new Error(i18n.t('vfs:canvas_edit.apply_rejected', { defaultValue: '编辑器拒绝应用建议' }));
           }
         } else {
           if (!editor.setMarkdown(proposedContent)) {
-            throw new Error('编辑器拒绝应用建议');
+            throw new Error(i18n.t('vfs:canvas_edit.apply_rejected', { defaultValue: '编辑器拒绝应用建议' }));
           }
           if (onSaveRef.current) {
             await onSaveRef.current(proposedContent);
@@ -190,10 +194,10 @@ export function useCanvasAIEditHandler({
                 expectedMarkdown: proposedContent,
               });
               if (!restored) {
-                throw new Error('编辑器拒绝恢复建议前内容');
+                throw new Error(i18n.t('vfs:canvas_edit.restore_rejected', { defaultValue: '编辑器拒绝恢复建议前内容' }));
               }
             } else if (!editor.setMarkdown(contentBeforeApply)) {
-              throw new Error('编辑器拒绝恢复建议前内容');
+              throw new Error(i18n.t('vfs:canvas_edit.restore_rejected', { defaultValue: '编辑器拒绝恢复建议前内容' }));
             }
           } catch (restoreErr) {
             console.warn('[useCanvasAIEditHandler] Failed to restore after apply error:', restoreErr);
@@ -202,7 +206,9 @@ export function useCanvasAIEditHandler({
         await sendResult({
           requestId: result.requestId,
           success: false,
-          error: err instanceof Error ? err.message : '应用编辑建议失败',
+          error: err instanceof Error
+            ? err.message
+            : i18n.t('vfs:canvas_edit.apply_failed', { defaultValue: '应用编辑建议失败' }),
           beforePreview: result.beforePreview,
           afterPreview: result.afterPreview,
           addedContent: result.addedContent,
@@ -242,10 +248,10 @@ export function useCanvasAIEditHandler({
           expectedMarkdown: current,
         });
         if (!restored) {
-          throw new Error('编辑器拒绝回滚检查点');
+          throw new Error(i18n.t('vfs:canvas_edit.rollback_rejected', { defaultValue: '编辑器拒绝回滚检查点' }));
         }
       } else if (!editor.setMarkdown(checkpoint.originalContent)) {
-        throw new Error('编辑器拒绝回滚检查点');
+        throw new Error(i18n.t('vfs:canvas_edit.rollback_rejected', { defaultValue: '编辑器拒绝回滚检查点' }));
       }
     } catch (err) {
       console.warn('[useCanvasAIEditHandler] Rollback apply failed:', err);
@@ -296,7 +302,7 @@ export function useCanvasAIEditHandler({
       if (pendingRequest) {
         request.onLocalDisposition?.({
           accepted: false,
-          reason: '已有一条笔记编辑建议等待确认',
+          reason: i18n.t('vfs:canvas_edit.suggestion_pending', { defaultValue: '已有一条笔记编辑建议等待确认' }),
         });
         try {
           await invoke('chat_v2_canvas_edit_ack', { requestId: request.requestId });
@@ -307,7 +313,9 @@ export function useCanvasAIEditHandler({
           await sendResult({
             requestId: request.requestId,
             success: false,
-            error: '已有一条笔记编辑建议等待确认，请先接受或拒绝当前建议',
+            error: i18n.t('vfs:canvas_edit.suggestion_pending_detail', {
+              defaultValue: '已有一条笔记编辑建议等待确认，请先接受或拒绝当前建议',
+            }),
           });
         }
         return;
@@ -317,11 +325,12 @@ export function useCanvasAIEditHandler({
       const editor = editorApiRef.current;
       if (!editor) {
         settlePendingRequest();
-        request.onLocalDisposition?.({ accepted: false, reason: '编辑器未就绪' });
+        const editorNotReady = i18n.t('vfs:canvas_edit.editor_not_ready', { defaultValue: '编辑器未就绪' });
+        request.onLocalDisposition?.({ accepted: false, reason: editorNotReady });
         const result: CanvasAIEditResult = {
           requestId: request.requestId,
           success: false,
-          error: '编辑器未就绪',
+          error: editorNotReady,
         };
         await sendResult(result);
         return;
@@ -338,7 +347,8 @@ export function useCanvasAIEditHandler({
         settlePendingRequest();
         request.onLocalDisposition?.({
           accepted: false,
-          reason: immediateFailure.error ?? '建议内容无效',
+          reason: immediateFailure.error
+            ?? i18n.t('vfs:canvas_edit.invalid_suggestion', { defaultValue: '建议内容无效' }),
         });
         await sendResult(immediateFailure);
         return;
@@ -427,7 +437,7 @@ export function useCanvasAIEditHandler({
           result: {
             requestId: pending.request.requestId,
             success: false,
-            error: '编辑器已关闭，修改未应用',
+            error: i18n.t('vfs:canvas_edit.editor_closed', { defaultValue: '编辑器已关闭，修改未应用' }),
           },
         }).catch((err) => {
           console.warn('[useCanvasAIEditHandler] Failed to send unmount rejection:', err);

--- a/src/locales/en-US/vfs.json
+++ b/src/locales/en-US/vfs.json
@@ -16,5 +16,18 @@
     "resolveFailed": "Failed to resolve resource references",
     "pathFailed": "Failed to get resource path",
     "cacheFailed": "Failed to update path cache"
+  },
+  "canvas_edit": {
+    "apply_rejected": "Editor refused to apply the suggestion",
+    "restore_rejected": "Editor refused to restore the pre-suggestion content",
+    "apply_failed": "Failed to apply the edit suggestion",
+    "rollback_rejected": "Editor refused to roll back to the checkpoint",
+    "editor_readonly": "Editor is not writable; changes were not applied",
+    "doc_changed_while_pending": "The document was modified while awaiting confirmation, so the suggestion cannot be applied: {{error}}",
+    "suggestion_pending": "A note edit suggestion is already awaiting confirmation",
+    "suggestion_pending_detail": "A note edit suggestion is already awaiting confirmation; accept or reject the current one first",
+    "editor_not_ready": "Editor is not ready",
+    "invalid_suggestion": "Invalid suggestion content",
+    "editor_closed": "Editor was closed; changes were not applied"
   }
 }

--- a/src/locales/zh-CN/vfs.json
+++ b/src/locales/zh-CN/vfs.json
@@ -16,5 +16,18 @@
     "resolveFailed": "解析资源引用失败",
     "pathFailed": "获取资源路径失败",
     "cacheFailed": "更新路径缓存失败"
+  },
+  "canvas_edit": {
+    "apply_rejected": "编辑器拒绝应用建议",
+    "restore_rejected": "编辑器拒绝恢复建议前内容",
+    "apply_failed": "应用编辑建议失败",
+    "rollback_rejected": "编辑器拒绝回滚检查点",
+    "editor_readonly": "编辑器不可写，修改未应用",
+    "doc_changed_while_pending": "文档在等待确认期间已被修改，建议无法应用：{{error}}",
+    "suggestion_pending": "已有一条笔记编辑建议等待确认",
+    "suggestion_pending_detail": "已有一条笔记编辑建议等待确认，请先接受或拒绝当前建议",
+    "editor_not_ready": "编辑器未就绪",
+    "invalid_suggestion": "建议内容无效",
+    "editor_closed": "编辑器已关闭，修改未应用"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

画布 AI 编辑失败时，`sendResult.error` 与 throw 文案是硬编码中文。改为 `vfs:canvas_edit.*`，不改被占用的 `notes.json`。

### Changes
- `useCanvasAIEditHandler` 用户/agent 可见失败文案走 i18n（应用拒绝、恢复、回滚、只读、建议待确认等）
- zh-CN / en-US `vfs.json` 补 `canvas_edit` 组
- 新增 key-echo 测试

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下让编辑器拒绝 AI 建议，回执应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

