### PR TITLE
fix(i18n): 打开资源错误文案走 analysis:open_resource

### DIFF
--- a/src/dstu/__tests__/openResource.i18n.test.ts
+++ b/src/dstu/__tests__/openResource.i18n.test.ts
@@ -1,0 +1,170 @@
+/**
+ * openResource 用户可见错误文案 i18n 契约测试
+ *
+ * 覆盖：
+ * - reportError 动作名走 analysis:open_resource.action
+ * - VfsError message 走 analysis:open_resource.*（含插值）
+ * - defaultValue 与 zh-CN/analysis.json 主干原文一致
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import zhAnalysis from '@/locales/zh-CN/analysis.json';
+import enAnalysis from '@/locales/en-US/analysis.json';
+
+interface CapturedCall {
+  key: string;
+  options: Record<string, unknown> | undefined;
+}
+
+/** vi.mock 工厂被提升到 import 之前执行，共享状态必须走 vi.hoisted */
+const harness = vi.hoisted(() => ({
+  calls: [] as { key: string; options: Record<string, unknown> | undefined }[],
+}));
+
+function lookup(obj: Record<string, unknown>, dottedKey: string): unknown {
+  return dottedKey.split('.').reduce<unknown>((acc, part) => {
+    if (acc && typeof acc === 'object' && part in (acc as object)) {
+      return (acc as Record<string, unknown>)[part];
+    }
+    return undefined;
+  }, obj);
+}
+
+function interpolate(template: string, options: Record<string, unknown> | undefined): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
+    String(options?.[name] ?? `{{${name}}}`)
+  );
+}
+
+vi.mock('@/i18n', () => ({
+  default: {
+    t: (key: string, options?: Record<string, unknown>) => {
+      harness.calls.push({ key, options });
+      const bare = key.includes(':') ? key.split(':')[1] : key;
+      const zh = lookup(zhAnalysis as unknown as Record<string, unknown>, bare);
+      const template =
+        typeof zh === 'string'
+          ? zh
+          : typeof options?.defaultValue === 'string'
+            ? options.defaultValue
+            : key;
+      return interpolate(template, options);
+    },
+  },
+}));
+
+vi.mock('@/shared/result', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/shared/result')>();
+  return {
+    ...actual,
+    reportError: vi.fn(),
+  };
+});
+
+vi.mock('../api', () => ({
+  dstu: {
+    get: vi.fn(),
+  },
+}));
+
+import { openResource, registerOpenResourceHandler, type OpenResourceHandler } from '../openResource';
+import { reportError } from '@/shared/result';
+import { dstu } from '../api';
+import type { DstuNode } from '../types';
+
+const NAMESPACE = 'open-resource-i18n-test';
+
+const noopHandler: OpenResourceHandler = {
+  openInPanel: vi.fn(),
+  openInPage: vi.fn(),
+  openInFullscreen: vi.fn(),
+  openInModal: vi.fn(),
+};
+
+function makeNode(overrides: Partial<DstuNode>): DstuNode {
+  return {
+    path: '/notes/demo.md',
+    name: 'demo.md',
+    type: 'note',
+    ...overrides,
+  } as DstuNode;
+}
+
+let unregister: (() => void) | null = null;
+
+beforeEach(() => {
+  harness.calls.length = 0;
+  vi.mocked(reportError).mockClear();
+  unregister = registerOpenResourceHandler(noopHandler, NAMESPACE);
+});
+
+afterEach(() => {
+  unregister?.();
+  unregister = null;
+});
+
+function lastReport(): { error: { message: string }; context: string } {
+  const calls = vi.mocked(reportError).mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  const [error, context] = calls[calls.length - 1];
+  return { error: error as { message: string }, context: context as string };
+}
+
+describe('openResource i18n', () => {
+  it('处理器未注册（无目标）→ handler_not_registered，动作名走 action key', async () => {
+    const result = await openResource(makeNode({}), { handlerNamespace: 'no-such-namespace-registered' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('OpenResourceHandler 未注册: no-such-namespace-registered');
+    }
+    const { context } = lastReport();
+    expect(context).toBe('打开资源');
+  });
+
+  it('文件夹节点 → folder_not_openable', async () => {
+    const result = await openResource(makeNode({ type: 'folder' }), { handlerNamespace: NAMESPACE });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('文件夹不能在编辑器中打开');
+    }
+    const { context } = lastReport();
+    expect(context).toBe('打开资源');
+  });
+
+  it('资源未找到 → not_found 带 path 插值', async () => {
+    vi.mocked(dstu.get).mockResolvedValueOnce({ ok: true, value: null });
+
+    const result = await openResource('/notes/missing.md', { handlerNamespace: NAMESPACE });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('资源未找到: /notes/missing.md');
+    }
+    const { context } = lastReport();
+    expect(context).toBe('打开资源');
+  });
+
+  it('所有 analysis:open_resource key 的 defaultValue 与 zh-CN 主干原文一致', async () => {
+    vi.mocked(dstu.get).mockResolvedValueOnce({ ok: true, value: null });
+    await openResource(makeNode({}), { handlerNamespace: 'no-such-namespace-registered' });
+    await openResource(makeNode({ type: 'folder' }), { handlerNamespace: NAMESPACE });
+    await openResource('/notes/missing.md', { handlerNamespace: NAMESPACE });
+
+    const openResourceCalls: CapturedCall[] = harness.calls.filter((call) =>
+      call.key.startsWith('analysis:open_resource.')
+    );
+    expect(openResourceCalls.length).toBeGreaterThan(0);
+
+    for (const call of openResourceCalls) {
+      const bare = call.key.split(':')[1];
+      const zhValue = lookup(zhAnalysis as unknown as Record<string, unknown>, bare);
+      expect(typeof zhValue, `zh-CN 缺少 key: ${call.key}`).toBe('string');
+      expect(call.options?.defaultValue, `defaultValue 应与 zh-CN 原文一致: ${call.key}`).toBe(zhValue);
+
+      const enValue = lookup(enAnalysis as unknown as Record<string, unknown>, bare);
+      expect(typeof enValue, `en-US 缺少 key: ${call.key}`).toBe('string');
+    }
+  });
+});

--- a/src/dstu/openResource.ts
+++ b/src/dstu/openResource.ts
@@ -12,6 +12,12 @@ import type { EditorLocation, EditorMode, EditorProps, OpenResourceOptions } fro
 import { editorRegistry, loadEditorComponent } from './editorRegistry';
 import { Result, ok, err, VfsError, VfsErrorCode, reportError } from '@/shared/result';
 import type { CurrentView } from '@/types/navigation';
+import i18n from '@/i18n';
+
+/** reportError 的动作名（用户可见的错误上下文） */
+function openResourceActionLabel(): string {
+  return i18n.t('analysis:open_resource.action', { defaultValue: '打开资源' });
+}
 
 // ============================================================================
 // 资源打开状态管理
@@ -197,12 +203,17 @@ export async function openResource(
     const error = new VfsError(
       VfsErrorCode.INVALID_STATE,
       options?.handlerNamespace || options?.targetView
-        ? `OpenResourceHandler 未注册: ${options.handlerNamespace ?? options.targetView}`
-        : 'OpenResourceHandler 未注册',
+        ? i18n.t('analysis:open_resource.handler_not_registered_for', {
+            target: options.handlerNamespace ?? options.targetView,
+            defaultValue: 'OpenResourceHandler 未注册: {{target}}',
+          })
+        : i18n.t('analysis:open_resource.handler_not_registered', {
+            defaultValue: 'OpenResourceHandler 未注册',
+          }),
       false
     );
     console.warn('[DSTU] OpenResourceHandler not registered. Cannot open resource.');
-    reportError(error, '打开资源');
+    reportError(error, openResourceActionLabel());
     return err(error);
   }
 
@@ -216,17 +227,20 @@ export async function openResource(
     const { dstu } = await import('./api');
     const nodeResult = await dstu.get(path);
     if (!nodeResult.ok) {
-      reportError(nodeResult.error, '打开资源');
+      reportError(nodeResult.error, openResourceActionLabel());
       return err(nodeResult.error);
     }
     if (!nodeResult.value) {
       const error = new VfsError(
         VfsErrorCode.NOT_FOUND,
-        `资源未找到: ${path}`,
+        i18n.t('analysis:open_resource.not_found', {
+          path,
+          defaultValue: '资源未找到: {{path}}',
+        }),
         true,
         { path }
       );
-      reportError(error, '打开资源');
+      reportError(error, openResourceActionLabel());
       return err(error);
     }
     node = nodeResult.value;
@@ -239,12 +253,14 @@ export async function openResource(
   if (node.type === 'folder') {
     const error = new VfsError(
       VfsErrorCode.INVALID_STATE,
-      '文件夹不能在编辑器中打开',
+      i18n.t('analysis:open_resource.folder_not_openable', {
+        defaultValue: '文件夹不能在编辑器中打开',
+      }),
       false,
       { path, type: node.type }
     );
     console.warn('[DSTU] Cannot open folder in editor:', path);
-    reportError(error, '打开资源');
+    reportError(error, openResourceActionLabel());
     return err(error);
   }
 
@@ -253,12 +269,15 @@ export async function openResource(
   if (!entry) {
     const error = new VfsError(
       VfsErrorCode.INVALID_STATE,
-      `未注册类型为 ${node.type} 的编辑器`,
+      i18n.t('analysis:open_resource.editor_not_registered', {
+        type: node.type,
+        defaultValue: '未注册类型为 {{type}} 的编辑器',
+      }),
       false,
       { type: node.type }
     );
     console.warn('[DSTU] No editor registered for type:', node.type);
-    reportError(error, '打开资源');
+    reportError(error, openResourceActionLabel());
     return err(error);
   }
 
@@ -284,12 +303,15 @@ export async function openResource(
     default: {
       const error = new VfsError(
         VfsErrorCode.VALIDATION,
-        `未知的打开位置: ${location}`,
+        i18n.t('analysis:open_resource.unknown_location', {
+          location,
+          defaultValue: '未知的打开位置: {{location}}',
+        }),
         false,
         { location }
       );
       console.warn('[DSTU] Unknown location:', location);
-      reportError(error, '打开资源');
+      reportError(error, openResourceActionLabel());
       return err(error);
     }
   }

--- a/src/locales/en-US/analysis.json
+++ b/src/locales/en-US/analysis.json
@@ -136,5 +136,14 @@
       "panel_state_saved": "Panel state saved",
       "panel_closed": "Panel closed"
     }
+  },
+  "open_resource": {
+    "action": "Open resource",
+    "handler_not_registered": "OpenResourceHandler is not registered",
+    "handler_not_registered_for": "OpenResourceHandler is not registered: {{target}}",
+    "not_found": "Resource not found: {{path}}",
+    "folder_not_openable": "Folders cannot be opened in an editor",
+    "editor_not_registered": "No editor registered for type {{type}}",
+    "unknown_location": "Unknown open location: {{location}}"
   }
 }

--- a/src/locales/zh-CN/analysis.json
+++ b/src/locales/zh-CN/analysis.json
@@ -136,5 +136,14 @@
       "panel_state_saved": "面板状态已保存",
       "panel_closed": "面板已关闭"
     }
+  },
+  "open_resource": {
+    "action": "打开资源",
+    "handler_not_registered": "OpenResourceHandler 未注册",
+    "handler_not_registered_for": "OpenResourceHandler 未注册: {{target}}",
+    "not_found": "资源未找到: {{path}}",
+    "folder_not_openable": "文件夹不能在编辑器中打开",
+    "editor_not_registered": "未注册类型为 {{type}} 的编辑器",
+    "unknown_location": "未知的打开位置: {{location}}"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`openResource` 把「打开资源 / 文件夹不能在编辑器中打开」等用户可见错误写成硬编码中文。改为 `analysis:open_resource.*`，不改被占用的 `dstu.json` / `learningHub.json`。

### Changes
- `openResource` 的 reportError 动作名与 VfsError 用户文案走 i18n
- zh-CN / en-US `analysis.json` 补 `open_resource` 组
- 新增 key-echo 测试

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下打开文件夹或未注册类型，错误应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

