### PR TITLE
fix(i18n): UnifiedAppPanel 加载资源错误走已有 learningHub key

### DIFF
--- a/src/features/learning-hub/apps/UnifiedAppPanel.tsx
+++ b/src/features/learning-hub/apps/UnifiedAppPanel.tsx
@@ -218,7 +218,7 @@ export const UnifiedAppPanel: React.FC<UnifiedAppPanelProps> = ({
       if (cancelled) return;
 
       if (!result.ok) {
-        reportError(result.error, '加载资源');
+        reportError(result.error, t('error.loadFailedRetry'));
         setError(result.error.toUserMessage());
         setIsLoading(false);
         return;

--- a/src/features/learning-hub/apps/__tests__/UnifiedAppPanel.load.i18n.test.ts
+++ b/src/features/learning-hub/apps/__tests__/UnifiedAppPanel.load.i18n.test.ts
@@ -1,0 +1,30 @@
+/**
+ * UnifiedAppPanel 资源加载错误上报 i18n — source 守卫
+ *
+ * 资源加载失败时的 reportError 上下文（原硬编码「加载资源」）必须走
+ * learningHub 命名空间已有的 i18n key（error.loadFailedRetry），
+ * 不允许再以中文字面量作为 reportError 的第二个参数。
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  path.join(process.cwd(), 'src/features/learning-hub/apps/UnifiedAppPanel.tsx'),
+  'utf8'
+);
+
+describe('UnifiedAppPanel load-error reporting i18n', () => {
+  it('does not pass the hardcoded literal 「加载资源」 as the reportError context', () => {
+    expect(source).not.toMatch(/reportError\([^)]*['"`]加载资源['"`]/);
+  });
+
+  it('routes the reportError context through the existing learningHub key', () => {
+    expect(source).toContain("reportError(result.error, t('error.loadFailedRetry'))");
+  });
+
+  it('keeps the learningHub namespace bound so the key resolves', () => {
+    expect(source).toContain("useTranslation(['learningHub', 'common'])");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

UnifiedAppPanel 资源加载失败时，`reportError` 的动作名写成硬编码「加载资源」。改为复用已有 `learningHub:error.loadFailedRetry`，不改 locale 文件。

### Changes
- `UnifiedAppPanel` 的 `reportError` 上下文走 `t('error.loadFailedRetry')`（组件已绑定 `learningHub`）
- 新增 source 守卫测试，禁止再写回「加载资源」字面量

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下打开资源失败，上报上下文应为「加载失败，请重试」的英文译文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

