### PR TITLE
fix(a11y): Crepe 演示返回按钮复用 common:back

### DIFF
--- a/src/components/dev/CrepeDemoPage.tsx
+++ b/src/components/dev/CrepeDemoPage.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { DsButton } from '@/components/ui/DsButton';
 import { ArrowLeft, Copy, Check } from '@phosphor-icons/react';
 import { CrepeEditor, type CrepeEditorApi } from '../crepe';
@@ -12,6 +13,7 @@ import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { copyTextToClipboard } from '@/utils/clipboardUtils';
 
 export const CrepeDemoPage: React.FC<{ onBack?: () => void }> = ({ onBack }) => {
+  const { t } = useTranslation();
   const { isSmallScreen } = useBreakpoint();
   const [markdown, setMarkdown] = useState<string>('');
   const [copied, setCopied] = useState(false);
@@ -106,7 +108,7 @@ greeting('Crepe');
         <div className="flex items-center justify-between mb-6 p-6 pb-0">
           <div className="flex items-center gap-4">
             {onBack && (
-              <DsButton variant="ghost" iconOnly size="sm" onClick={onBack} aria-label="返回设置">
+              <DsButton variant="ghost" iconOnly size="sm" onClick={onBack} aria-label={t('common:back', '返回')}>
                 <ArrowLeft size={20} />
               </DsButton>
             )}

--- a/src/components/dev/__tests__/CrepeDemoPage.a11y.i18n.test.ts
+++ b/src/components/dev/__tests__/CrepeDemoPage.a11y.i18n.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pageSource = readFileSync(path.join(here, '../CrepeDemoPage.tsx'), 'utf8');
+const zhCommon = JSON.parse(
+  readFileSync(path.join(here, '../../../locales/zh-CN/common.json'), 'utf8'),
+);
+const enCommon = JSON.parse(
+  readFileSync(path.join(here, '../../../locales/en-US/common.json'), 'utf8'),
+);
+
+describe('CrepeDemoPage back button a11y i18n contract', () => {
+  it('uses the shared common:back key with a zh fallback for the back aria-label', () => {
+    expect(pageSource).toContain("useTranslation");
+    expect(pageSource).toContain("aria-label={t('common:back', '返回')}");
+  });
+
+  it('does not hardcode the back aria-label in Chinese', () => {
+    expect(pageSource).not.toContain('aria-label="返回设置"');
+    expect(pageSource).not.toContain('aria-label="返回"');
+  });
+
+  it('relies on an existing top-level back key in both locales (no new keys)', () => {
+    expect(zhCommon.back).toBe('返回');
+    expect(enCommon.back).toBe('Back');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Crepe 演示页返回按钮的 `aria-label` 写成硬编码「返回设置」。不改任何 locale，复用已有 `common:back`。

### Changes
- `CrepeDemoPage` 桌面端返回按钮 `aria-label={t('common:back', '返回')}`
- 新增 source 守卫测试
- 零 locale 文件改动；页面标题等其它中文未切

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下该按钮可访问名称应为 Back

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

