### PR TITLE
fix(i18n): 资源引用注入错误走 chat_module:vfs_inject

### DIFF
--- a/src/features/chat/context/__tests__/vfsInject.i18n.test.ts
+++ b/src/features/chat/context/__tests__/vfsInject.i18n.test.ts
@@ -1,0 +1,151 @@
+/**
+ * VFS 资源引用注入链路 i18n 契约测试
+ *
+ * 覆盖「把资源引用注入对话」链路上用户可见错误的 i18n 化：
+ * - locale：zh-CN / en-US chat_module.json 均含 vfs_inject 组，插值占位符齐全
+ * - key-echo：checkResourceCapacity 走 chat_module:vfs_inject.capacity_exceeded 且带 defaultValue
+ * - source 守卫：调用点引用正确的 key，旧的硬编码拼接形式不再出现
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import zhChatModule from '@/locales/zh-CN/chat_module.json';
+import enChatModule from '@/locales/en-US/chat_module.json';
+
+const { tCalls } = vi.hoisted(() => ({
+  tCalls: [] as Array<{ key: string; options?: Record<string, unknown> }>,
+}));
+
+vi.mock('@/i18n', () => ({
+  default: {
+    t: (key: string, options?: Record<string, unknown>) => {
+      tCalls.push({ key, options });
+      const vars = options
+        ? Object.entries(options).filter(([name]) => name !== 'defaultValue')
+        : [];
+      return `${key}|${vars.map(([name, value]) => `${name}=${String(value)}`).join(',')}`;
+    },
+  },
+}));
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ENHANCEMENTS_PATH = path.resolve(TEST_DIR, '../vfsRefApiEnhancements.ts');
+const VFS_CONTEXT_INJECT_PATH = path.resolve(
+  TEST_DIR,
+  '../../../learning-hub/hooks/useVfsContextInject.ts'
+);
+const REFERENCE_TO_CHAT_PATH = path.resolve(
+  TEST_DIR,
+  '../../../learning-hub/useReferenceToChat.ts'
+);
+
+const EXPECTED_ZH: Record<string, string> = {
+  resource_not_found: '资源 {{sourceId}} 未找到',
+  network_error: '网络错误，无法获取资源引用',
+  permission_denied: '权限不足，无法访问资源',
+  capacity_exceeded: '资源数量超限：当前 {{count}}，最大 {{maxCount}}',
+  batch_query_failed: '批量查询资源失败',
+  network_retry: '网络错误，请重试',
+};
+
+describe('chat_module vfs_inject locale keys', () => {
+  it('zh-CN 含全部 vfs_inject key 且与主干原文一致', () => {
+    const group = (zhChatModule as Record<string, unknown>).vfs_inject as Record<string, string>;
+    expect(group).toBeDefined();
+    for (const [key, value] of Object.entries(EXPECTED_ZH)) {
+      expect(group[key]).toBe(value);
+    }
+  });
+
+  it('en-US 含全部 vfs_inject key 且插值占位符与 zh-CN 对齐', () => {
+    const zhGroup = (zhChatModule as Record<string, unknown>).vfs_inject as Record<string, string>;
+    const enGroup = (enChatModule as Record<string, unknown>).vfs_inject as Record<string, string>;
+    expect(enGroup).toBeDefined();
+    for (const key of Object.keys(EXPECTED_ZH)) {
+      expect(typeof enGroup[key]).toBe('string');
+      expect(enGroup[key].length).toBeGreaterThan(0);
+      // 占位符集合必须一致，避免翻译丢插值
+      const placeholders = (value: string) => (value.match(/\{\{\w+\}\}/g) ?? []).sort();
+      expect(placeholders(enGroup[key])).toEqual(placeholders(zhGroup[key]));
+    }
+    expect(enGroup.resource_not_found).toContain('{{sourceId}}');
+    expect(enGroup.capacity_exceeded).toContain('{{count}}');
+    expect(enGroup.capacity_exceeded).toContain('{{maxCount}}');
+  });
+});
+
+describe('checkResourceCapacity key-echo', () => {
+  it('超限时错误消息走 chat_module:vfs_inject.capacity_exceeded 并传入插值变量', async () => {
+    const { checkResourceCapacity } = await import('../vfsRefApiEnhancements');
+
+    const result = checkResourceCapacity(51, 50);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe(
+        'chat_module:vfs_inject.capacity_exceeded|count=51,maxCount=50'
+      );
+    }
+
+    const call = tCalls.find((c) => c.key === 'chat_module:vfs_inject.capacity_exceeded');
+    expect(call).toBeDefined();
+    // 异步 namespace 惯例：必须带 defaultValue，且与 zh-CN locale 原文一致
+    expect(call?.options?.defaultValue).toBe(EXPECTED_ZH.capacity_exceeded);
+    expect(call?.options?.count).toBe(51);
+    expect(call?.options?.maxCount).toBe(50);
+  });
+
+  it('未超限时不触发翻译调用', async () => {
+    const { checkResourceCapacity } = await import('../vfsRefApiEnhancements');
+    const before = tCalls.length;
+    const result = checkResourceCapacity(3, 50);
+    expect(result.ok).toBe(true);
+    expect(tCalls.length).toBe(before);
+  });
+});
+
+describe('注入链路调用点 source 守卫', () => {
+  it('vfsRefApiEnhancements.ts：容量/批量查询错误走 i18n，旧硬编码拼接消失', () => {
+    const source = readFileSync(ENHANCEMENTS_PATH, 'utf-8');
+
+    expect(source).toContain("i18n.t('chat_module:vfs_inject.capacity_exceeded'");
+    expect(source).toContain("i18n.t('chat_module:vfs_inject.batch_query_failed'");
+    expect(source).toContain("defaultValue: '资源数量超限：当前 {{count}}，最大 {{maxCount}}'");
+    expect(source).toContain("{ defaultValue: '批量查询资源失败' }");
+
+    // 旧形式：模板字符串拼接 / 裸中文字面量直传 toVfsError
+    expect(source).not.toMatch(/`资源数量超限：当前 \$\{count\}/);
+    expect(source).not.toMatch(/toVfsError\(\s*caughtError,\s*'批量查询资源失败'/);
+  });
+
+  it('useVfsContextInject.ts：NOT_FOUND/NETWORK/PERMISSION 错误走 chat_module:vfs_inject.*', () => {
+    const source = readFileSync(VFS_CONTEXT_INJECT_PATH, 'utf-8');
+
+    expect(source).toContain("t('chat_module:vfs_inject.resource_not_found'");
+    expect(source).toContain("t('chat_module:vfs_inject.network_error'");
+    expect(source).toContain("t('chat_module:vfs_inject.permission_denied'");
+    expect(source).toContain("defaultValue: '资源 {{sourceId}} 未找到'");
+
+    // 旧形式：模板字符串 / 裸赋值
+    expect(source).not.toMatch(/`资源 \$\{sourceId\} 未找到`/);
+    expect(source).not.toMatch(/errorMsg = '网络错误，无法获取资源引用'/);
+    expect(source).not.toMatch(/errorMsg = '权限不足，无法访问资源'/);
+
+    // 已有的 learningHub / notes 调用保持不动
+    expect(source).toContain("t('learningHub:context.resourceNotFound')");
+    expect(source).toContain("t('notes:reference.session_not_found')");
+  });
+
+  it('useReferenceToChat.ts：NETWORK 分支走 chat_module:vfs_inject.network_retry', () => {
+    const source = readFileSync(REFERENCE_TO_CHAT_PATH, 'utf-8');
+
+    expect(source).toContain("t('chat_module:vfs_inject.network_retry'");
+    expect(source).not.toMatch(/errorMsg = '网络错误，请重试'/);
+
+    // 已有的 notes:reference.* 调用保持不动
+    expect(source).toContain("t('notes:reference.resource_not_found')");
+    expect(source).toContain("t('notes:reference.no_active_session')");
+  });
+});

--- a/src/features/chat/context/vfsRefApiEnhancements.ts
+++ b/src/features/chat/context/vfsRefApiEnhancements.ts
@@ -11,6 +11,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
+import i18n from '@/i18n';
 import type { VfsResourceRef, ResolvedResource } from './vfsRefTypes';
 import { ok, err, toVfsError, type Result, VfsErrorCode, VfsError } from '@/shared/result';
 import { withTimeout } from '@/utils/concurrency';
@@ -507,7 +508,11 @@ export function checkResourceCapacity(
     return err(
       new VfsError(
         VfsErrorCode.CAPACITY_EXCEEDED,
-        `资源数量超限：当前 ${count}，最大 ${maxCount}`,
+        i18n.t('chat_module:vfs_inject.capacity_exceeded', {
+          defaultValue: '资源数量超限：当前 {{count}}，最大 {{maxCount}}',
+          count,
+          maxCount,
+        }),
         false,
         { count, maxCount }
       )
@@ -639,7 +644,11 @@ export async function batchGetResources(
     return ok(result);
   } catch (caughtError: unknown) {
     debugError(LOG_PREFIX, '❌ 批量查询失败:', caughtError);
-    return err(toVfsError(caughtError, '批量查询资源失败', { refs: uncachedRefs }));
+    return err(toVfsError(
+      caughtError,
+      i18n.t('chat_module:vfs_inject.batch_query_failed', { defaultValue: '批量查询资源失败' }),
+      { refs: uncachedRefs }
+    ));
   }
 }
 

--- a/src/features/learning-hub/hooks/useVfsContextInject.ts
+++ b/src/features/learning-hub/hooks/useVfsContextInject.ts
@@ -90,7 +90,7 @@ const LOG_PREFIX = '[useVfsContextInject]';
  * 使用引用模式，只存储 sourceId + resourceHash，不存储实际内容。
  */
 export function useVfsContextInject(): UseVfsContextInjectReturn {
-  const { t } = useTranslation(['learningHub', 'notes']);
+  const { t } = useTranslation(['learningHub', 'notes', 'chat_module']);
   const [isInjecting, setIsInjecting] = useState(false);
 
   /**
@@ -140,11 +140,18 @@ export function useVfsContextInject(): UseVfsContextInjectReturn {
           const vfsError = result.error;
 
           if (vfsError.code === VfsErrorCode.NOT_FOUND) {
-            errorMsg = `资源 ${sourceId} 未找到`;
+            errorMsg = t('chat_module:vfs_inject.resource_not_found', {
+              defaultValue: '资源 {{sourceId}} 未找到',
+              sourceId,
+            });
           } else if (vfsError.code === VfsErrorCode.NETWORK) {
-            errorMsg = '网络错误，无法获取资源引用';
+            errorMsg = t('chat_module:vfs_inject.network_error', {
+              defaultValue: '网络错误，无法获取资源引用',
+            });
           } else if (vfsError.code === VfsErrorCode.PERMISSION) {
-            errorMsg = '权限不足，无法访问资源';
+            errorMsg = t('chat_module:vfs_inject.permission_denied', {
+              defaultValue: '权限不足，无法访问资源',
+            });
           } else {
             errorMsg = vfsError.toUserMessage();
           }

--- a/src/features/learning-hub/useReferenceToChat.ts
+++ b/src/features/learning-hub/useReferenceToChat.ts
@@ -206,7 +206,7 @@ function getTypeId(sourceType: SourceType): string {
  * 提供将学习资源引用到对话的能力，集成同步服务。
  */
 export function useReferenceToChat(): UseReferenceToChatReturn {
-  const { t } = useTranslation(['notes', 'learningHub']);
+  const { t } = useTranslation(['notes', 'learningHub', 'chat_module']);
 
   /**
    * 检查是否可以引用到对话
@@ -261,7 +261,9 @@ export function useReferenceToChat(): UseReferenceToChatReturn {
             errorMsg = t('notes:reference.resource_not_found');
             showGlobalNotification('warning', errorMsg);
           } else if (result.error.code === VfsErrorCode.NETWORK) {
-            errorMsg = '网络错误，请重试';
+            errorMsg = t('chat_module:vfs_inject.network_retry', {
+              defaultValue: '网络错误，请重试',
+            });
             showGlobalNotification('error', errorMsg);
           } else {
             errorMsg = result.error.toUserMessage();

--- a/src/locales/en-US/chat_module.json
+++ b/src/locales/en-US/chat_module.json
@@ -70,5 +70,13 @@
   "virtual_list": {
     "scroll_to_bottom": "Scroll to bottom",
     "new_messages": "New messages"
+  },
+  "vfs_inject": {
+    "resource_not_found": "Resource {{sourceId}} not found",
+    "network_error": "Network error: unable to fetch resource references",
+    "permission_denied": "Insufficient permissions to access this resource",
+    "capacity_exceeded": "Resource limit exceeded: {{count}} selected, maximum {{maxCount}}",
+    "batch_query_failed": "Failed to batch-query resources",
+    "network_retry": "Network error, please retry"
   }
 }

--- a/src/locales/zh-CN/chat_module.json
+++ b/src/locales/zh-CN/chat_module.json
@@ -70,5 +70,13 @@
   "virtual_list": {
     "scroll_to_bottom": "滚动到底部",
     "new_messages": "有新消息"
+  },
+  "vfs_inject": {
+    "resource_not_found": "资源 {{sourceId}} 未找到",
+    "network_error": "网络错误，无法获取资源引用",
+    "permission_denied": "权限不足，无法访问资源",
+    "capacity_exceeded": "资源数量超限：当前 {{count}}，最大 {{maxCount}}",
+    "batch_query_failed": "批量查询资源失败",
+    "network_retry": "网络错误，请重试"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

把资源引用注入对话时，失败通知写成硬编码中文。`learningHub.json` / `notes.json` 已被占用，改为 `chat_module:vfs_inject.*`。

### Changes
- `useVfsContextInject` 的未找到/网络/权限通知走 i18n
- `vfsRefApiEnhancements` 容量超限与批量查询失败走 i18n
- `useReferenceToChat` 仅切「网络错误，请重试」
- zh-CN / en-US `chat_module.json` 只追加 `vfs_inject` 组
- 新增契约测试；已有 `learningHub:` / `notes:` 调用保持不动

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下引用资源到对话失败，通知应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

