### PR TITLE
fix(i18n): 题库/附件适配器错误走 mcp:dstu_*

### DIFF
--- a/src/dstu/adapters/__tests__/examAttachmentDstuAdapter.i18n.test.ts
+++ b/src/dstu/adapters/__tests__/examAttachmentDstuAdapter.i18n.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import zhMcp from '@/locales/zh-CN/mcp.json';
+import enMcp from '@/locales/en-US/mcp.json';
+
+const EXAM_KEYS = [
+  'listQuestionSets',
+  'getQuestionSetDetail',
+  'deleteQuestionSet',
+  'getQuestionSetSessionDetail',
+] as const;
+
+const ATTACHMENT_KEYS = [
+  'listAttachments',
+  'listImageAttachments',
+  'listFileAttachments',
+  'getAttachmentDetail',
+  'deleteAttachment',
+  'createAttachment',
+  'updateAttachmentMetadata',
+  'getUpdatedAttachment',
+  'setAttachmentFavorite',
+  'searchAttachments',
+  'searchImageAttachments',
+  'searchFileAttachments',
+] as const;
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), 'utf8');
+}
+
+const examSource = readSource('src/dstu/adapters/examDstuAdapter.ts');
+const attachmentSource = readSource('src/dstu/adapters/attachmentDstuAdapter.ts');
+
+describe('exam/attachment DSTU adapter i18n contract', () => {
+  it('provides dstu_exam keys in both locales with aligned key sets', () => {
+    expect(Object.keys(zhMcp.dstu_exam).sort()).toEqual([...EXAM_KEYS].sort());
+    expect(Object.keys(enMcp.dstu_exam).sort()).toEqual([...EXAM_KEYS].sort());
+    for (const key of EXAM_KEYS) {
+      expect(zhMcp.dstu_exam[key]).toBeTruthy();
+      expect(enMcp.dstu_exam[key]).toBeTruthy();
+    }
+  });
+
+  it('provides dstu_attachment keys in both locales with aligned key sets', () => {
+    expect(Object.keys(zhMcp.dstu_attachment).sort()).toEqual([...ATTACHMENT_KEYS].sort());
+    expect(Object.keys(enMcp.dstu_attachment).sort()).toEqual([...ATTACHMENT_KEYS].sort());
+    for (const key of ATTACHMENT_KEYS) {
+      expect(zhMcp.dstu_attachment[key]).toBeTruthy();
+      expect(enMcp.dstu_attachment[key]).toBeTruthy();
+    }
+  });
+
+  it('references every locale key from the adapter sources with an en-US defaultValue', () => {
+    const pattern =
+      /i18next\.t\('mcp:(dstu_exam|dstu_attachment)\.(\w+)',\s*\{\s*defaultValue:\s*'([^']+)'\s*\}\)/g;
+
+    const referenced = new Set<string>();
+    for (const source of [examSource, attachmentSource]) {
+      for (const match of source.matchAll(pattern)) {
+        const [, group, key, defaultValue] = match;
+        referenced.add(`${group}.${key}`);
+        const en = (enMcp as Record<string, Record<string, string>>)[group][key];
+        expect(defaultValue).toBe(en);
+      }
+    }
+
+    for (const key of EXAM_KEYS) {
+      expect(referenced).toContain(`dstu_exam.${key}`);
+    }
+    for (const key of ATTACHMENT_KEYS) {
+      expect(referenced).toContain(`dstu_attachment.${key}`);
+    }
+  });
+
+  it('does not pass hardcoded English contexts to reportError', () => {
+    const hardcodedContext = /reportError\([^,]+,\s*'[A-Za-z][^']*'\)/;
+    expect(examSource).not.toMatch(hardcodedContext);
+    expect(attachmentSource).not.toMatch(hardcodedContext);
+  });
+
+  it('keeps the existing dstu namespace attachmentNotFound message untouched', () => {
+    expect(attachmentSource).toContain(
+      "i18next.t('dstu:adapters.attachment.attachmentNotFound')"
+    );
+  });
+});

--- a/src/dstu/adapters/attachmentDstuAdapter.ts
+++ b/src/dstu/adapters/attachmentDstuAdapter.ts
@@ -199,7 +199,7 @@ export const attachmentDstuAdapter = {
     if (typeFilter) {
       const result = await dstu.list(path, { ...options, typeFilter });
       if (!result.ok) {
-        reportError(result.error, 'List attachments');
+        reportError(result.error, i18next.t('mcp:dstu_attachment.listAttachments', { defaultValue: 'List attachments' }));
       }
       return result;
     }
@@ -226,18 +226,18 @@ export const attachmentDstuAdapter = {
     // 处理错误情况
     if (!imageResult.ok && !fileResult.ok) {
       // 两者都失败，返回第一个错误
-      reportError(imageResult.error, 'List image attachments');
+      reportError(imageResult.error, i18next.t('mcp:dstu_attachment.listImageAttachments', { defaultValue: 'List image attachments' }));
       return imageResult;
     }
 
     if (!imageResult.ok) {
-      reportError(imageResult.error, 'List image attachments');
+      reportError(imageResult.error, i18next.t('mcp:dstu_attachment.listImageAttachments', { defaultValue: 'List image attachments' }));
       // 只返回文件列表
       return fileResult;
     }
 
     if (!fileResult.ok) {
-      reportError(fileResult.error, 'List file attachments');
+      reportError(fileResult.error, i18next.t('mcp:dstu_attachment.listFileAttachments', { defaultValue: 'List file attachments' }));
       // 只返回图片列表
       return imageResult;
     }
@@ -292,7 +292,7 @@ export const attachmentDstuAdapter = {
     console.log(LOG_PREFIX, 'get via DSTU:', path);
     const result = await dstu.get(path);
     if (!result.ok) {
-      reportError(result.error, 'Get attachment detail');
+      reportError(result.error, i18next.t('mcp:dstu_attachment.getAttachmentDetail', { defaultValue: 'Get attachment detail' }));
     }
     return result;
   },
@@ -307,7 +307,7 @@ export const attachmentDstuAdapter = {
     console.log(LOG_PREFIX, 'delete via DSTU:', path);
     const result = await dstu.delete(path);
     if (!result.ok) {
-      reportError(result.error, 'Delete attachment');
+      reportError(result.error, i18next.t('mcp:dstu_attachment.deleteAttachment', { defaultValue: 'Delete attachment' }));
     }
     return result;
   },
@@ -353,7 +353,7 @@ export const attachmentDstuAdapter = {
     });
 
     if (!result.ok) {
-      reportError(result.error, 'Create attachment');
+      reportError(result.error, i18next.t('mcp:dstu_attachment.createAttachment', { defaultValue: 'Create attachment' }));
     }
     return result;
   },
@@ -372,17 +372,17 @@ export const attachmentDstuAdapter = {
     console.log(LOG_PREFIX, 'updateMetadata via DSTU:', path);
     const setResult = await dstu.setMetadata(path, metadata);
     if (!setResult.ok) {
-      reportError(setResult.error, 'Update attachment metadata');
+      reportError(setResult.error, i18next.t('mcp:dstu_attachment.updateAttachmentMetadata', { defaultValue: 'Update attachment metadata' }));
       return err(setResult.error);
     }
     const getResult = await dstu.get(path);
     if (!getResult.ok) {
-      reportError(getResult.error, 'Get updated attachment');
+      reportError(getResult.error, i18next.t('mcp:dstu_attachment.getUpdatedAttachment', { defaultValue: 'Get updated attachment' }));
       return err(getResult.error);
     }
     if (!getResult.value) {
       const error = toVfsError(new Error(`Attachment not found: ${attachmentId}`), i18next.t('dstu:adapters.attachment.attachmentNotFound'));
-      reportError(error, 'Get updated attachment');
+      reportError(error, i18next.t('mcp:dstu_attachment.getUpdatedAttachment', { defaultValue: 'Get updated attachment' }));
       return err(error);
     }
     return ok(getResult.value);
@@ -399,7 +399,7 @@ export const attachmentDstuAdapter = {
     console.log(LOG_PREFIX, 'setFavorite via DSTU:', path, isFavorite);
     const result = await dstu.setFavorite(path, isFavorite);
     if (!result.ok) {
-      reportError(result.error, 'Set attachment favorite');
+      reportError(result.error, i18next.t('mcp:dstu_attachment.setAttachmentFavorite', { defaultValue: 'Set attachment favorite' }));
     }
     return result;
   },
@@ -434,7 +434,7 @@ export const attachmentDstuAdapter = {
     if (typeFilter) {
       const result = await dstu.list(path, { search: query, limit, typeFilter });
       if (!result.ok) {
-        reportError(result.error, 'Search attachments');
+        reportError(result.error, i18next.t('mcp:dstu_attachment.searchAttachments', { defaultValue: 'Search attachments' }));
       }
       return result;
     }
@@ -447,17 +447,17 @@ export const attachmentDstuAdapter = {
 
     // 处理错误情况
     if (!imageResult.ok && !fileResult.ok) {
-      reportError(imageResult.error, 'Search image attachments');
+      reportError(imageResult.error, i18next.t('mcp:dstu_attachment.searchImageAttachments', { defaultValue: 'Search image attachments' }));
       return imageResult;
     }
 
     if (!imageResult.ok) {
-      reportError(imageResult.error, 'Search image attachments');
+      reportError(imageResult.error, i18next.t('mcp:dstu_attachment.searchImageAttachments', { defaultValue: 'Search image attachments' }));
       return fileResult;
     }
 
     if (!fileResult.ok) {
-      reportError(fileResult.error, 'Search file attachments');
+      reportError(fileResult.error, i18next.t('mcp:dstu_attachment.searchFileAttachments', { defaultValue: 'Search file attachments' }));
       return imageResult;
     }
 

--- a/src/dstu/adapters/examDstuAdapter.ts
+++ b/src/dstu/adapters/examDstuAdapter.ts
@@ -9,6 +9,7 @@
  * @see 22-VFS与DSTU访达协议层改造任务分配.md Prompt 10
  */
 
+import i18next from 'i18next';
 import { dstu } from '../api';
 import { pathUtils } from '../utils/pathUtils';
 import type { DstuNode, DstuListOptions } from '../types';
@@ -138,7 +139,7 @@ export const examDstuAdapter = {
     console.log(LOG_PREFIX, 'listExams via DSTU:', path, 'typeFilter: exam');
     const result = await dstu.list(path, { ...options, typeFilter: 'exam' });
     if (!result.ok) {
-      reportError(result.error, 'List question sets');
+      reportError(result.error, i18next.t('mcp:dstu_exam.listQuestionSets', { defaultValue: 'List question sets' }));
     }
     return result;
   },
@@ -163,7 +164,7 @@ export const examDstuAdapter = {
     console.log(LOG_PREFIX, 'getExam via DSTU:', path);
     const result = await dstu.get(path);
     if (!result.ok) {
-      reportError(result.error, 'Get question set detail');
+      reportError(result.error, i18next.t('mcp:dstu_exam.getQuestionSetDetail', { defaultValue: 'Get question set detail' }));
     }
     return result;
   },
@@ -176,7 +177,7 @@ export const examDstuAdapter = {
     console.log(LOG_PREFIX, 'deleteExam via DSTU:', path);
     const result = await dstu.delete(path);
     if (!result.ok) {
-      reportError(result.error, 'Delete question set');
+      reportError(result.error, i18next.t('mcp:dstu_exam.deleteQuestionSet', { defaultValue: 'Delete question set' }));
     }
     return result;
   },
@@ -202,7 +203,7 @@ export const examDstuAdapter = {
       return ok(result);
     } catch (error: unknown) {
       const vfsError = toVfsError(error);
-      reportError(vfsError, 'Get question set session detail');
+      reportError(vfsError, i18next.t('mcp:dstu_exam.getQuestionSetSessionDetail', { defaultValue: 'Get question set session detail' }));
       return err(vfsError);
     }
   },

--- a/src/locales/en-US/mcp.json
+++ b/src/locales/en-US/mcp.json
@@ -365,5 +365,25 @@
     "spawn_hint_npx": "If you rely on npx, install Node.js and ensure the command works in your terminal.",
     "spawn_hint_install": "Install the reference MCP server with npm install -g @modelcontextprotocol/server-filesystem.",
     "spawn_hint_where": "On Windows you can run \"where {{command}}\" to inspect the resolved executable."
+  },
+  "dstu_exam": {
+    "listQuestionSets": "List question sets",
+    "getQuestionSetDetail": "Get question set detail",
+    "deleteQuestionSet": "Delete question set",
+    "getQuestionSetSessionDetail": "Get question set session detail"
+  },
+  "dstu_attachment": {
+    "listAttachments": "List attachments",
+    "listImageAttachments": "List image attachments",
+    "listFileAttachments": "List file attachments",
+    "getAttachmentDetail": "Get attachment detail",
+    "deleteAttachment": "Delete attachment",
+    "createAttachment": "Create attachment",
+    "updateAttachmentMetadata": "Update attachment metadata",
+    "getUpdatedAttachment": "Get updated attachment",
+    "setAttachmentFavorite": "Set attachment favorite",
+    "searchAttachments": "Search attachments",
+    "searchImageAttachments": "Search image attachments",
+    "searchFileAttachments": "Search file attachments"
   }
 }

--- a/src/locales/zh-CN/mcp.json
+++ b/src/locales/zh-CN/mcp.json
@@ -365,5 +365,25 @@
     "spawn_hint_npx": "如果使用 npx，请先安装 Node.js 并确保终端可以直接执行该命令。",
     "spawn_hint_install": "可运行 npm install -g @modelcontextprotocol/server-filesystem 安装官方示例服务器。",
     "spawn_hint_where": "Windows 用户可在命令提示符运行 \"where {{command}}\" 检查可执行文件路径。"
+  },
+  "dstu_exam": {
+    "listQuestionSets": "列出题目集",
+    "getQuestionSetDetail": "获取题目集详情",
+    "deleteQuestionSet": "删除题目集",
+    "getQuestionSetSessionDetail": "获取题目集会话详情"
+  },
+  "dstu_attachment": {
+    "listAttachments": "列出附件",
+    "listImageAttachments": "列出图片附件",
+    "listFileAttachments": "列出文件附件",
+    "getAttachmentDetail": "获取附件详情",
+    "deleteAttachment": "删除附件",
+    "createAttachment": "创建附件",
+    "updateAttachmentMetadata": "更新附件元数据",
+    "getUpdatedAttachment": "获取更新后的附件",
+    "setAttachmentFavorite": "设置附件收藏",
+    "searchAttachments": "搜索附件",
+    "searchImageAttachments": "搜索图片附件",
+    "searchFileAttachments": "搜索文件附件"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

题库与附件 DSTU 适配器的 `reportError` 上下文仍是英文硬编码，会进用户通知。`exam_sheet.json` / `dstu.json` 已被占用，改为 `mcp:dstu_exam.*` / `mcp:dstu_attachment.*`。

### Changes
- `examDstuAdapter` 4 处上下文走 i18n，`defaultValue` 保留主干英文
- `attachmentDstuAdapter` 英文上下文走 i18n；已有 `dstu:adapters.attachment.attachmentNotFound` 未改
- zh-CN / en-US `mcp.json` 只追加两组 key
- 新增契约测试

### How to test
- 跑该 PR 新增的 vitest
- 中文界面下列出题目集或附件失败，通知动作名应为中文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

