### PR TITLE
fix(i18n): 预览阅读进度/书签保存错误走 practice:preview_persist

### DIFF
--- a/src/features/learning-hub/apps/views/__tests__/previewPersistence.i18n.test.ts
+++ b/src/features/learning-hub/apps/views/__tests__/previewPersistence.i18n.test.ts
@@ -1,0 +1,169 @@
+/**
+ * previewPersistence i18n 契约
+ *
+ * 预览阅读进度 / 书签持久化失败的 reportError 标签必须走
+ * practice:preview_persist.*（defaultValue = 主干中文原文），
+ * 不允许在 reportError / toVfsError 调用点硬编码中文。
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import zhPractice from '@/locales/zh-CN/practice.json';
+import enPractice from '@/locales/en-US/practice.json';
+
+const { setMetadata, updateBookmarks, reportError, toVfsError, translate } = vi.hoisted(() => ({
+  setMetadata: vi.fn(),
+  updateBookmarks: vi.fn(),
+  reportError: vi.fn(),
+  toVfsError: vi.fn((error: unknown) => error),
+  translate: vi.fn((key: string) => `t:${key}`),
+}));
+
+vi.mock('@/dstu', () => ({ dstu: { setMetadata } }));
+vi.mock('@/api/vfsFileApi', () => ({ vfsFileApi: { updateBookmarks } }));
+vi.mock('@/shared/result', () => ({ reportError, toVfsError }));
+vi.mock('@/i18n', () => ({ default: { t: translate } }));
+
+import { createPreviewPersistController } from '../previewPersistence';
+
+const SOURCE_PATH = 'src/features/learning-hub/apps/views/previewPersistence.ts';
+
+const ZH_LABELS = {
+  save_progress: '保存阅读进度',
+  save_bookmarks: '保存书签',
+  save_bookmarks_failed: '保存书签失败',
+  flush_unsaved: '保存未持久化的阅读进度/书签',
+} as const;
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+function makeController(kind: 'textbook' | 'file') {
+  return createPreviewPersistController(
+    {
+      kind,
+      nodeId: 'node-1',
+      nodePath: '/node-1.pdf',
+      getMetadata: () => ({}),
+    },
+    { progressDebounceMs: 5, bookmarksDebounceMs: 5 },
+  );
+}
+
+describe('previewPersistence i18n locales', () => {
+  it('zh-CN keeps the original main-branch copy under practice:preview_persist', () => {
+    expect(zhPractice.preview_persist).toEqual(ZH_LABELS);
+  });
+
+  it('en-US mirrors the preview_persist leaf keys with translated copy', () => {
+    expect(Object.keys(enPractice.preview_persist).sort()).toEqual(
+      Object.keys(zhPractice.preview_persist).sort(),
+    );
+    for (const value of Object.values(enPractice.preview_persist)) {
+      expect(value).toBeTruthy();
+      expect(value).not.toMatch(/[\u4e00-\u9fff]/);
+    }
+  });
+});
+
+describe('previewPersistence i18n source contract', () => {
+  const source = readFileSync(resolve(process.cwd(), SOURCE_PATH), 'utf8');
+
+  it('imports the app i18n instance', () => {
+    expect(source).toContain("import i18n from '@/i18n';");
+  });
+
+  it('routes every user-facing label through practice:preview_persist keys', () => {
+    for (const key of Object.keys(ZH_LABELS)) {
+      expect(source).toContain(`i18n.t('practice:preview_persist.${key}'`);
+    }
+  });
+
+  it('only carries the Chinese copy as defaultValue, never as a raw label', () => {
+    for (const label of Object.values(ZH_LABELS)) {
+      const quoted = countOccurrences(source, `'${label}'`);
+      expect(quoted).toBeGreaterThan(0);
+      expect(quoted).toBe(countOccurrences(source, `defaultValue: '${label}'`));
+    }
+    expect(source).not.toContain("reportError(result.error, '");
+    expect(source).not.toContain("toVfsError(err, '");
+  });
+});
+
+describe('previewPersistence i18n runtime labels', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    setMetadata.mockReset();
+    updateBookmarks.mockReset();
+    reportError.mockClear();
+    toVfsError.mockClear();
+    translate.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('reports progress save failures with the save_progress label', async () => {
+    const error = new Error('meta write failed');
+    setMetadata.mockResolvedValue({ ok: false, error });
+    const controller = makeController('file');
+
+    controller.scheduleProgress({ page: 3, lastReadAt: 30 });
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(reportError).toHaveBeenCalledWith(error, 't:practice:preview_persist.save_progress');
+    expect(translate).toHaveBeenCalledWith('practice:preview_persist.save_progress', {
+      defaultValue: zhPractice.preview_persist.save_progress,
+    });
+  });
+
+  it('reports bookmark save failures with the save_bookmarks label', async () => {
+    const error = new Error('meta write failed');
+    setMetadata.mockResolvedValue({ ok: false, error });
+    const controller = makeController('file');
+
+    controller.scheduleBookmarks([{ id: 'b1', page: 7, title: 'Seven', createdAt: 10 }]);
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(reportError).toHaveBeenCalledWith(error, 't:practice:preview_persist.save_bookmarks');
+    expect(translate).toHaveBeenCalledWith('practice:preview_persist.save_bookmarks', {
+      defaultValue: zhPractice.preview_persist.save_bookmarks,
+    });
+  });
+
+  it('labels flush failures for the dual-write channel and pending metadata', async () => {
+    const dualWriteError = new Error('bookmarks channel down');
+    const metaError = new Error('meta write failed');
+    updateBookmarks.mockRejectedValue(dualWriteError);
+    setMetadata.mockResolvedValue({ ok: false, error: metaError });
+    const controller = makeController('textbook');
+
+    controller.scheduleProgress({ page: 8, lastReadAt: 20 });
+    controller.scheduleBookmarks([{ id: 'b1', page: 7, title: 'Seven', createdAt: 10 }]);
+    await controller.flush();
+
+    expect(toVfsError).toHaveBeenCalledWith(
+      dualWriteError,
+      't:practice:preview_persist.save_bookmarks_failed',
+    );
+    expect(reportError).toHaveBeenCalledWith(
+      dualWriteError,
+      't:practice:preview_persist.save_bookmarks',
+    );
+    expect(reportError).toHaveBeenCalledWith(
+      metaError,
+      't:practice:preview_persist.flush_unsaved',
+    );
+    expect(translate).toHaveBeenCalledWith('practice:preview_persist.save_bookmarks_failed', {
+      defaultValue: zhPractice.preview_persist.save_bookmarks_failed,
+    });
+    expect(translate).toHaveBeenCalledWith('practice:preview_persist.flush_unsaved', {
+      defaultValue: zhPractice.preview_persist.flush_unsaved,
+    });
+  });
+});

--- a/src/features/learning-hub/apps/views/previewPersistence.ts
+++ b/src/features/learning-hub/apps/views/previewPersistence.ts
@@ -15,6 +15,7 @@
  * 关 tab / 切换 node 时由 dispose() 内的 flush 兜底落盘。
  */
 
+import i18n from '@/i18n';
 import { dstu } from '@/dstu';
 import { vfsFileApi } from '@/api/vfsFileApi';
 import { reportError, toVfsError, type Result } from '@/shared/result';
@@ -128,7 +129,10 @@ export function createPreviewPersistController(
     };
     const result = await setMetadataWithRetry(newMetadata, 'readingProgress');
     if (!result.ok) {
-      reportError(result.error, '保存阅读进度');
+      reportError(
+        result.error,
+        i18n.t('practice:preview_persist.save_progress', { defaultValue: '保存阅读进度' }),
+      );
       options?.onProgressError?.(result.error);
     }
   };
@@ -152,7 +156,10 @@ export function createPreviewPersistController(
 
     const result = await setMetadataWithRetry(newMetadata, 'bookmarks');
     if (!result.ok) {
-      reportError(result.error, '保存书签');
+      reportError(
+        result.error,
+        i18n.t('practice:preview_persist.save_bookmarks', { defaultValue: '保存书签' }),
+      );
       options?.onBookmarksError?.(result.error);
     }
   };
@@ -201,7 +208,15 @@ export function createPreviewPersistController(
           } catch (err: unknown) {
             // ★ flush 常在关窗/切 node 前的最后一次落盘：书签双写通道失败
             // 不能连带丢掉 pending 的阅读进度，继续走 setMetadata。
-            reportError(toVfsError(err, '保存书签失败'), '保存书签');
+            reportError(
+              toVfsError(
+                err,
+                i18n.t('practice:preview_persist.save_bookmarks_failed', {
+                  defaultValue: '保存书签失败',
+                }),
+              ),
+              i18n.t('practice:preview_persist.save_bookmarks', { defaultValue: '保存书签' }),
+            );
             options?.onBookmarksError?.(err);
           }
         }
@@ -209,7 +224,12 @@ export function createPreviewPersistController(
 
       const result = await setMetadataWithRetry(mergedMetadata, 'flush');
       if (!result.ok) {
-        reportError(result.error, '保存未持久化的阅读进度/书签');
+        reportError(
+          result.error,
+          i18n.t('practice:preview_persist.flush_unsaved', {
+            defaultValue: '保存未持久化的阅读进度/书签',
+          }),
+        );
         if (progress) options?.onProgressError?.(result.error);
         if (bookmarks) options?.onBookmarksError?.(result.error);
       }

--- a/src/locales/en-US/practice.json
+++ b/src/locales/en-US/practice.json
@@ -531,5 +531,11 @@
   "stepper": {
     "decrease": "Decrease {{label}} count",
     "increase": "Increase {{label}} count"
+  },
+  "preview_persist": {
+    "save_progress": "Save reading progress",
+    "save_bookmarks": "Save bookmarks",
+    "save_bookmarks_failed": "Failed to save bookmarks",
+    "flush_unsaved": "Save unpersisted reading progress/bookmarks"
   }
 }

--- a/src/locales/zh-CN/practice.json
+++ b/src/locales/zh-CN/practice.json
@@ -531,5 +531,11 @@
   "stepper": {
     "decrease": "减少「{{label}}」数量",
     "increase": "增加「{{label}}」数量"
+  },
+  "preview_persist": {
+    "save_progress": "保存阅读进度",
+    "save_bookmarks": "保存书签",
+    "save_bookmarks_failed": "保存书签失败",
+    "flush_unsaved": "保存未持久化的阅读进度/书签"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

预览阅读进度/书签落盘失败时，`reportError` 动作名是硬编码中文。改为 `practice:preview_persist.*`，不改被占用的 `textbook.json` / `pdf.json` / `learningHub.json`。

### Changes
- `previewPersistence` 的保存进度/书签/flush 错误走 i18n
- zh-CN / en-US `practice.json` 补 `preview_persist` 组
- 新增 key-echo 测试

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下保存阅读进度失败，通知应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

