### PR TITLE
fix(i18n): 笔记预览引用加载错误走 template:preview_ref

### DIFF
--- a/src/features/notes/PreviewPanel.tsx
+++ b/src/features/notes/PreviewPanel.tsx
@@ -142,7 +142,10 @@ async function fetchReferenceContent(
 
   if (!nodeResult.ok) {
     console.error('[PreviewPanel] Failed to fetch node via DSTU:', nodeResult.error);
-    reportError(nodeResult.error, '获取引用节点');
+    reportError(
+      nodeResult.error,
+      i18next.t('template:preview_ref.get_node', { defaultValue: '获取引用节点' })
+    );
     return {
       success: false,
       error: nodeResult.error.toUserMessage(),
@@ -188,7 +191,10 @@ async function fetchReferenceContent(
     const contentResult = await dstu.getContent(dstuPath);
     if (!contentResult.ok) {
       console.error('[PreviewPanel] Failed to fetch content via DSTU:', contentResult.error);
-      reportError(contentResult.error, '获取引用内容');
+      reportError(
+        contentResult.error,
+        i18next.t('template:preview_ref.get_content', { defaultValue: '获取引用内容' })
+      );
       return {
         success: false,
         error: contentResult.error.toUserMessage(),

--- a/src/features/notes/__tests__/PreviewPanel.i18n.test.ts
+++ b/src/features/notes/__tests__/PreviewPanel.i18n.test.ts
@@ -1,0 +1,44 @@
+/**
+ * PreviewPanel reportError 标签 i18n 合同测试
+ *
+ * 背景：fetchReferenceContent 中两处 reportError 的上下文标签
+ * （「获取引用节点」/「获取引用内容」）原为硬编码中文，
+ * 现改走 template:preview_ref.* i18n key（defaultValue 保持主干原文）。
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import zhTemplate from '@/locales/zh-CN/template.json';
+import enTemplate from '@/locales/en-US/template.json';
+
+const componentSource = readFileSync(resolve(__dirname, '../PreviewPanel.tsx'), 'utf-8');
+
+describe('PreviewPanel reportError i18n', () => {
+  it('zh-CN locale 提供 preview_ref key，文案与主干原文一致', () => {
+    expect(zhTemplate.preview_ref.get_node).toBe('获取引用节点');
+    expect(zhTemplate.preview_ref.get_content).toBe('获取引用内容');
+  });
+
+  it('en-US locale 提供对应英文文案', () => {
+    expect(enTemplate.preview_ref.get_node).toBe('Fetch referenced node');
+    expect(enTemplate.preview_ref.get_content).toBe('Fetch referenced content');
+  });
+
+  it('reportError 标签通过 template:preview_ref.* 解析并保留 defaultValue', () => {
+    expect(componentSource).toContain(
+      "i18next.t('template:preview_ref.get_node', { defaultValue: '获取引用节点' })"
+    );
+    expect(componentSource).toContain(
+      "i18next.t('template:preview_ref.get_content', { defaultValue: '获取引用内容' })"
+    );
+  });
+
+  it('不再向 reportError 直接传硬编码中文标签', () => {
+    expect(componentSource).not.toContain("reportError(nodeResult.error, '获取引用节点')");
+    expect(componentSource).not.toContain("reportError(contentResult.error, '获取引用内容')");
+    // 兜底：reportError 第二个参数不应是含中文的字符串字面量
+    expect(componentSource).not.toMatch(/reportError\([^,]+,\s*'[^']*[\u4e00-\u9fff]/);
+  });
+});

--- a/src/locales/en-US/template.json
+++ b/src/locales/en-US/template.json
@@ -46,6 +46,10 @@
     "export_selected_count": "{{count}} selected",
     "panel_close": "Close panel"
   },
+  "preview_ref": {
+    "get_node": "Fetch referenced node",
+    "get_content": "Fetch referenced content"
+  },
   "manager_title": "Card Template Manager",
   "manager_subtitle": "Manage templates, create new ones or let AI generate",
   "refresh": "Refresh",

--- a/src/locales/zh-CN/template.json
+++ b/src/locales/zh-CN/template.json
@@ -46,6 +46,10 @@
     "export_selected_count": "已选 {{count}} 个",
     "panel_close": "收起面板"
   },
+  "preview_ref": {
+    "get_node": "获取引用节点",
+    "get_content": "获取引用内容"
+  },
   "manager_title": "卡片模板管理",
   "manager_subtitle": "管理模板、创建新模板或让 AI 直接生成",
   "refresh": "刷新",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

笔记预览拉引用节点/内容失败时，`reportError` 动作名写成硬编码中文。改为 `template:preview_ref.*`，不改被占用的 `notes.json`。

### Changes
- `PreviewPanel.fetchReferenceContent` 的「获取引用节点 / 获取引用内容」走 i18n，保留 `defaultValue`
- zh-CN / en-US `template.json` 只追加 `preview_ref` 组
- 新增 key-echo 测试

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下预览引用加载失败，通知上下文应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

