### PR TITLE
fix(i18n): wikilink 创建笔记失败 toast 走 graph_conflict:wikilink

### DIFF
--- a/src/features/notes/__tests__/createFromWikilink.i18n.test.ts
+++ b/src/features/notes/__tests__/createFromWikilink.i18n.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import zhCN from '@/locales/zh-CN/graph_conflict.json';
+import enUS from '@/locales/en-US/graph_conflict.json';
+
+const source = readFileSync(
+  new URL('../createFromWikilink.ts', import.meta.url),
+  'utf8',
+);
+
+describe('createFromWikilink i18n contract', () => {
+  it('provides wikilink.create_failed in both locales', () => {
+    expect(zhCN.wikilink.create_failed).toBe('创建笔记「{{title}}」失败');
+    expect(enUS.wikilink.create_failed).toContain('{{title}}');
+  });
+
+  it('keeps the pre-existing graph_conflict keys intact', () => {
+    for (const key of ['title', 'conflict', 'resolve', 'ignore']) {
+      expect(zhCN).toHaveProperty(key);
+      expect(enUS).toHaveProperty(key);
+    }
+  });
+
+  it('uses the i18n key instead of a hardcoded template string', () => {
+    expect(source).toContain("i18n.t('graph_conflict:wikilink.create_failed'");
+    expect(source).toContain("import i18n from '@/i18n';");
+    expect(source).not.toContain('`创建笔记「${trimmed}」失败`');
+  });
+});

--- a/src/features/notes/__tests__/createFromWikilink.i18n.test.ts
+++ b/src/features/notes/__tests__/createFromWikilink.i18n.test.ts
@@ -1,11 +1,12 @@
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import zhCN from '@/locales/zh-CN/graph_conflict.json';
 import enUS from '@/locales/en-US/graph_conflict.json';
 
 const source = readFileSync(
-  new URL('../createFromWikilink.ts', import.meta.url),
+  resolve(process.cwd(), 'src/features/notes/createFromWikilink.ts'),
   'utf8',
 );
 

--- a/src/features/notes/createFromWikilink.ts
+++ b/src/features/notes/createFromWikilink.ts
@@ -6,6 +6,7 @@
 import { notesDstuAdapter } from '@/dstu/adapters/notesDstuAdapter';
 import { createEmpty } from '@/dstu';
 import { showGlobalNotification } from '@/components/UnifiedNotification';
+import i18n from '@/i18n';
 import type { CrepeEditorApi } from '@/components/crepe';
 import { upsertWikilinkNoteCache } from './wikilinkNotesCache';
 
@@ -86,7 +87,13 @@ export async function createNoteFromWikilinkTitle(title: string): Promise<string
       return noteId;
     } catch (error: unknown) {
       console.error('[createNoteFromWikilinkTitle] failed:', error);
-      showGlobalNotification('error', `创建笔记「${trimmed}」失败`);
+      showGlobalNotification(
+        'error',
+        i18n.t('graph_conflict:wikilink.create_failed', {
+          defaultValue: '创建笔记「{{title}}」失败',
+          title: trimmed,
+        }),
+      );
       return null;
     } finally {
       // 只清理自己这个槽位，不影响其它标题的 in-flight 创建

--- a/src/locales/en-US/graph_conflict.json
+++ b/src/locales/en-US/graph_conflict.json
@@ -2,5 +2,8 @@
   "title": "Conflict Detection",
   "conflict": "Conflict",
   "resolve": "Resolve",
-  "ignore": "Ignore"
+  "ignore": "Ignore",
+  "wikilink": {
+    "create_failed": "Failed to create note \"{{title}}\""
+  }
 }

--- a/src/locales/zh-CN/graph_conflict.json
+++ b/src/locales/zh-CN/graph_conflict.json
@@ -2,5 +2,8 @@
   "title": "冲突检测",
   "conflict": "冲突",
   "resolve": "解决",
-  "ignore": "忽略"
+  "ignore": "忽略",
+  "wikilink": {
+    "create_failed": "创建笔记「{{title}}」失败"
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

未解析 wikilink 创建笔记失败时的 toast 写成硬编码中文。`notes.json` 已被占用，改为 `graph_conflict:wikilink.create_failed`。

### Changes
- `createFromWikilink` catch 路径走 i18n，插值 `{{title}}`，保留 `defaultValue`
- zh-CN / en-US `graph_conflict.json` 只追加 `wikilink` 组
- 新增 source 守卫测试
- 不改 in-flight 逻辑与 `toUserMessage()` 路径

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下 wikilink 创建笔记抛异常，toast 应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

