### PR TITLE
fix(i18n): DSTU 列表与创建空资源错误走 stats:dstu

### DIFF
--- a/src/dstu/__tests__/dstuListCreate.i18n.test.ts
+++ b/src/dstu/__tests__/dstuListCreate.i18n.test.ts
@@ -1,0 +1,123 @@
+/**
+ * DSTU 列表加载与创建空资源错误标签 i18n 测试
+ *
+ * 验证 useDstuList / createEmpty 的用户可见 reportError 标签
+ * 走 stats:dstu 命名空间，且 zh-CN / en-US 语言文件包含对应 key。
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import zhStats from '@/locales/zh-CN/stats.json';
+import enStats from '@/locales/en-US/stats.json';
+
+vi.mock('@/i18n', async () => {
+  const { default: zh } = await import('@/locales/zh-CN/stats.json');
+
+  const lookup = (obj: unknown, path: string): unknown =>
+    path.split('.').reduce<unknown>((acc, part) => {
+      if (acc && typeof acc === 'object' && part in (acc as Record<string, unknown>)) {
+        return (acc as Record<string, unknown>)[part];
+      }
+      return undefined;
+    }, obj);
+
+  const t = (key: string, options?: Record<string, unknown>): string => {
+    const [ns, bare] = key.includes(':')
+      ? (key.split(':') as [string, string])
+      : ['', key];
+    const raw = ns === 'stats' ? lookup(zh, bare) : undefined;
+    const template =
+      typeof raw === 'string'
+        ? raw
+        : typeof options?.defaultValue === 'string'
+          ? options.defaultValue
+          : key;
+    return template.replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
+      String(options?.[name] ?? '')
+    );
+  };
+
+  return { default: { t } };
+});
+
+vi.mock('@/shared/result', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/shared/result')>();
+  return {
+    ...actual,
+    reportError: vi.fn(),
+  };
+});
+
+vi.mock('../api', () => ({
+  dstu: {
+    list: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+import { dstu } from '../api';
+import { ok, err, reportError, VfsError, VfsErrorCode } from '@/shared/result';
+import { useDstuList } from '../hooks/useDstuList';
+import { createEmpty, type CreatableResourceType } from '../factory';
+
+const reportErrorMock = vi.mocked(reportError);
+const listMock = vi.mocked(dstu.list);
+const createMock = vi.mocked(dstu.create);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('locale files', () => {
+  it('zh-CN stats.json 包含 dstu key，取值与主干原文一致', () => {
+    expect(zhStats.dstu.load_list).toBe('加载列表');
+    expect(zhStats.dstu.create_empty).toBe('创建空资源');
+    expect(zhStats.dstu.unknown_resource_type).toBe('未知的资源类型: {{type}}');
+  });
+
+  it('en-US stats.json 包含对应的 dstu key', () => {
+    expect(enStats.dstu.load_list).toBeTruthy();
+    expect(enStats.dstu.create_empty).toBeTruthy();
+    expect(enStats.dstu.unknown_resource_type).toContain('{{type}}');
+  });
+});
+
+describe('useDstuList i18n', () => {
+  it('列表加载失败时 reportError 使用 stats:dstu.load_list 的翻译', async () => {
+    const listError = new VfsError(VfsErrorCode.VALIDATION, 'list failed');
+    listMock.mockResolvedValue(err(listError));
+
+    const { result } = renderHook(() => useDstuList('/'));
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(listError);
+    });
+
+    expect(reportErrorMock).toHaveBeenCalledWith(listError, '加载列表');
+  });
+});
+
+describe('createEmpty i18n', () => {
+  it('未知资源类型时错误消息插值，reportError 使用 stats:dstu.create_empty 的翻译', async () => {
+    const result = await createEmpty({ type: 'bogus' as CreatableResourceType });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('未知的资源类型: bogus');
+      expect(result.error.code).toBe(VfsErrorCode.VALIDATION);
+    }
+    expect(reportErrorMock).toHaveBeenCalledWith(expect.any(VfsError), '创建空资源');
+  });
+
+  it('dstu.create 失败时 reportError 使用 stats:dstu.create_empty 的翻译', async () => {
+    const createError = new VfsError(VfsErrorCode.VALIDATION, 'create failed');
+    listMock.mockResolvedValue(ok([]));
+    createMock.mockResolvedValue(err(createError));
+
+    const result = await createEmpty({ type: 'note' });
+
+    expect(result.ok).toBe(false);
+    expect(reportErrorMock).toHaveBeenCalledWith(createError, '创建空资源');
+  });
+});

--- a/src/dstu/factory.ts
+++ b/src/dstu/factory.ts
@@ -5,6 +5,7 @@
  * 名称去重、元数据合并等业务逻辑。
  */
 
+import i18n from '@/i18n';
 import { dstu } from './api';
 import type { DstuNode, DstuNodeType } from './types';
 import { EMPTY_RESOURCE_TEMPLATES } from './types';
@@ -100,12 +101,12 @@ export async function createEmpty(options: CreateEmptyOptions): Promise<Result<D
   if (!template) {
     const error = new VfsError(
       VfsErrorCode.VALIDATION,
-      `未知的资源类型: ${type}`,
+      i18n.t('stats:dstu.unknown_resource_type', { defaultValue: '未知的资源类型: {{type}}', type }),
       false,
       { type }
     );
     logger.error('createEmpty', error.message, [options]);
-    reportError(error, '创建空资源');
+    reportError(error, i18n.t('stats:dstu.create_empty', { defaultValue: '创建空资源' }));
     return err(error);
   }
 
@@ -166,7 +167,7 @@ export async function createEmpty(options: CreateEmptyOptions): Promise<Result<D
 
   if (!createResult.ok) {
     logger.error('createEmpty', createResult.error.message, [options]);
-    reportError(createResult.error, '创建空资源');
+    reportError(createResult.error, i18n.t('stats:dstu.create_empty', { defaultValue: '创建空资源' }));
     return createResult;
   }
 

--- a/src/dstu/hooks/useDstuList.ts
+++ b/src/dstu/hooks/useDstuList.ts
@@ -15,6 +15,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import i18n from '@/i18n';
 import { dstu } from '../api';
 import type { DstuNode, DstuListOptions } from '../types';
 import { type VfsError, reportError } from '@/shared/result';
@@ -108,7 +109,7 @@ export function useDstuList(
         setTotal(reset ? result.value.length : offset + result.value.length);
       }
     } else {
-      reportError(result.error, '加载列表');
+      reportError(result.error, i18n.t('stats:dstu.load_list', { defaultValue: '加载列表' }));
       setError(result.error);
     }
 

--- a/src/locales/en-US/stats.json
+++ b/src/locales/en-US/stats.json
@@ -133,5 +133,10 @@
     "loadMore": "Load more",
     "recordCount": "{{count}} records",
     "noFilterResult": "No records match this filter"
+  },
+  "dstu": {
+    "load_list": "Load list",
+    "create_empty": "Create empty resource",
+    "unknown_resource_type": "Unknown resource type: {{type}}"
   }
 }

--- a/src/locales/zh-CN/stats.json
+++ b/src/locales/zh-CN/stats.json
@@ -133,5 +133,10 @@
     "loadMore": "加载更多",
     "recordCount": "{{count}} 条",
     "noFilterResult": "当前筛选下没有记录"
+  },
+  "dstu": {
+    "load_list": "加载列表",
+    "create_empty": "创建空资源",
+    "unknown_resource_type": "未知的资源类型: {{type}}"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

DSTU 列表加载与创建空资源把 `reportError` 动作名写成硬编码中文。改为 `stats:dstu.*`，不改被占用的 `dstu.json` / `finderStore`。

### Changes
- `useDstuList` 的「加载列表」与 `factory.createEmpty` 的「创建空资源 / 未知的资源类型」走 i18n
- zh-CN / en-US `stats.json` 补 `dstu` 组
- 新增 key-echo 测试

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下列表加载失败或创建未知类型，通知应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

