### PR TITLE
fix(i18n): 作文/翻译适配器错误走 app_menu:dstu_*

### DIFF
--- a/src/dstu/adapters/__tests__/essayTranslationDstuAdapter.i18n.test.ts
+++ b/src/dstu/adapters/__tests__/essayTranslationDstuAdapter.i18n.test.ts
@@ -1,0 +1,206 @@
+/**
+ * essayDstuAdapter / translationDstuAdapter 错误上下文 i18n 契约
+ *
+ * - reportError / toVfsError 的上下文走 app_menu:dstu_essay.* / app_menu:dstu_translation.* key，
+ *   defaultValue 兜底为主干英文原文（namespace 异步加载窗口期不回退成裸 key）。
+ * - key-echo mock：断言与语言无关；真实文案由 app_menu.json 的 zh-CN / en-US 提供。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import enAppMenu from '@/locales/en-US/app_menu.json';
+import zhAppMenu from '@/locales/zh-CN/app_menu.json';
+
+const { tSpy, reportErrorSpy, dstuMock } = vi.hoisted(() => ({
+  tSpy: vi.fn((key: string) => key),
+  reportErrorSpy: vi.fn(),
+  dstuMock: {
+    list: vi.fn(),
+    get: vi.fn(),
+    getContent: vi.fn(),
+    delete: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    setFavorite: vi.fn(),
+    setMetadata: vi.fn(),
+  },
+}));
+
+vi.mock('i18next', () => ({ default: { t: tSpy } }));
+
+vi.mock('../../api', () => ({ dstu: dstuMock }));
+
+vi.mock('@/shared/result', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/shared/result')>();
+  return { ...actual, reportError: reportErrorSpy };
+});
+
+vi.mock('@/essay-grading/essayGradingApi', () => ({
+  EssayGradingAPI: {
+    getSession: vi.fn(),
+    getRounds: vi.fn(),
+    createSession: vi.fn(),
+  },
+  canonicalizeEssayModeId: (id: string) => id,
+}));
+
+import { VfsError, VfsErrorCode, err } from '@/shared/result';
+import { EssayGradingAPI } from '@/essay-grading/essayGradingApi';
+import { essayDstuAdapter } from '../essayDstuAdapter';
+import { translationDstuAdapter, type TranslationSession } from '../translationDstuAdapter';
+
+/** 主干英文原文（= 代码中的 defaultValue，= en-US locale 文案） */
+const EXPECTED_EN: Record<'dstu_essay' | 'dstu_translation', Record<string, string>> = {
+  dstu_essay: {
+    list_sessions: 'List essay grading sessions',
+    get_session_detail: 'Get essay session detail',
+    delete_session: 'Delete essay session',
+    get_session: 'Get essay session',
+    toggle_favorite: 'Toggle favorite',
+    set_favorite: 'Set favorite',
+    get_full_session: 'Get full essay session',
+    create_session: 'Create essay session',
+    update_session_metadata: 'Update session metadata',
+  },
+  dstu_translation: {
+    list_history: 'List translation history',
+    get_detail: 'Get translation detail',
+    delete_translation: 'Delete translation',
+    get_translation: 'Get translation',
+    toggle_favorite: 'Toggle favorite',
+    set_favorite: 'Set favorite',
+    create_record: 'Create translation record',
+    persist_settings: 'Persist translation settings',
+    update_record: 'Update translation record',
+  },
+};
+
+function makeError(): VfsError {
+  return new VfsError(VfsErrorCode.NETWORK, 'boom');
+}
+
+beforeEach(() => {
+  tSpy.mockClear();
+  reportErrorSpy.mockClear();
+  Object.values(dstuMock).forEach((fn) => fn.mockReset());
+});
+
+describe('app_menu locale 契约 — dstu_essay / dstu_translation', () => {
+  it('en-US 顶层组与主干英文原文一致', () => {
+    expect((enAppMenu as Record<string, unknown>).dstu_essay).toEqual(EXPECTED_EN.dstu_essay);
+    expect((enAppMenu as Record<string, unknown>).dstu_translation).toEqual(
+      EXPECTED_EN.dstu_translation,
+    );
+  });
+
+  it('zh-CN 与 en-US key 集合一致且均为非空中文文案', () => {
+    for (const group of ['dstu_essay', 'dstu_translation'] as const) {
+      const zhGroup = (zhAppMenu as Record<string, unknown>)[group] as Record<string, string>;
+      expect(Object.keys(zhGroup).sort()).toEqual(Object.keys(EXPECTED_EN[group]).sort());
+      for (const value of Object.values(zhGroup)) {
+        expect(typeof value).toBe('string');
+        expect(value.length).toBeGreaterThan(0);
+        expect(value).toMatch(/[\u4e00-\u9fff]/);
+      }
+    }
+  });
+});
+
+describe('essayDstuAdapter — reportError / toVfsError 上下文走 app_menu:dstu_essay.*', () => {
+  it('listEssays 失败 → list_sessions（defaultValue = 英文原文）', async () => {
+    const error = makeError();
+    dstuMock.list.mockResolvedValue(err(error));
+
+    const result = await essayDstuAdapter.listEssays();
+
+    expect(result.ok).toBe(false);
+    expect(reportErrorSpy).toHaveBeenCalledWith(error, 'app_menu:dstu_essay.list_sessions');
+    expect(tSpy).toHaveBeenCalledWith('app_menu:dstu_essay.list_sessions', {
+      defaultValue: 'List essay grading sessions',
+    });
+  });
+
+  it('deleteEssay 失败 → delete_session', async () => {
+    const error = makeError();
+    dstuMock.delete.mockResolvedValue(err(error));
+
+    await essayDstuAdapter.deleteEssay('s1');
+
+    expect(reportErrorSpy).toHaveBeenCalledWith(error, 'app_menu:dstu_essay.delete_session');
+    expect(tSpy).toHaveBeenCalledWith('app_menu:dstu_essay.delete_session', {
+      defaultValue: 'Delete essay session',
+    });
+  });
+
+  it('createSession 抛错 → toVfsError 上下文 create_session', async () => {
+    vi.mocked(EssayGradingAPI.createSession).mockRejectedValue(null);
+
+    const result = await essayDstuAdapter.createSession({
+      title: 't',
+      essayType: 'narrative',
+      gradeLevel: 'g1',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // 非 Error/字符串错误 → VfsError.message 采用 defaultMessage（key-echo 即 key）
+      expect(result.error.message).toBe('app_menu:dstu_essay.create_session');
+    }
+    expect(tSpy).toHaveBeenCalledWith('app_menu:dstu_essay.create_session', {
+      defaultValue: 'Create essay session',
+    });
+  });
+});
+
+describe('translationDstuAdapter — reportError 上下文走 app_menu:dstu_translation.*', () => {
+  it('listTranslations 失败 → list_history（defaultValue = 英文原文）', async () => {
+    const error = makeError();
+    dstuMock.list.mockResolvedValue(err(error));
+
+    const result = await translationDstuAdapter.listTranslations();
+
+    expect(result.ok).toBe(false);
+    expect(reportErrorSpy).toHaveBeenCalledWith(error, 'app_menu:dstu_translation.list_history');
+    expect(tSpy).toHaveBeenCalledWith('app_menu:dstu_translation.list_history', {
+      defaultValue: 'List translation history',
+    });
+  });
+
+  it('updateTranslation 正文补写失败 → persist_settings', async () => {
+    const error = makeError();
+    dstuMock.setMetadata.mockResolvedValue({ ok: true, value: undefined });
+    dstuMock.update.mockResolvedValue(err(error));
+
+    const session: TranslationSession = {
+      id: 'tr_1',
+      sourceText: 'hello',
+      translatedText: '你好',
+      srcLang: 'en',
+      tgtLang: 'zh-CN',
+      formality: 'auto',
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const result = await translationDstuAdapter.updateTranslation(session);
+
+    expect(result.ok).toBe(false);
+    expect(reportErrorSpy).toHaveBeenCalledWith(
+      error,
+      'app_menu:dstu_translation.persist_settings',
+    );
+    expect(tSpy).toHaveBeenCalledWith('app_menu:dstu_translation.persist_settings', {
+      defaultValue: 'Persist translation settings',
+    });
+  });
+
+  it('setFavorite 失败 → set_favorite', async () => {
+    const error = makeError();
+    dstuMock.setFavorite.mockResolvedValue(err(error));
+
+    await translationDstuAdapter.setFavorite('tr_1', true);
+
+    expect(reportErrorSpy).toHaveBeenCalledWith(error, 'app_menu:dstu_translation.set_favorite');
+    expect(tSpy).toHaveBeenCalledWith('app_menu:dstu_translation.set_favorite', {
+      defaultValue: 'Set favorite',
+    });
+  });
+});

--- a/src/dstu/adapters/essayDstuAdapter.ts
+++ b/src/dstu/adapters/essayDstuAdapter.ts
@@ -235,7 +235,10 @@ export const essayDstuAdapter = {
       typeFilter: 'essay',
     });
     if (!result.ok) {
-      reportError(result.error, 'List essay grading sessions');
+      reportError(
+        result.error,
+        i18next.t('app_menu:dstu_essay.list_sessions', { defaultValue: 'List essay grading sessions' })
+      );
       return err(result.error);
     }
     return ok({
@@ -252,7 +255,10 @@ export const essayDstuAdapter = {
     console.log(LOG_PREFIX, 'getEssay via DSTU:', path);
     const result = await dstu.get(path);
     if (!result.ok) {
-      reportError(result.error, 'Get essay session detail');
+      reportError(
+        result.error,
+        i18next.t('app_menu:dstu_essay.get_session_detail', { defaultValue: 'Get essay session detail' })
+      );
       return result;
     }
     return ok(result.value);
@@ -266,7 +272,10 @@ export const essayDstuAdapter = {
     console.log(LOG_PREFIX, 'deleteEssay via DSTU:', path);
     const result = await dstu.delete(path);
     if (!result.ok) {
-      reportError(result.error, 'Delete essay session');
+      reportError(
+        result.error,
+        i18next.t('app_menu:dstu_essay.delete_session', { defaultValue: 'Delete essay session' })
+      );
     }
     return result;
   },
@@ -290,7 +299,10 @@ export const essayDstuAdapter = {
       // 先获取当前状态
       const getResult = await dstu.get(path);
       if (!getResult.ok) {
-        reportError(getResult.error, 'Get essay session');
+        reportError(
+          getResult.error,
+          i18next.t('app_menu:dstu_essay.get_session', { defaultValue: 'Get essay session' })
+        );
         return err(getResult.error);
       }
 
@@ -300,7 +312,10 @@ export const essayDstuAdapter = {
     // 使用统一的 setFavorite API
     const setResult = await dstu.setFavorite(path, newFavorite);
     if (!setResult.ok) {
-      reportError(setResult.error, 'Toggle favorite');
+      reportError(
+        setResult.error,
+        i18next.t('app_menu:dstu_essay.toggle_favorite', { defaultValue: 'Toggle favorite' })
+      );
       return err(setResult.error);
     }
 
@@ -318,7 +333,10 @@ export const essayDstuAdapter = {
 
     const result = await dstu.setFavorite(path, isFavorite);
     if (!result.ok) {
-      reportError(result.error, 'Set favorite');
+      reportError(
+        result.error,
+        i18next.t('app_menu:dstu_essay.set_favorite', { defaultValue: 'Set favorite' })
+      );
     }
     return result;
   },
@@ -387,7 +405,10 @@ export const essayDstuAdapter = {
       });
     } catch (error: unknown) {
       console.error(LOG_PREFIX, 'getFullSession failed:', error);
-      return err(toVfsError(error, 'Get full essay session'));
+      return err(toVfsError(
+        error,
+        i18next.t('app_menu:dstu_essay.get_full_session', { defaultValue: 'Get full essay session' })
+      ));
     }
   },
 
@@ -442,7 +463,10 @@ export const essayDstuAdapter = {
       });
     } catch (error: unknown) {
       console.error(LOG_PREFIX, 'createSession failed:', error);
-      return err(toVfsError(error, 'Create essay session'));
+      return err(toVfsError(
+        error,
+        i18next.t('app_menu:dstu_essay.create_session', { defaultValue: 'Create essay session' })
+      ));
     }
   },
 
@@ -470,7 +494,10 @@ export const essayDstuAdapter = {
       isFavorite: data.isFavorite,
     });
     if (!result.ok) {
-      reportError(result.error, 'Update session metadata');
+      reportError(
+        result.error,
+        i18next.t('app_menu:dstu_essay.update_session_metadata', { defaultValue: 'Update session metadata' })
+      );
     }
     return result;
   },

--- a/src/dstu/adapters/translationDstuAdapter.ts
+++ b/src/dstu/adapters/translationDstuAdapter.ts
@@ -6,6 +6,7 @@
  * @see 22-VFS与DSTU访达协议层改造任务分配.md Prompt 10
  */
 
+import i18next from 'i18next';
 import { dstu } from '../api';
 import { pathUtils } from '../utils/pathUtils';
 import type { DstuNode, DstuListOptions } from '../types';
@@ -319,7 +320,10 @@ export const translationDstuAdapter = {
       typeFilter: 'translation',
     });
     if (!result.ok) {
-      reportError(result.error, 'List translation history');
+      reportError(
+        result.error,
+        i18next.t('app_menu:dstu_translation.list_history', { defaultValue: 'List translation history' })
+      );
       return err(result.error);
     }
     // ★ 后端 list 不返回真实 total，此处返回「已见下界」（offset + 本页条数）：
@@ -343,7 +347,10 @@ export const translationDstuAdapter = {
     console.log(LOG_PREFIX, 'getTranslation via DSTU:', path);
     const result = await dstu.get(path);
     if (!result.ok) {
-      reportError(result.error, 'Get translation detail');
+      reportError(
+        result.error,
+        i18next.t('app_menu:dstu_translation.get_detail', { defaultValue: 'Get translation detail' })
+      );
       return result;
     }
     const contentResult = await dstu.getContent(path);
@@ -380,7 +387,10 @@ export const translationDstuAdapter = {
     console.log(LOG_PREFIX, 'deleteTranslation via DSTU:', path);
     const result = await dstu.delete(path);
     if (!result.ok) {
-      reportError(result.error, 'Delete translation');
+      reportError(
+        result.error,
+        i18next.t('app_menu:dstu_translation.delete_translation', { defaultValue: 'Delete translation' })
+      );
     }
     return result;
   },
@@ -404,7 +414,10 @@ export const translationDstuAdapter = {
       // 先获取当前状态
       const getResult = await dstu.get(path);
       if (!getResult.ok) {
-        reportError(getResult.error, 'Get translation');
+        reportError(
+          getResult.error,
+          i18next.t('app_menu:dstu_translation.get_translation', { defaultValue: 'Get translation' })
+        );
         return err(getResult.error);
       }
 
@@ -414,7 +427,10 @@ export const translationDstuAdapter = {
     // 使用统一的 setFavorite API
     const setResult = await dstu.setFavorite(path, newFavorite);
     if (!setResult.ok) {
-      reportError(setResult.error, 'Toggle favorite');
+      reportError(
+        setResult.error,
+        i18next.t('app_menu:dstu_translation.toggle_favorite', { defaultValue: 'Toggle favorite' })
+      );
       return err(setResult.error);
     }
 
@@ -432,7 +448,10 @@ export const translationDstuAdapter = {
 
     const result = await dstu.setFavorite(path, isFavorite);
     if (!result.ok) {
-      reportError(result.error, 'Set favorite');
+      reportError(
+        result.error,
+        i18next.t('app_menu:dstu_translation.set_favorite', { defaultValue: 'Set favorite' })
+      );
     }
     return result;
   },
@@ -475,7 +494,10 @@ export const translationDstuAdapter = {
       },
     });
     if (!result.ok) {
-      reportError(result.error, 'Create translation record');
+      reportError(
+        result.error,
+        i18next.t('app_menu:dstu_translation.create_record', { defaultValue: 'Create translation record' })
+      );
       return result;
     }
 
@@ -486,7 +508,10 @@ export const translationDstuAdapter = {
       'translation'
     );
     if (!bodyResult.ok) {
-      reportError(bodyResult.error, 'Persist translation settings');
+      reportError(
+        bodyResult.error,
+        i18next.t('app_menu:dstu_translation.persist_settings', { defaultValue: 'Persist translation settings' })
+      );
       return ok(node);
     }
     return ok(mergeContentIntoNode(bodyResult.value, {
@@ -523,13 +548,19 @@ export const translationDstuAdapter = {
       isFavorite: session.isFavorite,
     });
     if (!metaResult.ok) {
-      reportError(metaResult.error, 'Update translation record');
+      reportError(
+        metaResult.error,
+        i18next.t('app_menu:dstu_translation.update_record', { defaultValue: 'Update translation record' })
+      );
       return metaResult;
     }
 
     const bodyResult = await dstu.update(path, buildTranslationContent(session), 'translation');
     if (!bodyResult.ok) {
-      reportError(bodyResult.error, 'Persist translation settings');
+      reportError(
+        bodyResult.error,
+        i18next.t('app_menu:dstu_translation.persist_settings', { defaultValue: 'Persist translation settings' })
+      );
       return err(bodyResult.error);
     }
     return ok(undefined);

--- a/src/locales/en-US/app_menu.json
+++ b/src/locales/en-US/app_menu.json
@@ -74,5 +74,27 @@
         "dark_light": "Dark/Light theme adaptive"
       }
     }
+  },
+  "dstu_essay": {
+    "list_sessions": "List essay grading sessions",
+    "get_session_detail": "Get essay session detail",
+    "delete_session": "Delete essay session",
+    "get_session": "Get essay session",
+    "toggle_favorite": "Toggle favorite",
+    "set_favorite": "Set favorite",
+    "get_full_session": "Get full essay session",
+    "create_session": "Create essay session",
+    "update_session_metadata": "Update session metadata"
+  },
+  "dstu_translation": {
+    "list_history": "List translation history",
+    "get_detail": "Get translation detail",
+    "delete_translation": "Delete translation",
+    "get_translation": "Get translation",
+    "toggle_favorite": "Toggle favorite",
+    "set_favorite": "Set favorite",
+    "create_record": "Create translation record",
+    "persist_settings": "Persist translation settings",
+    "update_record": "Update translation record"
   }
 }

--- a/src/locales/zh-CN/app_menu.json
+++ b/src/locales/zh-CN/app_menu.json
@@ -74,5 +74,27 @@
         "dark_light": "暗色/亮色主题自适应"
       }
     }
+  },
+  "dstu_essay": {
+    "list_sessions": "获取作文批改会话列表",
+    "get_session_detail": "获取作文会话详情",
+    "delete_session": "删除作文会话",
+    "get_session": "获取作文会话",
+    "toggle_favorite": "切换收藏状态",
+    "set_favorite": "设置收藏状态",
+    "get_full_session": "获取完整作文会话",
+    "create_session": "创建作文会话",
+    "update_session_metadata": "更新会话元数据"
+  },
+  "dstu_translation": {
+    "list_history": "获取翻译历史列表",
+    "get_detail": "获取翻译详情",
+    "delete_translation": "删除翻译记录",
+    "get_translation": "获取翻译记录",
+    "toggle_favorite": "切换收藏状态",
+    "set_favorite": "设置收藏状态",
+    "create_record": "创建翻译记录",
+    "persist_settings": "保存翻译设置",
+    "update_record": "更新翻译记录"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

作文与翻译 DSTU 适配器的 `reportError` / `toVfsError` 上下文仍是英文硬编码。`essay_grading.json` / `translation.json` 已被占用，改为 `app_menu:dstu_essay.*` / `app_menu:dstu_translation.*`。

### Changes
- `essayDstuAdapter` 与 `translationDstuAdapter` 走 i18n，`defaultValue` 保留主干英文
- zh-CN / en-US `app_menu.json` 只追加两组 key
- 新增契约测试
- 不改 console.warn / 已有 app_menu 文案

### How to test
- 跑该 PR 新增的 vitest
- 中文界面下列出作文或翻译失败，通知动作名应为中文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

