### PR TITLE
fix(i18n): 学习中心笔记错误文案走 backend_errors:note_content

### DIFF
--- a/src/features/learning-hub/apps/views/NoteContentView.tsx
+++ b/src/features/learning-hub/apps/views/NoteContentView.tsx
@@ -15,6 +15,7 @@ import { DsButton } from '@/components/ui/DsButton';
 import { NotesCrepeEditor } from '@/features/notes/NotesCrepeEditor';
 import { NotesContextPanel } from '@/features/notes/NotesContextPanel';
 import { reportError, toVfsError, VfsError, VfsErrorCode } from '@/shared/result';
+import i18n from '@/i18n';
 import { dstu } from '@/dstu';
 import { useSystemStatusStore } from '@/stores/systemStatusStore';
 import { showGlobalNotification } from '@/components/UnifiedNotification';
@@ -241,7 +242,7 @@ const NoteContentView: React.FC<ContentViewProps> = ({
       // dstu API 均为 Result 语义、正常不抛异常；此处兜底防止
       // 意外 throw 让 isLoading 永远卡住（无重试入口的死加载态）
       if (loadingNoteIdRef.current !== currentNoteId) return;
-      setError(toVfsError(unexpected, '加载笔记内容失败'));
+      setError(toVfsError(unexpected, i18n.t('backend_errors:note_content.load_note_failed', { defaultValue: '加载笔记内容失败' })));
       setIsLoading(false);
       return;
     }
@@ -254,7 +255,7 @@ const NoteContentView: React.FC<ContentViewProps> = ({
     if (!result.ok) {
       console.error('[NoteContentView] ❌ 加载笔记内容失败:', result.error);
       if (result.error.code !== VfsErrorCode.NOT_FOUND) {
-        reportError(result.error, '加载笔记内容');
+        reportError(result.error, i18n.t('backend_errors:note_content.load_note_action', { defaultValue: '加载笔记内容' }));
       }
       setError(result.error);
       setIsLoading(false);
@@ -378,9 +379,9 @@ const NoteContentView: React.FC<ContentViewProps> = ({
         if (isContentDirty('note', currentNoteId)) {
           showGlobalNotification(
             'warning',
-            t(
-              'notes:editor.deleted_with_unsaved_changes',
-              '资源已被删除；窗口保留未保存内容，请复制内容后再关闭。',
+            i18n.t(
+              'backend_errors:note_content.deleted_with_unsaved_changes',
+              { defaultValue: '资源已被删除；窗口保留未保存内容，请复制内容后再关闭。' },
             ),
           );
           return;
@@ -647,7 +648,7 @@ const NoteContentView: React.FC<ContentViewProps> = ({
       }
 
       console.error('[NoteContentView] ❌ 保存笔记失败:', result.error);
-      reportError(result.error, '保存笔记');
+      reportError(result.error, i18n.t('backend_errors:note_content.save_note_action', { defaultValue: '保存笔记' }));
       throw new Error(result.error.toUserMessage());
     } finally {
       // 并发保存（强制保存 + 自动保存）时避免误清对方的标志
@@ -672,7 +673,7 @@ const NoteContentView: React.FC<ContentViewProps> = ({
     const result = await dstu.setMetadata(node.path, { title: newTitle });
     if (!result.ok) {
       console.error('[NoteContentView] Failed to update title:', result.error);
-      reportError(result.error, '更新标题');
+      reportError(result.error, i18n.t('backend_errors:note_content.update_title_action', { defaultValue: '更新标题' }));
       throw new Error(result.error.toUserMessage());
     }
     // ★ R4：await 期间可能已切换笔记，禁止把旧笔记标题回写进当前视图
@@ -689,7 +690,7 @@ const NoteContentView: React.FC<ContentViewProps> = ({
     const result = await dstu.setMetadata(node.path, { tags: newTags });
     if (!result.ok) {
       console.error('[NoteContentView] Failed to update tags:', result.error);
-      reportError(result.error, '更新标签');
+      reportError(result.error, i18n.t('backend_errors:note_content.update_tags_action', { defaultValue: '更新标签' }));
       throw new Error(result.error.toUserMessage());
     }
     if (loadingNoteIdRef.current !== savedNoteId) return;
@@ -734,16 +735,16 @@ const NoteContentView: React.FC<ContentViewProps> = ({
         isDocumentWindowed: () => markdownWindowRef.current?.hasMore === true,
         replaceFullMarkdown: async (markdown, options) => {
           if (loadingNoteIdRef.current !== node.id) {
-            throw new Error('笔记实例已切换，拒绝写入过期编辑器');
+            throw new Error(i18n.t('backend_errors:note_content.stale_editor_write_rejected', { defaultValue: '笔记实例已切换，拒绝写入过期编辑器' }));
           }
           if (api.isReadonly()) {
-            throw new Error('笔记编辑器为只读状态');
+            throw new Error(i18n.t('backend_errors:note_content.editor_readonly', { defaultValue: '笔记编辑器为只读状态' }));
           }
 
           const previousFull = getLiveFullMarkdown();
           const previousBackingFull = fullContentRef.current;
           if (previousFull !== options.expectedMarkdown) {
-            throw new Error('笔记正文已变化，全文写入 OCC 校验失败');
+            throw new Error(i18n.t('backend_errors:note_content.full_write_occ_failed', { defaultValue: '笔记正文已变化，全文写入 OCC 校验失败' }));
           }
 
           const previousWindow = markdownWindowRef.current;
@@ -768,15 +769,15 @@ const NoteContentView: React.FC<ContentViewProps> = ({
             setContent(previousBackingFull);
             setMarkdownWindow(previousWindow);
             if (previousWindow) api.setMarkdown(previousWindow.loadedMarkdown);
-            throw new Error('编辑器未确认全文替换');
+            throw new Error(i18n.t('backend_errors:note_content.full_replace_not_confirmed', { defaultValue: '编辑器未确认全文替换' }));
           }
           if (!api.flushPendingSave) {
-            throw new Error('编辑器未提供持久化确认能力');
+            throw new Error(i18n.t('backend_errors:note_content.flush_capability_missing', { defaultValue: '编辑器未提供持久化确认能力' }));
           }
 
           await api.flushPendingSave();
           if (persistedContentRef.current !== markdown) {
-            throw new Error('笔记全文替换未通过持久化验证');
+            throw new Error(i18n.t('backend_errors:note_content.full_replace_persist_failed', { defaultValue: '笔记全文替换未通过持久化验证' }));
           }
           return true;
         },

--- a/src/features/learning-hub/apps/views/__tests__/NoteContentView.i18n.test.ts
+++ b/src/features/learning-hub/apps/views/__tests__/NoteContentView.i18n.test.ts
@@ -1,0 +1,89 @@
+/**
+ * NoteContentView 用户可见错误/通知文案 i18n 契约测试
+ *
+ * 背景：学习中心笔记视图的加载/保存/OCC 失败文案曾是硬编码中文。
+ * notes.json / learningHub.json 命名空间已被其他切片占用，
+ * 本切片将新 key 收敛到 backend_errors.json 的 note_content 分组。
+ *
+ * 契约：
+ * - 源码中所有用户可见的 throw / setError fallback / reportError 动作名 /
+ *   通知正文必须通过 i18n.t('backend_errors:note_content.<key>', { defaultValue }) 调用；
+ * - defaultValue 与 zh-CN locale 完全一致（key-echo，防止 key 与文案漂移）；
+ * - zh-CN / en-US 两份 locale 的 note_content key 集合一致；
+ * - 源码不得残留裸中文 throw new Error('...')。
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  path.join(process.cwd(), 'src/features/learning-hub/apps/views/NoteContentView.tsx'),
+  'utf8',
+);
+
+const zhCN = JSON.parse(
+  readFileSync(path.join(process.cwd(), 'src/locales/zh-CN/backend_errors.json'), 'utf8'),
+) as Record<string, Record<string, string>>;
+
+const enUS = JSON.parse(
+  readFileSync(path.join(process.cwd(), 'src/locales/en-US/backend_errors.json'), 'utf8'),
+) as Record<string, Record<string, string>>;
+
+/** 主干必须覆盖的 key -> 原中文文案（与任务验收清单一一对应） */
+const REQUIRED_KEYS: Record<string, string> = {
+  load_note_failed: '加载笔记内容失败',
+  load_note_action: '加载笔记内容',
+  deleted_with_unsaved_changes: '资源已被删除；窗口保留未保存内容，请复制内容后再关闭。',
+  save_note_action: '保存笔记',
+  update_title_action: '更新标题',
+  update_tags_action: '更新标签',
+  stale_editor_write_rejected: '笔记实例已切换，拒绝写入过期编辑器',
+  editor_readonly: '笔记编辑器为只读状态',
+  full_write_occ_failed: '笔记正文已变化，全文写入 OCC 校验失败',
+  full_replace_not_confirmed: '编辑器未确认全文替换',
+  flush_capability_missing: '编辑器未提供持久化确认能力',
+  full_replace_persist_failed: '笔记全文替换未通过持久化验证',
+};
+
+describe('NoteContentView backend_errors:note_content i18n contract', () => {
+  it("imports the shared i18n instance via '@/i18n'", () => {
+    expect(source).toContain("import i18n from '@/i18n';");
+  });
+
+  it.each(Object.entries(REQUIRED_KEYS))(
+    'calls i18n.t for backend_errors:note_content.%s with the original Chinese defaultValue',
+    (key, zhText) => {
+      // 允许单行或多行（prettier 折行）两种排版
+      const callPattern = new RegExp(
+        `i18n\\.t\\(\\s*'backend_errors:note_content\\.${key}',\\s*\\{\\s*defaultValue:\\s*'([^']+)'\\s*,?\\s*\\}`,
+        'm',
+      );
+      const match = source.match(callPattern);
+      expect(match, `源码中缺少 backend_errors:note_content.${key} 的 i18n.t 调用`).not.toBeNull();
+      expect(match![1], `key ${key} 的 defaultValue 与原中文文案不一致`).toBe(zhText);
+    },
+  );
+
+  it('key-echo: zh-CN locale mirrors every required key with the exact original text', () => {
+    expect(zhCN.note_content, 'zh-CN backend_errors.json 缺少 note_content 分组').toBeDefined();
+    for (const [key, zhText] of Object.entries(REQUIRED_KEYS)) {
+      expect(zhCN.note_content[key], `zh-CN note_content.${key} 缺失或文案漂移`).toBe(zhText);
+    }
+  });
+
+  it('en-US locale provides a non-empty English translation for every note_content key', () => {
+    expect(enUS.note_content, 'en-US backend_errors.json 缺少 note_content 分组').toBeDefined();
+    expect(Object.keys(enUS.note_content).sort()).toEqual(Object.keys(zhCN.note_content).sort());
+    for (const [key, value] of Object.entries(enUS.note_content)) {
+      expect(value.trim(), `en-US note_content.${key} 不能为空`).not.toBe('');
+      expect(value, `en-US note_content.${key} 不应残留中文`).not.toMatch(/[\u4e00-\u9fff]/);
+    }
+  });
+
+  it('leaves no user-visible hardcoded Chinese throw / reportError / toVfsError in the source', () => {
+    expect(source).not.toMatch(/throw new Error\('[^']*[\u4e00-\u9fff]/);
+    expect(source).not.toMatch(/reportError\([^,]+,\s*'[^']*[\u4e00-\u9fff]/);
+    expect(source).not.toMatch(/toVfsError\([^,]+,\s*'[^']*[\u4e00-\u9fff]/);
+  });
+});

--- a/src/locales/en-US/backend_errors.json
+++ b/src/locales/en-US/backend_errors.json
@@ -128,5 +128,19 @@
   "metrics": {
     "parse_addr_failed": "Failed to parse DSTU_METRICS_ADDR",
     "server_error": "Metrics server error"
+  },
+  "note_content": {
+    "load_note_failed": "Failed to load note content",
+    "load_note_action": "Load note content",
+    "deleted_with_unsaved_changes": "The resource has been deleted; this window keeps your unsaved content, please copy it before closing.",
+    "save_note_action": "Save note",
+    "update_title_action": "Update title",
+    "update_tags_action": "Update tags",
+    "stale_editor_write_rejected": "Note instance has switched; refusing to write to a stale editor",
+    "editor_readonly": "Note editor is read-only",
+    "full_write_occ_failed": "Note content has changed; full-document write failed OCC validation",
+    "full_replace_not_confirmed": "Editor did not confirm the full-document replacement",
+    "flush_capability_missing": "Editor does not provide persistence confirmation capability",
+    "full_replace_persist_failed": "Full-document replacement failed persistence verification"
   }
 }

--- a/src/locales/zh-CN/backend_errors.json
+++ b/src/locales/zh-CN/backend_errors.json
@@ -128,5 +128,19 @@
   "metrics": {
     "parse_addr_failed": "解析DSTU_METRICS_ADDR失败",
     "server_error": "metrics server错误"
+  },
+  "note_content": {
+    "load_note_failed": "加载笔记内容失败",
+    "load_note_action": "加载笔记内容",
+    "deleted_with_unsaved_changes": "资源已被删除；窗口保留未保存内容，请复制内容后再关闭。",
+    "save_note_action": "保存笔记",
+    "update_title_action": "更新标题",
+    "update_tags_action": "更新标签",
+    "stale_editor_write_rejected": "笔记实例已切换，拒绝写入过期编辑器",
+    "editor_readonly": "笔记编辑器为只读状态",
+    "full_write_occ_failed": "笔记正文已变化，全文写入 OCC 校验失败",
+    "full_replace_not_confirmed": "编辑器未确认全文替换",
+    "flush_capability_missing": "编辑器未提供持久化确认能力",
+    "full_replace_persist_failed": "笔记全文替换未通过持久化验证"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

学习中心笔记视图把加载/保存/OCC 失败写成硬编码中文。改为 `backend_errors:note_content.*`，不改被占用的 `notes.json` / `learningHub.json`。

### Changes
- `NoteContentView` 用户可见 throw / reportError / 删除保留未保存内容通知走 i18n
- zh-CN / en-US `backend_errors.json` 补 `note_content` 组
- 新增 key-echo + 源码契约测试

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下保存冲突或加载失败，错误应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

