### PR TITLE
fix(i18n): pathUtils 资源 ID 校验错误走 llm_usage:dstu_path

### DIFF
--- a/src/dstu/utils/__tests__/pathUtils.i18n.test.ts
+++ b/src/dstu/utils/__tests__/pathUtils.i18n.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import zhLlmUsage from '@/locales/zh-CN/llm_usage.json';
+import enLlmUsage from '@/locales/en-US/llm_usage.json';
+
+// 模拟 i18next 在 key 缺失时的 defaultValue 回退 + 插值行为，
+// 验证纯函数在无 locale 资源时输出与主干一致的中文原文。
+vi.mock('@/i18n', () => ({
+  default: {
+    t: (key: string, options?: Record<string, unknown>) => {
+      const template = typeof options?.defaultValue === 'string' ? options.defaultValue : key;
+      return template.replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
+        String(options?.[name] ?? ''),
+      );
+    },
+  },
+}));
+
+import { buildPath, validateResourceId, MAX_RESOURCE_ID_LENGTH } from '../pathUtils';
+
+describe('pathUtils resource ID validation i18n', () => {
+  it('locale files contain the dstu_path keys in both languages', () => {
+    const expectedKeys = ['emptyId', 'idLengthExceeded', 'invalidPrefix'];
+    for (const key of expectedKeys) {
+      expect(zhLlmUsage.dstu_path).toHaveProperty(key);
+      expect(enLlmUsage.dstu_path).toHaveProperty(key);
+    }
+  });
+
+  it('zh-CN locale texts match the original hardcoded messages', () => {
+    expect(zhLlmUsage.dstu_path.emptyId).toBe('资源ID不能为空');
+    expect(zhLlmUsage.dstu_path.idLengthExceeded).toBe(
+      '资源ID长度超限: {{length}} 字符（最大 {{max}}）',
+    );
+    expect(zhLlmUsage.dstu_path.invalidPrefix).toBe('资源ID格式无效：缺少有效前缀');
+  });
+
+  it('validateResourceId returns the original Chinese message for empty id', () => {
+    const result = validateResourceId('');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('资源ID不能为空');
+  });
+
+  it('validateResourceId returns the original Chinese message with interpolation for overlong id', () => {
+    const overlongId = `note_${'a'.repeat(MAX_RESOURCE_ID_LENGTH)}`;
+    const result = validateResourceId(overlongId);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe(
+      `资源ID长度超限: ${overlongId.length} 字符（最大 ${MAX_RESOURCE_ID_LENGTH}）`,
+    );
+  });
+
+  it('validateResourceId returns the original Chinese message for missing prefix', () => {
+    const result = validateResourceId('unknownprefix_abc');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('资源ID格式无效：缺少有效前缀');
+  });
+
+  it('buildPath throws the original Chinese message for overlong resource id', () => {
+    const overlongId = `note_${'a'.repeat(MAX_RESOURCE_ID_LENGTH)}`;
+    expect(() => buildPath('/folder', overlongId)).toThrowError(
+      `资源ID长度超限: ${overlongId.length} 字符（最大 ${MAX_RESOURCE_ID_LENGTH}）`,
+    );
+  });
+
+  it('validateResourceId still accepts a valid id', () => {
+    expect(validateResourceId('note_abc123')).toEqual({ valid: true });
+  });
+});

--- a/src/dstu/utils/pathUtils.ts
+++ b/src/dstu/utils/pathUtils.ts
@@ -8,6 +8,7 @@
  * 2. 支持新路径格式（/{folder_path}/{resource_id}）
  */
 
+import i18n from '@/i18n';
 import type { ParsedPath, PathUtils } from '../types/path';
 import {
   MAX_RESOURCE_ID_LENGTH,
@@ -78,21 +79,31 @@ function isResourceId(segment: string): boolean {
  */
 function validateResourceId(id: string): { valid: boolean; error?: string } {
   if (!id) {
-    return { valid: false, error: '资源ID不能为空' };
+    return {
+      valid: false,
+      error: i18n.t('llm_usage:dstu_path.emptyId', { defaultValue: '资源ID不能为空' }),
+    };
   }
   
   // [PATH-006] 长度限制检查
   if (id.length > MAX_RESOURCE_ID_LENGTH) {
     return { 
       valid: false, 
-      error: `资源ID长度超限: ${id.length} 字符（最大 ${MAX_RESOURCE_ID_LENGTH}）` 
+      error: i18n.t('llm_usage:dstu_path.idLengthExceeded', {
+        length: id.length,
+        max: MAX_RESOURCE_ID_LENGTH,
+        defaultValue: '资源ID长度超限: {{length}} 字符（最大 {{max}}）',
+      }),
     };
   }
   
   // 前缀检查
   const resourceType = inferResourceType(id);
   if (!resourceType) {
-    return { valid: false, error: '资源ID格式无效：缺少有效前缀' };
+    return {
+      valid: false,
+      error: i18n.t('llm_usage:dstu_path.invalidPrefix', { defaultValue: '资源ID格式无效：缺少有效前缀' }),
+    };
   }
   
   return { valid: true };
@@ -240,7 +251,11 @@ function build(folderPath: string | null, resourceId: string): string {
   
   // [PATH-006] 验证资源 ID 长度
   if (resourceId.length > MAX_RESOURCE_ID_LENGTH) {
-    throw new Error(`资源ID长度超限: ${resourceId.length} 字符（最大 ${MAX_RESOURCE_ID_LENGTH}）`);
+    throw new Error(i18n.t('llm_usage:dstu_path.idLengthExceeded', {
+      length: resourceId.length,
+      max: MAX_RESOURCE_ID_LENGTH,
+      defaultValue: '资源ID长度超限: {{length}} 字符（最大 {{max}}）',
+    }));
   }
   
   if (!folderPath || folderPath === '/') {

--- a/src/locales/en-US/llm_usage.json
+++ b/src/locales/en-US/llm_usage.json
@@ -93,5 +93,10 @@
   "error": {
     "loadFailed": "Failed to load statistics",
     "cleanupFailed": "Failed to cleanup data"
+  },
+  "dstu_path": {
+    "emptyId": "Resource ID cannot be empty",
+    "idLengthExceeded": "Resource ID length exceeded: {{length}} characters (max {{max}})",
+    "invalidPrefix": "Invalid resource ID format: missing valid prefix"
   }
 }

--- a/src/locales/zh-CN/llm_usage.json
+++ b/src/locales/zh-CN/llm_usage.json
@@ -93,5 +93,10 @@
   "error": {
     "loadFailed": "加载统计数据失败",
     "cleanupFailed": "清理数据失败"
+  },
+  "dstu_path": {
+    "emptyId": "资源ID不能为空",
+    "idLengthExceeded": "资源ID长度超限: {{length}} 字符（最大 {{max}}）",
+    "invalidPrefix": "资源ID格式无效：缺少有效前缀"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

DSTU `pathUtils` 的资源 ID 校验错误写成硬编码中文。`dstu.json` / `vfs.json` 已被占用，改为 `llm_usage:dstu_path.*`。

### Changes
- `validateResourceId` 与 `build` 超限 throw 走 i18n，插值 `{{length}}` / `{{max}}`
- zh-CN / en-US `llm_usage.json` 只追加 `dstu_path` 组
- 新增契约测试；主干 pathUtils 旧测试零改动
- JSDoc 示例未改

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下非法资源 ID 的错误消息应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

