### PR TITLE
fix(i18n): useDstuResource 错误上下文复用已有 common/learningHub key

### DIFF
--- a/src/dstu/hooks/__tests__/useDstuResource.i18n.test.ts
+++ b/src/dstu/hooks/__tests__/useDstuResource.i18n.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const hookSource = readFileSync(path.join(here, '../useDstuResource.ts'), 'utf8');
+const zhCommon = JSON.parse(
+  readFileSync(path.join(here, '../../../locales/zh-CN/common.json'), 'utf8'),
+);
+const zhLearningHub = JSON.parse(
+  readFileSync(path.join(here, '../../../locales/zh-CN/learningHub.json'), 'utf8'),
+);
+
+describe('useDstuResource reportError i18n contract', () => {
+  it('no longer passes hardcoded English contexts to reportError', () => {
+    for (const legacyContext of [
+      "'Get content'",
+      "'Get resource'",
+      "'Save resource'",
+      "'Delete resource'",
+      "'Create resource'",
+      "'Search resource'",
+    ]) {
+      expect(hookSource).not.toContain(legacyContext);
+    }
+  });
+
+  it('resolves reportError contexts through i18n with Chinese defaults', () => {
+    expect(hookSource).toContain("import i18n from '@/i18n'");
+    expect(hookSource).toContain("i18n.t('learningHub:error.loadFailed', { defaultValue: '加载失败' })");
+    expect(hookSource).toContain("i18n.t('common:save', { defaultValue: '保存' })");
+    expect(hookSource).toContain("i18n.t('common:delete', { defaultValue: '删除' })");
+    expect(hookSource).toContain("i18n.t('common:create', { defaultValue: '新建' })");
+    expect(hookSource).toContain("i18n.t('common:search', { defaultValue: '搜索' })");
+  });
+
+  it('only reuses locale keys that already exist on main (no locale edits needed)', () => {
+    expect(zhCommon.save).toBe('保存');
+    expect(zhCommon.delete).toBe('删除');
+    expect(zhCommon.create).toBe('新建');
+    expect(zhCommon.search).toBe('搜索');
+    expect(zhLearningHub.error.loadFailed).toBe('加载失败');
+  });
+});

--- a/src/dstu/hooks/useDstuResource.ts
+++ b/src/dstu/hooks/useDstuResource.ts
@@ -13,6 +13,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { dstu } from '../api';
 import type { DstuNode, DstuCreateOptions } from '../types';
 import { type VfsError, reportError } from '@/shared/result';
+import i18n from '@/i18n';
 
 // ============================================================================
 // 类型定义
@@ -107,12 +108,12 @@ export function useDstuResource(
             setOriginalContent(null);
           }
         } else {
-          reportError(contentResult.error, 'Get content');
+          reportError(contentResult.error, i18n.t('learningHub:error.loadFailed', { defaultValue: '加载失败' }));
           setError(contentResult.error);
         }
       }
     } else {
-      reportError(nodeResult.error, 'Get resource');
+      reportError(nodeResult.error, i18n.t('learningHub:error.loadFailed', { defaultValue: '加载失败' }));
       setError(nodeResult.error);
     }
 
@@ -142,7 +143,7 @@ export function useDstuResource(
       setNode(result.value);
       setOriginalContent(content);
     } else {
-      reportError(result.error, 'Save resource');
+      reportError(result.error, i18n.t('common:save', { defaultValue: '保存' }));
       setError(result.error);
       throw result.error;
     }
@@ -163,7 +164,7 @@ export function useDstuResource(
       setContentState(null);
       setOriginalContent(null);
     } else {
-      reportError(result.error, 'Delete resource');
+      reportError(result.error, i18n.t('common:delete', { defaultValue: '删除' }));
       setError(result.error);
       throw result.error;
     }
@@ -221,7 +222,7 @@ export function useDstuCreate(): UseDstuCreateReturn {
       setCreating(false);
       return result.value;
     } else {
-      reportError(result.error, 'Create resource');
+      reportError(result.error, i18n.t('common:create', { defaultValue: '新建' }));
       setError(result.error);
       setCreating(false);
       throw result.error;
@@ -294,7 +295,7 @@ export function useDstuSearch(options: UseDstuSearchOptions = {}): UseDstuSearch
       if (result.ok) {
         setResults(result.value);
       } else {
-        reportError(result.error, 'Search resource');
+        reportError(result.error, i18n.t('common:search', { defaultValue: '搜索' }));
         setError(result.error);
       }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`useDstuResource` 的 `reportError` 上下文仍是英文硬编码。不改任何 locale，复用已有 `common:save` / `delete` / `create` / `search` 与 `learningHub:error.loadFailed`。

### Changes
- 六处 reportError 第二参走 i18n，保留中文 `defaultValue`
- 新增 source 守卫测试
- 零 locale 文件改动

### How to test
- 跑该 PR 新增的 vitest
- 中文界面下保存/删除资源失败，通知动作名应为「保存」「删除」等

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

