### PR TITLE
fix(i18n): 教材适配器错误走 card_manager:textbook

### DIFF
--- a/src/dstu/adapters/__tests__/textbookDstuAdapter.i18n.test.ts
+++ b/src/dstu/adapters/__tests__/textbookDstuAdapter.i18n.test.ts
@@ -1,0 +1,222 @@
+/**
+ * 教材 DSTU 适配器错误文案 i18n 契约测试
+ *
+ * 覆盖三层保障：
+ * 1. locale 契约：zh-CN/en-US 的 card_manager.json 均含顶层 textbook 组，
+ *    且 zh-CN 取值与主干原始中文文案逐字一致。
+ * 2. source 守卫：textbookDstuAdapter.ts 中 reportError / toVfsError 的
+ *    用户可见文案均经由 i18next.t('card_manager:textbook.*')，
+ *    defaultValue 与 zh-CN locale 完全一致（异步 namespace 未就绪时兜底）。
+ * 3. key-echo：mock i18next 后走真实失败路径，确认 reportError 的 context
+ *    与 VfsError.message 确实来自 i18next.t 的返回值。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import zhCardManager from '@/locales/zh-CN/card_manager.json';
+import enCardManager from '@/locales/en-US/card_manager.json';
+
+const invokeMock = vi.fn();
+const reportErrorMock = vi.fn();
+const dstuListMock = vi.fn();
+const dstuGetMock = vi.fn();
+const dstuDeleteMock = vi.fn();
+const dstuSetFavoriteMock = vi.fn();
+const tMock = vi.fn(
+  (key: string, options?: { defaultValue?: string }): string => {
+    const bare = key.includes(':') ? key.slice(key.indexOf(':') + 1) : key;
+    const value = bare.split('.').reduce<unknown>((acc, part) => {
+      if (acc && typeof acc === 'object' && part in (acc as object)) {
+        return (acc as Record<string, unknown>)[part];
+      }
+      return undefined;
+    }, zhCardManager as Record<string, unknown>);
+    if (typeof value === 'string') return value;
+    return options?.defaultValue ?? key;
+  },
+);
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock('../../api', () => ({
+  dstu: {
+    list: dstuListMock,
+    get: dstuGetMock,
+    delete: dstuDeleteMock,
+    setFavorite: dstuSetFavoriteMock,
+  },
+}));
+
+vi.mock('i18next', () => ({
+  default: {
+    t: tMock,
+  },
+}));
+
+vi.mock('@/utils/fileManager', () => ({
+  isOpaqueDocumentId: () => false,
+}));
+
+vi.mock('@/shared/result', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/shared/result')>();
+  return {
+    ...actual,
+    reportError: reportErrorMock,
+  };
+});
+
+/** 主干原始中文文案（zh-CN locale 必须与之逐字一致） */
+const EXPECTED_ZH_CN: Record<string, string> = {
+  list: '列出教材',
+  get_detail: '获取教材详情',
+  delete: '删除教材',
+  set_favorite: '设置收藏状态',
+  add: '添加教材',
+};
+
+// jsdom 环境下 import.meta.url 非 file 协议，使用 vitest 根目录（项目根）解析
+const adapterSourcePath = resolve(process.cwd(), 'src/dstu/adapters/textbookDstuAdapter.ts');
+const adapterSource = readFileSync(adapterSourcePath, 'utf-8');
+
+describe('textbookDstuAdapter 错误文案 i18n（card_manager:textbook）', async () => {
+  // 动态导入以避免静态 import 触发 vi.mock 工厂对未初始化 mock 变量的提前访问
+  const { err, VfsError, VfsErrorCode } = await import('@/shared/result');
+  const { textbookDstuAdapter } = await import('../textbookDstuAdapter');
+
+  beforeEach(() => {
+    invokeMock.mockReset();
+    reportErrorMock.mockReset();
+    dstuListMock.mockReset();
+    dstuGetMock.mockReset();
+    dstuDeleteMock.mockReset();
+    dstuSetFavoriteMock.mockReset();
+    tMock.mockClear();
+  });
+
+  describe('locale 契约', () => {
+    it('zh-CN 含顶层 textbook 组且取值与主干原文一致', () => {
+      const group = (zhCardManager as Record<string, unknown>).textbook as Record<string, string>;
+      expect(group).toBeTruthy();
+      expect(group).toEqual(EXPECTED_ZH_CN);
+    });
+
+    it('en-US 含顶层 textbook 组，key 与 zh-CN 对齐且值非空、不含中文', () => {
+      const group = (enCardManager as Record<string, unknown>).textbook as Record<string, string>;
+      expect(group).toBeTruthy();
+      expect(Object.keys(group).sort()).toEqual(Object.keys(EXPECTED_ZH_CN).sort());
+      for (const [key, value] of Object.entries(group)) {
+        expect(value, `en-US textbook.${key} 不应为空`).toBeTruthy();
+        expect(value, `en-US textbook.${key} 不应含中文`).not.toMatch(/[\u4e00-\u9fff]/);
+      }
+    });
+  });
+
+  describe('source 守卫', () => {
+    it('所有 reportError 调用的 context 均来自 i18next.t(card_manager:textbook.*)', () => {
+      const totalCalls = adapterSource.match(/reportError\(/g) ?? [];
+      expect(totalCalls.length).toBe(5);
+      const i18nLabeled =
+        adapterSource.match(
+          /reportError\([^,\n]+,\s*(?:i18next\.t\('card_manager:textbook\.\w+'|context\b)/g
+        ) ?? [];
+      expect(i18nLabeled.length).toBe(totalCalls.length);
+      // reportError / toVfsError 的第二参数不允许再出现裸字符串字面量
+      expect(adapterSource).not.toMatch(/reportError\([^,\n]+,\s*'/);
+      expect(adapterSource).not.toMatch(/toVfsError\([^,\n]+,\s*'/);
+      // addTextbooks 失败路径：context 变量必须由 i18next.t(card_manager:textbook.add) 赋值
+      expect(adapterSource).toMatch(
+        /const context = i18next\.t\('card_manager:textbook\.add',\s*\{ defaultValue: '添加教材' \}\)/
+      );
+      expect(adapterSource).toMatch(/toVfsError\(error,\s*context\)/);
+    });
+
+    it('source 引用的每个 key 均存在于两种 locale，且 defaultValue 与 zh-CN 一致', () => {
+      const zhGroup = (zhCardManager as Record<string, unknown>).textbook as Record<string, string>;
+      const enGroup = (enCardManager as Record<string, unknown>).textbook as Record<string, string>;
+
+      const pairs = [
+        ...adapterSource.matchAll(
+          /i18next\.t\('card_manager:textbook\.(\w+)',\s*\{ defaultValue: '([^']*)' \}\)/g
+        ),
+      ];
+      const usedKeys = new Set(pairs.map(([, key]) => key));
+      expect([...usedKeys].sort()).toEqual(Object.keys(EXPECTED_ZH_CN).sort());
+      for (const [, key, defaultValue] of pairs) {
+        expect(zhGroup[key], `zh-CN 缺少 textbook.${key}`).toBeTruthy();
+        expect(enGroup[key], `en-US 缺少 textbook.${key}`).toBeTruthy();
+        expect(defaultValue, `textbook.${key} 的 defaultValue 应与 zh-CN 一致`).toBe(zhGroup[key]);
+      }
+    });
+  });
+
+  describe('key-echo 失败路径（mock i18next）', () => {
+    it('listTextbooks 失败时 reportError 的 context 来自 card_manager:textbook.list', async () => {
+      const backendError = new VfsError(VfsErrorCode.NETWORK, 'backend boom', false);
+      dstuListMock.mockResolvedValue(err(backendError));
+
+      const result = await textbookDstuAdapter.listTextbooks();
+
+      expect(result.ok).toBe(false);
+      expect(tMock).toHaveBeenCalledWith('card_manager:textbook.list', {
+        defaultValue: '列出教材',
+      });
+      expect(reportErrorMock).toHaveBeenCalledWith(backendError, '列出教材');
+    });
+
+    it('getTextbook / deleteTextbook / setFavorite 失败时各自使用对应 key', async () => {
+      const backendError = new VfsError(VfsErrorCode.NETWORK, 'backend boom', false);
+      dstuGetMock.mockResolvedValue(err(backendError));
+      dstuDeleteMock.mockResolvedValue(err(backendError));
+      dstuSetFavoriteMock.mockResolvedValue(err(backendError));
+
+      await textbookDstuAdapter.getTextbook('tb-1');
+      expect(tMock).toHaveBeenCalledWith('card_manager:textbook.get_detail', {
+        defaultValue: '获取教材详情',
+      });
+      expect(reportErrorMock).toHaveBeenLastCalledWith(backendError, '获取教材详情');
+
+      await textbookDstuAdapter.deleteTextbook('tb-1');
+      expect(tMock).toHaveBeenCalledWith('card_manager:textbook.delete', {
+        defaultValue: '删除教材',
+      });
+      expect(reportErrorMock).toHaveBeenLastCalledWith(backendError, '删除教材');
+
+      await textbookDstuAdapter.setFavorite('tb-1', true);
+      expect(tMock).toHaveBeenCalledWith('card_manager:textbook.set_favorite', {
+        defaultValue: '设置收藏状态',
+      });
+      expect(reportErrorMock).toHaveBeenLastCalledWith(backendError, '设置收藏状态');
+    });
+
+    it('addTextbooks 失败时 toVfsError 兜底文案与 reportError context 来自 card_manager:textbook.add', async () => {
+      // 非 Error 拒绝值会走 toVfsError 的 defaultMessage 分支
+      invokeMock.mockRejectedValue(undefined);
+
+      const result = await textbookDstuAdapter.addTextbooks(['/tmp/a.pdf']);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('expected failure result');
+
+      expect(tMock).toHaveBeenCalledWith('card_manager:textbook.add', {
+        defaultValue: '添加教材',
+      });
+      expect(result.error.message).toBe('添加教材');
+      expect(reportErrorMock).toHaveBeenCalledWith(result.error, '添加教材');
+    });
+
+    it('addTextbooks 保留后端错误消息，不覆盖为兜底文案', async () => {
+      invokeMock.mockRejectedValue(new Error('disk full'));
+
+      const result = await textbookDstuAdapter.addTextbooks(['/tmp/a.pdf']);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('expected failure result');
+
+      expect(result.error.message).toBe('disk full');
+      expect(reportErrorMock).toHaveBeenCalledWith(result.error, '添加教材');
+    });
+  });
+});

--- a/src/dstu/adapters/textbookDstuAdapter.ts
+++ b/src/dstu/adapters/textbookDstuAdapter.ts
@@ -12,6 +12,7 @@ import type { DstuNode, DstuListOptions, DstuPreviewType } from '../types';
 import { Result, VfsError, ok, err, reportError, toVfsError } from '@/shared/result';
 import { isOpaqueDocumentId } from '@/utils/fileManager';
 import { invoke } from '@tauri-apps/api/core';
+import i18next from 'i18next';
 
 // ============================================================================
 // 配置
@@ -112,7 +113,7 @@ export const textbookDstuAdapter = {
     console.log(LOG_PREFIX, 'listTextbooks via DSTU:', path, 'typeFilter: textbook');
     const result = await dstu.list(path, { ...options, typeFilter: 'textbook' });
     if (!result.ok) {
-      reportError(result.error, '列出教材');
+      reportError(result.error, i18next.t('card_manager:textbook.list', { defaultValue: '列出教材' }));
     }
     return result;
   },
@@ -125,7 +126,7 @@ export const textbookDstuAdapter = {
     console.log(LOG_PREFIX, 'getTextbook via DSTU:', path);
     const result = await dstu.get(path);
     if (!result.ok) {
-      reportError(result.error, '获取教材详情');
+      reportError(result.error, i18next.t('card_manager:textbook.get_detail', { defaultValue: '获取教材详情' }));
     }
     return result;
   },
@@ -138,7 +139,7 @@ export const textbookDstuAdapter = {
     console.log(LOG_PREFIX, 'deleteTextbook via DSTU:', path);
     const result = await dstu.delete(path);
     if (!result.ok) {
-      reportError(result.error, '删除教材');
+      reportError(result.error, i18next.t('card_manager:textbook.delete', { defaultValue: '删除教材' }));
     }
     return result;
   },
@@ -151,7 +152,7 @@ export const textbookDstuAdapter = {
     console.log(LOG_PREFIX, 'setFavorite via DSTU:', path, isFavorite);
     const result = await dstu.setFavorite(path, isFavorite);
     if (!result.ok) {
-      reportError(result.error, '设置收藏状态');
+      reportError(result.error, i18next.t('card_manager:textbook.set_favorite', { defaultValue: '设置收藏状态' }));
     }
     return result;
   },
@@ -230,8 +231,9 @@ export const textbookDstuAdapter = {
       
       return ok(nodes);
     } catch (error: unknown) {
-      const vfsError = toVfsError(error, '添加教材');
-      reportError(vfsError, '添加教材');
+      const context = i18next.t('card_manager:textbook.add', { defaultValue: '添加教材' });
+      const vfsError = toVfsError(error, context);
+      reportError(vfsError, context);
       return err(vfsError);
     }
   },

--- a/src/locales/en-US/card_manager.json
+++ b/src/locales/en-US/card_manager.json
@@ -44,6 +44,13 @@
   "mapping_success": "Mapped successfully",
   "mapping_created": "Newly created",
   "mapping_failed": "Mapping failed",
-  "processing_time": "Processing time"
+  "processing_time": "Processing time",
+  "textbook": {
+    "list": "Listing textbooks",
+    "get_detail": "Getting textbook details",
+    "delete": "Deleting textbook",
+    "set_favorite": "Setting favorite status",
+    "add": "Adding textbooks"
+  }
 }
 

--- a/src/locales/zh-CN/card_manager.json
+++ b/src/locales/zh-CN/card_manager.json
@@ -44,5 +44,12 @@
   "mapping_success": "映射成功",
   "mapping_created": "新创建",
   "mapping_failed": "映射失败",
-  "processing_time": "处理时间"
+  "processing_time": "处理时间",
+  "textbook": {
+    "list": "列出教材",
+    "get_detail": "获取教材详情",
+    "delete": "删除教材",
+    "set_favorite": "设置收藏状态",
+    "add": "添加教材"
+  }
 } 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

教材 DSTU 适配器把列出/详情/删除/收藏/添加失败的动作名写成硬编码中文。`textbook.json` 已被占用，改为 `card_manager:textbook.*`。

### Changes
- `textbookDstuAdapter` 的 `reportError` / `toVfsError` 走 i18n，保留 `defaultValue`
- zh-CN / en-US `card_manager.json` 只追加 `textbook` 组
- 新增契约测试
- 「文件」不透明名探测与 `导入文档_` 前缀未改

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下添加或列出教材失败，错误上下文应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

