### PR TITLE
fix(i18n): 图片预览未就绪 hint 走 textbook:image_preview

### DIFF
--- a/src/features/learning-hub/apps/views/ImageContentView.tsx
+++ b/src/features/learning-hub/apps/views/ImageContentView.tsx
@@ -32,6 +32,7 @@
 
 import React, { useState, useCallback, useRef, useEffect, useLayoutEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import i18n from '@/i18n';
 import {
   MagnifyingGlassPlus,
   MagnifyingGlassMinus,
@@ -748,7 +749,9 @@ const ImageContentView: React.FC<ContentViewProps> = ({
           return {
             handled: false,
             code: 'ACTION_UNAVAILABLE',
-            hint: '图片尚未加载完成，无法缩放',
+            hint: i18n.t('textbook:image_preview.zoom_not_ready', {
+              defaultValue: '图片尚未加载完成，无法缩放',
+            }),
           };
         }
         const before = { zoomPercent: Math.round(s.effectiveZoom), fitMode: s.fitMode };
@@ -760,7 +763,11 @@ const ImageContentView: React.FC<ContentViewProps> = ({
           return {
             handled: false,
             code: 'INVALID_ARGS',
-            hint: `zoom 百分比须在 ${ZOOM_MIN}–${ZOOM_MAX} 之间，或传 'fit'`,
+            hint: i18n.t('textbook:image_preview.zoom_out_of_range', {
+              defaultValue: "zoom 百分比须在 {{min}}–{{max}} 之间，或传 'fit'",
+              min: ZOOM_MIN,
+              max: ZOOM_MAX,
+            }),
           };
         }
         applyZoom(zoom);
@@ -777,14 +784,18 @@ const ImageContentView: React.FC<ContentViewProps> = ({
           return {
             handled: false,
             code: 'ACTION_UNAVAILABLE',
-            hint: '图片尚未加载完成，无法旋转',
+            hint: i18n.t('textbook:image_preview.rotate_not_ready', {
+              defaultValue: '图片尚未加载完成，无法旋转',
+            }),
           };
         }
         if (degrees !== 90 && degrees !== 180 && degrees !== 270) {
           return {
             handled: false,
             code: 'INVALID_ARGS',
-            hint: 'rotate 的 degrees 仅支持 90/180/270（顺时针）',
+            hint: i18n.t('textbook:image_preview.rotate_invalid_degrees', {
+              defaultValue: 'rotate 的 degrees 仅支持 90/180/270（顺时针）',
+            }),
           };
         }
         setRotation((prev) => prev + degrees);

--- a/src/features/learning-hub/apps/views/__tests__/ImageContentView.hint.i18n.test.ts
+++ b/src/features/learning-hub/apps/views/__tests__/ImageContentView.hint.i18n.test.ts
@@ -1,0 +1,75 @@
+/**
+ * 图片预览 agent hint i18n 契约（textbook:image_preview）
+ *
+ * ImageContentView 的 setZoom/rotate agent surface 回调此前硬编码中文 hint；
+ * 现改走 textbook:image_preview.* 键（defaultValue 保持主干原文）。
+ * 本测试锁定：
+ * 1. zh-CN / en-US 的 image_preview 叶子键对齐，zh 文案即主干原文；
+ * 2. 源码通过 i18n.t 引用全部四个键，且 defaultValue 与 zh 文案一致
+ *    （defaultValue 兜底保证现有测试与未配置 locale 时行为不变）；
+ * 3. 源码不再以字面量形式硬编码这批 hint。
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import zhTextbook from '@/locales/zh-CN/textbook.json';
+import enTextbook from '@/locales/en-US/textbook.json';
+
+const SOURCE_PATH = 'src/features/learning-hub/apps/views/ImageContentView.tsx';
+
+const ZH_COPY: Record<string, string> = {
+  zoom_not_ready: '图片尚未加载完成，无法缩放',
+  zoom_out_of_range: "zoom 百分比须在 {{min}}–{{max}} 之间，或传 'fit'",
+  rotate_not_ready: '图片尚未加载完成，无法旋转',
+  rotate_invalid_degrees: 'rotate 的 degrees 仅支持 90/180/270（顺时针）',
+};
+
+function readSource(): string {
+  return readFileSync(resolve(process.cwd(), SOURCE_PATH), 'utf8');
+}
+
+describe('ImageContentView agent hint i18n contract (textbook:image_preview)', () => {
+  it('keeps zh-CN and en-US image_preview leaf keys aligned', () => {
+    const zh = zhTextbook.image_preview as Record<string, string>;
+    const en = enTextbook.image_preview as Record<string, string>;
+    expect(Object.keys(zh).sort()).toEqual(Object.keys(en).sort());
+    expect(Object.keys(zh).sort()).toEqual(Object.keys(ZH_COPY).sort());
+  });
+
+  it('keeps zh-CN copy identical to the original main-branch hints', () => {
+    const zh = zhTextbook.image_preview as Record<string, string>;
+    for (const [key, copy] of Object.entries(ZH_COPY)) {
+      expect(zh[key]).toBe(copy);
+    }
+  });
+
+  it('keeps {{min}}/{{max}} interpolation in both locales for the zoom range hint', () => {
+    for (const locale of [zhTextbook, enTextbook]) {
+      const copy = (locale.image_preview as Record<string, string>).zoom_out_of_range;
+      expect(copy).toContain('{{min}}');
+      expect(copy).toContain('{{max}}');
+    }
+  });
+
+  it('references every image_preview key via i18n.t with the zh copy as defaultValue', () => {
+    const source = readSource();
+    for (const key of Object.keys(ZH_COPY)) {
+      expect(source).toContain(`i18n.t('textbook:image_preview.${key}'`);
+    }
+    // defaultValue 兜底 = zh 原文（zoom_out_of_range 用双引号包裹以容纳 'fit'）
+    expect(source).toContain("defaultValue: '图片尚未加载完成，无法缩放'");
+    expect(source).toContain("defaultValue: '图片尚未加载完成，无法旋转'");
+    expect(source).toContain(
+      'defaultValue: "zoom 百分比须在 {{min}}–{{max}} 之间，或传 \'fit\'"'
+    );
+    expect(source).toContain("defaultValue: 'rotate 的 degrees 仅支持 90/180/270（顺时针）'");
+  });
+
+  it('no longer hardcodes the hints as plain literals', () => {
+    const source = readSource();
+    expect(source).not.toContain("hint: '图片尚未加载完成，无法缩放'");
+    expect(source).not.toContain("hint: '图片尚未加载完成，无法旋转'");
+    expect(source).not.toContain('hint: `zoom 百分比须在 ${ZOOM_MIN}–${ZOOM_MAX}');
+    expect(source).not.toContain("hint: 'rotate 的 degrees 仅支持 90/180/270（顺时针）'");
+  });
+});

--- a/src/locales/en-US/textbook.json
+++ b/src/locales/en-US/textbook.json
@@ -47,6 +47,12 @@
     "tooltip": "Page {{page}}",
     "tooltip_with_name": "{{name}} · Page {{page}}"
   },
+  "image_preview": {
+    "zoom_not_ready": "Image has not finished loading; zoom is unavailable",
+    "zoom_out_of_range": "zoom percent must be between {{min}}–{{max}}, or pass 'fit'",
+    "rotate_not_ready": "Image has not finished loading; rotate is unavailable",
+    "rotate_invalid_degrees": "rotate only supports degrees of 90/180/270 (clockwise)"
+  },
   "bookmarkSaveFailed": "Failed to save bookmark",
   "export_no_pdf_file": "No PDF file available for export",
   "export_render_failed": "Unable to render selected pages"

--- a/src/locales/zh-CN/textbook.json
+++ b/src/locales/zh-CN/textbook.json
@@ -47,6 +47,12 @@
     "tooltip": "第{{page}}页",
     "tooltip_with_name": "{{name}} 第{{page}}页"
   },
+  "image_preview": {
+    "zoom_not_ready": "图片尚未加载完成，无法缩放",
+    "zoom_out_of_range": "zoom 百分比须在 {{min}}–{{max}} 之间，或传 'fit'",
+    "rotate_not_ready": "图片尚未加载完成，无法旋转",
+    "rotate_invalid_degrees": "rotate 的 degrees 仅支持 90/180/270（顺时针）"
+  },
   "bookmarkSaveFailed": "书签保存失败",
   "export_no_pdf_file": "未找到可导出的PDF文件",
   "export_render_failed": "无法渲染选中的页面"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

图片预览 agent 在未加载完成时返回硬编码中文 hint。改为 `textbook:image_preview.*`，不改被占用的 `vfs.json` / `pdf.json` / `ImageViewer.tsx`。

### Changes
- `ImageContentView` 缩放/旋转 hint 走 i18n
- zh-CN / en-US `textbook.json` 补 `image_preview` 组
- 新增 hint 契约测试

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下在图片未加载完时触发缩放/旋转，hint 应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

