### PR TITLE
fix(i18n): 预览 Base64 解码错误走 pdf:preview

### DIFF
--- a/src/features/learning-hub/apps/views/__tests__/previewUtils.i18n.test.ts
+++ b/src/features/learning-hub/apps/views/__tests__/previewUtils.i18n.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/i18n', () => ({
+  default: {
+    t: (key: string) => key,
+  },
+}));
+
+import { decodeBase64ToArrayBuffer } from '../previewUtils';
+
+describe('previewUtils Base64 解码错误 i18n', () => {
+  it('空字符串抛出 pdf:preview.empty_content', () => {
+    expect(() => decodeBase64ToArrayBuffer('')).toThrowError('pdf:preview.empty_content');
+  });
+
+  it('非法 base64 抛出 pdf:preview.decode_failed', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => decodeBase64ToArrayBuffer('!!!not-base64!!!')).toThrowError('pdf:preview.decode_failed');
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});

--- a/src/features/learning-hub/apps/views/previewUtils.ts
+++ b/src/features/learning-hub/apps/views/previewUtils.ts
@@ -4,6 +4,8 @@
  * 提供 Base64 解码、数值限制、缩放常量、偏好持久化等通用功能
  */
 
+import i18n from '@/i18n';
+
 // ============================================================================
 // Base64 解码工具
 // ============================================================================
@@ -43,7 +45,7 @@ export const normalizeBase64 = (input: string): string => {
  */
 export const decodeBase64ToArrayBuffer = (normalizedBase64: string): ArrayBuffer => {
   if (!normalizedBase64) {
-    throw new Error('内容为空');
+    throw new Error(i18n.t('pdf:preview.empty_content', { defaultValue: '内容为空' }));
   }
   
   let binaryString = '';
@@ -52,7 +54,7 @@ export const decodeBase64ToArrayBuffer = (normalizedBase64: string): ArrayBuffer
   } catch {
     const preview = normalizedBase64.slice(0, 80);
     console.error('[decodeBase64ToArrayBuffer] atob failed, input preview:', preview, 'length:', normalizedBase64.length);
-    throw new Error('内容解码失败');
+    throw new Error(i18n.t('pdf:preview.decode_failed', { defaultValue: '内容解码失败' }));
   }
   
   const bytes = new Uint8Array(binaryString.length);

--- a/src/locales/en-US/pdf.json
+++ b/src/locales/en-US/pdf.json
@@ -23,6 +23,10 @@
     "description": "Choose a PDF file to start reading",
     "select_button": "Choose PDF file"
   },
+  "preview": {
+    "empty_content": "Content is empty",
+    "decode_failed": "Failed to decode content"
+  },
   "errors": {
     "invalid_file": "Please choose a valid PDF file",
     "load_failed": "Failed to load PDF. Please retry",

--- a/src/locales/zh-CN/pdf.json
+++ b/src/locales/zh-CN/pdf.json
@@ -23,6 +23,10 @@
     "description": "选择一个 PDF 文件开始阅读",
     "select_button": "选择 PDF 文件"
   },
+  "preview": {
+    "empty_content": "内容为空",
+    "decode_failed": "内容解码失败"
+  },
   "errors": {
     "invalid_file": "请选择有效的 PDF 文件",
     "load_failed": "PDF 加载失败，请重试",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

学习中心预览把 Base64 解码失败写成硬编码中文。改为 `pdf:preview.*`，不改被占用的 `vfs.json` / `learningHub.json`。

### Changes
- `decodeBase64ToArrayBuffer` 的空内容 / 解码失败 throw 走 i18n
- zh-CN / en-US `pdf.json` 补 `preview` 组
- 新增 key-echo 测试

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下打开损坏的预览内容，错误应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

