### PR TITLE
fix(a11y): 开发恢复菜单 aria-label 走 dev:recovery_fab

### DIFF
--- a/src/dev/DevMobileRecoveryFab.tsx
+++ b/src/dev/DevMobileRecoveryFab.tsx
@@ -3,6 +3,7 @@
  * 仅在 DEV + 小屏时挂载（见 App.tsx）。支持拖动，避免挡住侧栏内容。
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ArrowClockwise, Bug, House } from '@phosphor-icons/react';
 import { DsButton } from '@/components/ui/DsButton';
 import { cn } from '@/lib/utils';
@@ -58,6 +59,7 @@ async function openDevTools() {
 }
 
 export const DevMobileRecoveryFab: React.FC = () => {
+  const { t } = useTranslation('dev');
   const [open, setOpen] = useState(false);
   const [position, setPosition] = useState<FabPosition>(() => readStoredPosition() ?? defaultPosition());
   const [dragging, setDragging] = useState(false);
@@ -195,7 +197,7 @@ export const DevMobileRecoveryFab: React.FC = () => {
             dragging && 'cursor-grabbing opacity-90',
           )}
           aria-expanded={open}
-          aria-label="开发恢复菜单（可拖动）"
+          aria-label={t('recovery_fab.aria_label', { defaultValue: '开发恢复菜单（可拖动）' })}
           onPointerDown={handleFabPointerDown}
           onPointerMove={handleFabPointerMove}
           onPointerUp={handleFabPointerUp}

--- a/src/dev/__tests__/DevMobileRecoveryFab.i18n.test.ts
+++ b/src/dev/__tests__/DevMobileRecoveryFab.i18n.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const componentPath = path.join(repoRoot, 'src/dev/DevMobileRecoveryFab.tsx');
+const zhDevPath = path.join(repoRoot, 'src/locales/zh-CN/dev.json');
+const enDevPath = path.join(repoRoot, 'src/locales/en-US/dev.json');
+
+describe('DevMobileRecoveryFab aria-label i18n', () => {
+  it('source uses the dev namespace key instead of a hardcoded aria-label', () => {
+    const source = readFileSync(componentPath, 'utf8');
+
+    expect(source).toContain("useTranslation('dev')");
+    expect(source).toContain("t('recovery_fab.aria_label'");
+    expect(source).not.toContain('aria-label="开发恢复菜单（可拖动）"');
+  });
+
+  it('zh-CN and en-US dev locales define recovery_fab.aria_label', () => {
+    const zh = JSON.parse(readFileSync(zhDevPath, 'utf8'));
+    const en = JSON.parse(readFileSync(enDevPath, 'utf8'));
+
+    for (const bundle of [zh, en]) {
+      expect(typeof bundle?.recovery_fab?.aria_label).toBe('string');
+      expect(bundle.recovery_fab.aria_label.length).toBeGreaterThan(0);
+    }
+
+    expect(zh.recovery_fab.aria_label).toBe('开发恢复菜单（可拖动）');
+  });
+});

--- a/src/locales/en-US/dev.json
+++ b/src/locales/en-US/dev.json
@@ -369,5 +369,8 @@
       "not_found": "Cannot find a mistake with ID {{id}}",
       "load_failed": "Failed to load: {{message}}"
     }
+  },
+  "recovery_fab": {
+    "aria_label": "Dev recovery menu (draggable)"
   }
 }

--- a/src/locales/zh-CN/dev.json
+++ b/src/locales/zh-CN/dev.json
@@ -369,5 +369,8 @@
       "not_found": "未找到 ID 为 {{id}} 的错题",
       "load_failed": "加载失败：{{message}}"
     }
+  },
+  "recovery_fab": {
+    "aria_label": "开发恢复菜单（可拖动）"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

开发构建里移动端恢复 FAB 的 `aria-label` 写成硬编码中文。改为 `dev:recovery_fab.aria_label`。

### Changes
- `DevMobileRecoveryFab` 走 `useTranslation('dev')`，保留 `defaultValue`
- zh-CN / en-US `dev.json` 只追加 `recovery_fab` 组
- 新增 source 守卫测试
- 不改拖动 / 菜单逻辑

### How to test
- 跑该 PR 新增的 vitest
- 英文开发构建下，恢复 FAB 的可访问名称应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

