### PR TITLE
fix(i18n): Style Lab 迁移总览走 migration:style_lab

### DIFF
--- a/src/components/style-lab/MigrationOverviewTab.tsx
+++ b/src/components/style-lab/MigrationOverviewTab.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { cn } from '@/lib/utils';
 import type { ScanData } from './types';
 
@@ -11,14 +13,15 @@ const statusColor = (pct: number) => {
   return 'bg-[color:hsl(var(--destructive))]';
 };
 
-const statusLabel = (pct: number) => {
-  if (pct >= 90) return '已收口';
-  if (pct >= 60) return '进行中';
-  if (pct >= 30) return '需推进';
-  return '待启动';
+const statusLabel = (pct: number, t: TFunction) => {
+  if (pct >= 90) return t('style_lab.status.converged', { defaultValue: '已收口' });
+  if (pct >= 60) return t('style_lab.status.in_progress', { defaultValue: '进行中' });
+  if (pct >= 30) return t('style_lab.status.needs_push', { defaultValue: '需推进' });
+  return t('style_lab.status.not_started', { defaultValue: '待启动' });
 };
 
 export function MigrationOverviewTab({ data }: Props) {
+  const { t, i18n } = useTranslation('migration');
   const { migrationProgress, summary, cssMetrics, generatedAt, scanDurationMs } = data;
 
   const overallTarget = migrationProgress.reduce((s, p) => s + p.targetRefs, 0);
@@ -29,15 +32,15 @@ export function MigrationOverviewTab({ data }: Props) {
     <div className="space-y-6">
       {/* 总览卡片 */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <MetricCard label="总体迁移率" value={`${overallPct}%`} detail={`${overallTarget} / ${overallTotal} refs`} />
-        <MetricCard label="源码文件" value={String(summary.totalFiles)} detail={`${summary.tsxFiles} TSX · ${summary.cssFiles ?? 0} CSS`} />
-        <MetricCard label="!important" value={String(cssMetrics.important?.count ?? 0)} detail={`${cssMetrics.important?.files ?? 0} 文件`} tone="warning" />
-        <MetricCard label="硬编码颜色" value={String(cssMetrics.hardcodedColor?.count ?? 0)} detail={`${cssMetrics.hardcodedColor?.files ?? 0} 文件`} tone="warning" />
+        <MetricCard label={t('style_lab.metrics.overall_rate', { defaultValue: '总体迁移率' })} value={`${overallPct}%`} detail={`${overallTarget} / ${overallTotal} refs`} />
+        <MetricCard label={t('style_lab.metrics.source_files', { defaultValue: '源码文件' })} value={String(summary.totalFiles)} detail={`${summary.tsxFiles} TSX · ${summary.cssFiles ?? 0} CSS`} />
+        <MetricCard label={t('style_lab.metrics.important', { defaultValue: '!important' })} value={String(cssMetrics.important?.count ?? 0)} detail={t('style_lab.metrics.files_count', { count: cssMetrics.important?.files ?? 0, defaultValue: '{{count}} 文件' })} tone="warning" />
+        <MetricCard label={t('style_lab.metrics.hardcoded_colors', { defaultValue: '硬编码颜色' })} value={String(cssMetrics.hardcodedColor?.count ?? 0)} detail={t('style_lab.metrics.files_count', { count: cssMetrics.hardcodedColor?.files ?? 0, defaultValue: '{{count}} 文件' })} tone="warning" />
       </div>
 
       {/* 各组件族迁移进度 */}
       <div className="space-y-3">
-        <h3 className="text-sm font-medium text-[color:var(--text-secondary)]">组件族迁移进度</h3>
+        <h3 className="text-sm font-medium text-[color:var(--text-secondary)]">{t('style_lab.sections.component_progress', { defaultValue: '组件族迁移进度' })}</h3>
         <div className="space-y-2">
           {migrationProgress.map(entry => (
             <ProgressRow key={entry.id} entry={entry} components={data.components} />
@@ -47,13 +50,13 @@ export function MigrationOverviewTab({ data }: Props) {
 
       {/* CSS 质量指标 */}
       <div className="space-y-3">
-        <h3 className="text-sm font-medium text-[color:var(--text-secondary)]">CSS 质量指标</h3>
+        <h3 className="text-sm font-medium text-[color:var(--text-secondary)]">{t('style_lab.sections.css_quality', { defaultValue: 'CSS 质量指标' })}</h3>
         <div className="space-y-1.5">
           {Object.values(cssMetrics).map(metric => (
             <div key={metric.id} className="flex items-center justify-between rounded-md px-3 py-2 bg-[color:var(--surface-elevated)]">
               <span className="text-sm text-[color:var(--text-primary)]">{metric.label}</span>
               <div className="flex items-center gap-3">
-                <span className="text-xs text-[color:var(--text-muted)]">{metric.files} 文件</span>
+                <span className="text-xs text-[color:var(--text-muted)]">{t('style_lab.metrics.files_count', { count: metric.files, defaultValue: '{{count}} 文件' })}</span>
                 <span className="text-sm font-mono font-medium text-[color:var(--text-primary)]">{metric.count.toLocaleString()}</span>
               </div>
             </div>
@@ -63,7 +66,13 @@ export function MigrationOverviewTab({ data }: Props) {
 
       {/* 扫描元信息 */}
       <p className="text-xs text-[color:var(--text-muted)]">
-        扫描于 {new Date(generatedAt).toLocaleString('zh-CN')} · 耗时 {scanDurationMs}ms · 运行 <code className="font-mono">node scripts/scan-component-usage.mjs</code> 刷新
+        {t('style_lab.footer.scan_meta', {
+          time: new Date(generatedAt).toLocaleString(i18n.language),
+          duration: scanDurationMs,
+          defaultValue: '扫描于 {{time}} · 耗时 {{duration}}ms · 运行',
+        })}{' '}
+        <code className="font-mono">node scripts/scan-component-usage.mjs</code>{' '}
+        {t('style_lab.footer.refresh_suffix', { defaultValue: '刷新' })}
       </p>
     </div>
   );
@@ -82,6 +91,7 @@ function MetricCard({ label, value, detail, tone }: { label: string; value: stri
 }
 
 function ProgressRow({ entry, components }: { entry: ScanData['migrationProgress'][number]; components: ScanData['components'] }) {
+  const { t } = useTranslation('migration');
   const pct = entry.percentage;
   const targetNames = entry.targetIds.map(id => components[id]?.label ?? id).join(', ');
   const legacyNames = entry.legacyIds.map(id => components[id]?.label ?? id).join(', ');
@@ -92,7 +102,7 @@ function ProgressRow({ entry, components }: { entry: ScanData['migrationProgress
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-[color:var(--text-primary)]">{entry.label}</span>
           <span className={cn('text-[10px] px-1.5 py-0.5 rounded-full font-medium', pct >= 90 && 'bg-[color:hsl(var(--success)/0.12)] text-[color:hsl(var(--success))]', pct >= 60 && pct < 90 && 'bg-[color:hsl(var(--info)/0.12)] text-[color:hsl(var(--info))]', pct >= 30 && pct < 60 && 'bg-[color:hsl(var(--warning)/0.12)] text-[color:hsl(var(--warning))]', pct < 30 && 'bg-[color:hsl(var(--destructive)/0.12)] text-[color:hsl(var(--destructive))]')}>
-            {statusLabel(pct)}
+            {statusLabel(pct, t)}
           </span>
         </div>
         <span className="text-xs font-mono text-[color:var(--text-secondary)]">

--- a/src/components/style-lab/__tests__/MigrationOverviewTab.i18n.test.ts
+++ b/src/components/style-lab/__tests__/MigrationOverviewTab.i18n.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const componentPath = path.join(repoRoot, 'src/components/style-lab/MigrationOverviewTab.tsx');
+const zhPath = path.join(repoRoot, 'src/locales/zh-CN/migration.json');
+const enPath = path.join(repoRoot, 'src/locales/en-US/migration.json');
+
+const source = readFileSync(componentPath, 'utf8');
+const zh = JSON.parse(readFileSync(zhPath, 'utf8'));
+const en = JSON.parse(readFileSync(enPath, 'utf8'));
+
+function keyPaths(obj: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const full = prefix ? `${prefix}.${key}` : key;
+    return value && typeof value === 'object'
+      ? keyPaths(value as Record<string, unknown>, full)
+      : [full];
+  });
+}
+
+describe('MigrationOverviewTab i18n (migration:style_lab.*)', () => {
+  it('uses the migration namespace and t() for user-facing copy', () => {
+    expect(source).toContain("useTranslation('migration')");
+
+    for (const key of [
+      'style_lab.status.converged',
+      'style_lab.status.in_progress',
+      'style_lab.status.needs_push',
+      'style_lab.status.not_started',
+      'style_lab.metrics.overall_rate',
+      'style_lab.metrics.source_files',
+      'style_lab.metrics.important',
+      'style_lab.metrics.hardcoded_colors',
+      'style_lab.metrics.files_count',
+      'style_lab.sections.component_progress',
+      'style_lab.sections.css_quality',
+      'style_lab.footer.scan_meta',
+      'style_lab.footer.refresh_suffix',
+    ]) {
+      expect(source, `component should reference ${key}`).toContain(`'${key}'`);
+    }
+
+    // 页脚时间格式跟随当前语言，而不是写死 zh-CN
+    expect(source).toContain('toLocaleString(i18n.language)');
+    expect(source).not.toContain("toLocaleString('zh-CN')");
+  });
+
+  it('zh-CN keeps the original mainline copy under style_lab', () => {
+    expect(zh.style_lab.status).toEqual({
+      converged: '已收口',
+      in_progress: '进行中',
+      needs_push: '需推进',
+      not_started: '待启动',
+    });
+    expect(zh.style_lab.metrics.overall_rate).toBe('总体迁移率');
+    expect(zh.style_lab.metrics.source_files).toBe('源码文件');
+    expect(zh.style_lab.metrics.hardcoded_colors).toBe('硬编码颜色');
+    expect(zh.style_lab.metrics.files_count).toBe('{{count}} 文件');
+    expect(zh.style_lab.sections.component_progress).toBe('组件族迁移进度');
+    expect(zh.style_lab.sections.css_quality).toBe('CSS 质量指标');
+    expect(zh.style_lab.footer.scan_meta).toBe('扫描于 {{time}} · 耗时 {{duration}}ms · 运行');
+    expect(zh.style_lab.footer.refresh_suffix).toBe('刷新');
+  });
+
+  it('en-US mirrors the style_lab key structure with English copy', () => {
+    expect(keyPaths(en.style_lab)).toEqual(keyPaths(zh.style_lab));
+
+    for (const key of keyPaths(en.style_lab)) {
+      const value = key.split('.').reduce<unknown>(
+        (acc, part) => (acc as Record<string, unknown>)[part],
+        en.style_lab,
+      );
+      expect(typeof value, `${key} should be a string`).toBe('string');
+    }
+
+    // 插值占位符两侧一致
+    expect(en.style_lab.metrics.files_count).toContain('{{count}}');
+    expect(en.style_lab.footer.scan_meta).toContain('{{time}}');
+    expect(en.style_lab.footer.scan_meta).toContain('{{duration}}');
+  });
+
+  it('does not touch the existing data-migration wizard keys', () => {
+    for (const bundle of [zh, en]) {
+      for (const key of ['title', 'description', 'status', 'check', 'actions', 'progress', 'steps', 'report', 'confirm', 'toast']) {
+        expect(bundle, `wizard key "${key}" should still exist`).toHaveProperty(key);
+      }
+    }
+    expect(zh.status.inProgress).toBe('迁移中');
+    expect(zh.toast.checkFailed).toBe('检查状态失败');
+  });
+});

--- a/src/locales/en-US/migration.json
+++ b/src/locales/en-US/migration.json
@@ -64,5 +64,28 @@
     "rollbackCompleted": "Rollback completed",
     "rollbackFailed": "Rollback failed",
     "checkFailed": "Status check failed"
+  },
+  "style_lab": {
+    "status": {
+      "converged": "Converged",
+      "in_progress": "In progress",
+      "needs_push": "Needs push",
+      "not_started": "Not started"
+    },
+    "metrics": {
+      "overall_rate": "Overall migration",
+      "source_files": "Source files",
+      "important": "!important",
+      "hardcoded_colors": "Hardcoded colors",
+      "files_count": "{{count}} files"
+    },
+    "sections": {
+      "component_progress": "Component family migration progress",
+      "css_quality": "CSS quality metrics"
+    },
+    "footer": {
+      "scan_meta": "Scanned at {{time}} · took {{duration}}ms · run",
+      "refresh_suffix": "to refresh"
+    }
   }
 }

--- a/src/locales/zh-CN/migration.json
+++ b/src/locales/zh-CN/migration.json
@@ -64,5 +64,28 @@
     "rollbackCompleted": "回滚完成",
     "rollbackFailed": "回滚失败",
     "checkFailed": "检查状态失败"
+  },
+  "style_lab": {
+    "status": {
+      "converged": "已收口",
+      "in_progress": "进行中",
+      "needs_push": "需推进",
+      "not_started": "待启动"
+    },
+    "metrics": {
+      "overall_rate": "总体迁移率",
+      "source_files": "源码文件",
+      "important": "!important",
+      "hardcoded_colors": "硬编码颜色",
+      "files_count": "{{count}} 文件"
+    },
+    "sections": {
+      "component_progress": "组件族迁移进度",
+      "css_quality": "CSS 质量指标"
+    },
+    "footer": {
+      "scan_meta": "扫描于 {{time}} · 耗时 {{duration}}ms · 运行",
+      "refresh_suffix": "刷新"
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Style Lab 迁移总览页的状态标签、指标卡和小节标题写成硬编码中文。改为 `migration:style_lab.*`，不改数据迁移向导已有 key。

### Changes
- `MigrationOverviewTab` 走 `useTranslation('migration')`，保留 `defaultValue`
- zh-CN / en-US `migration.json` 只追加 `style_lab` 组
- 日期格式跟随当前语言
- 新增 source / locale 守卫测试
- 不改扫描数据逻辑

### How to test
- 跑该 PR 新增的 vitest
- 英文界面打开 Style Lab 迁移总览，卡片与页脚应为英文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

