### PR TITLE
fix(i18n): 笔记 Markdown 导入错误走 sidebar:notes_import

### DIFF
--- a/src/dstu/adapters/__tests__/notesDstuAdapter.i18n.test.ts
+++ b/src/dstu/adapters/__tests__/notesDstuAdapter.i18n.test.ts
@@ -1,0 +1,118 @@
+/**
+ * 笔记 Markdown 导入错误文案 i18n 契约测试
+ *
+ * 验证 importMarkdownFile / importMarkdownFiles 失败时，
+ * toVfsError / reportError 的用户可见文案走 sidebar:notes_import.* 翻译键，
+ * 且 defaultValue 与 zh-CN 主干原文一致。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import zhSidebar from '@/locales/zh-CN/sidebar.json';
+import enSidebar from '@/locales/en-US/sidebar.json';
+
+const invokeMock = vi.fn();
+const reportErrorMock = vi.fn();
+const tMock = vi.fn(
+  (key: string, options?: { defaultValue?: string }): string => {
+    const bare = key.includes(':') ? key.slice(key.indexOf(':') + 1) : key;
+    const value = bare.split('.').reduce<unknown>((acc, part) => {
+      if (acc && typeof acc === 'object' && part in (acc as object)) {
+        return (acc as Record<string, unknown>)[part];
+      }
+      return undefined;
+    }, zhSidebar as Record<string, unknown>);
+    if (typeof value === 'string') return value;
+    return options?.defaultValue ?? key;
+  },
+);
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock('../../api', () => ({
+  dstu: {},
+}));
+
+vi.mock('i18next', () => ({
+  default: {
+    t: tMock,
+  },
+}));
+
+vi.mock('@/utils/fileManager', () => ({
+  isOpaqueDocumentId: () => false,
+}));
+
+vi.mock('@/shared/result', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/shared/result')>();
+  return {
+    ...actual,
+    reportError: reportErrorMock,
+  };
+});
+
+describe('notesDstuAdapter markdown import i18n', async () => {
+  const { notesDstuAdapter } = await import('../notesDstuAdapter');
+
+  beforeEach(() => {
+    invokeMock.mockReset();
+    reportErrorMock.mockReset();
+    tMock.mockClear();
+  });
+
+  it('locale files provide sidebar notes_import keys in both languages', () => {
+    expect(zhSidebar.notes_import.markdown).toBe('导入 Markdown 笔记');
+    expect(zhSidebar.notes_import.markdown_batch).toBe('批量导入 Markdown 笔记');
+
+    expect(enSidebar.notes_import.markdown).toBeTypeOf('string');
+    expect(enSidebar.notes_import.markdown).not.toHaveLength(0);
+    expect(enSidebar.notes_import.markdown_batch).toBeTypeOf('string');
+    expect(enSidebar.notes_import.markdown_batch).not.toHaveLength(0);
+  });
+
+  it('importMarkdownFile failure uses sidebar:notes_import.markdown for error and report context', async () => {
+    invokeMock.mockRejectedValue(undefined);
+
+    const result = await notesDstuAdapter.importMarkdownFile('/tmp/a.md', 'A.md', null);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure result');
+
+    expect(tMock).toHaveBeenCalledWith('sidebar:notes_import.markdown', {
+      defaultValue: '导入 Markdown 笔记',
+    });
+    expect(result.error.message).toBe('导入 Markdown 笔记');
+    expect(reportErrorMock).toHaveBeenCalledWith(result.error, '导入 Markdown 笔记');
+  });
+
+  it('importMarkdownFiles failure uses sidebar:notes_import.markdown_batch for error and report context', async () => {
+    invokeMock.mockRejectedValue(undefined);
+
+    const result = await notesDstuAdapter.importMarkdownFiles(
+      [{ filePath: '/tmp/a.md' }, { filePath: '/tmp/b.md' }],
+      null,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure result');
+
+    expect(tMock).toHaveBeenCalledWith('sidebar:notes_import.markdown_batch', {
+      defaultValue: '批量导入 Markdown 笔记',
+    });
+    expect(result.error.message).toBe('批量导入 Markdown 笔记');
+    expect(reportErrorMock).toHaveBeenCalledWith(result.error, '批量导入 Markdown 笔记');
+  });
+
+  it('keeps backend-provided error messages instead of the default context text', async () => {
+    invokeMock.mockRejectedValue(new Error('disk full'));
+
+    const result = await notesDstuAdapter.importMarkdownFile('/tmp/a.md');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure result');
+
+    expect(result.error.message).toBe('disk full');
+    expect(reportErrorMock).toHaveBeenCalledWith(result.error, '导入 Markdown 笔记');
+  });
+});

--- a/src/dstu/adapters/notesDstuAdapter.ts
+++ b/src/dstu/adapters/notesDstuAdapter.ts
@@ -227,8 +227,9 @@ export const notesDstuAdapter = {
       });
       return ok(node);
     } catch (error: unknown) {
-      const vfsError = toVfsError(error, '导入 Markdown 笔记');
-      reportError(vfsError, '导入 Markdown 笔记');
+      const context = i18next.t('sidebar:notes_import.markdown', { defaultValue: '导入 Markdown 笔记' });
+      const vfsError = toVfsError(error, context);
+      reportError(vfsError, context);
       return err(vfsError);
     }
   },
@@ -251,8 +252,9 @@ export const notesDstuAdapter = {
       });
       return ok(response);
     } catch (error: unknown) {
-      const vfsError = toVfsError(error, '批量导入 Markdown 笔记');
-      reportError(vfsError, '批量导入 Markdown 笔记');
+      const context = i18next.t('sidebar:notes_import.markdown_batch', { defaultValue: '批量导入 Markdown 笔记' });
+      const vfsError = toVfsError(error, context);
+      reportError(vfsError, context);
       return err(vfsError);
     }
   },

--- a/src/locales/en-US/sidebar.json
+++ b/src/locales/en-US/sidebar.json
@@ -73,6 +73,10 @@
   "delete": {
     "confirm_hint": "Delete permanently? This cannot be undone"
   },
+  "notes_import": {
+    "markdown": "Import Markdown note",
+    "markdown_batch": "Batch import Markdown notes"
+  },
   "search": {
     "placeholder": "Search sessions...",
     "clear": "Clear search",

--- a/src/locales/zh-CN/sidebar.json
+++ b/src/locales/zh-CN/sidebar.json
@@ -73,6 +73,10 @@
   "delete": {
     "confirm_hint": "永久删除？不可恢复"
   },
+  "notes_import": {
+    "markdown": "导入 Markdown 笔记",
+    "markdown_batch": "批量导入 Markdown 笔记"
+  },
   "search": {
     "placeholder": "搜索会话...",
     "clear": "清除搜索",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

笔记 Markdown 导入失败时，`toVfsError` / `reportError` 的动作名写成硬编码中文。改为 `sidebar:notes_import.*`，不改被占用的 `notes.json`。

### Changes
- `notesDstuAdapter.importMarkdownFile` / `importMarkdownFiles` 走 i18n，保留 `defaultValue`
- zh-CN / en-US `sidebar.json` 只追加 `notes_import` 组
- 新增契约测试（失败路径 + locale key）

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下导入 Markdown 失败，错误上下文应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

