### PR TITLE
fix(i18n): 画布 AI 编辑状态错误走 learningHub:ai_edit defaultValue

### DIFF
--- a/src/features/notes/hooks/__tests__/useAIEditState.i18n.test.ts
+++ b/src/features/notes/hooks/__tests__/useAIEditState.i18n.test.ts
@@ -1,0 +1,183 @@
+/**
+ * useAIEditState 用户可见错误文案 i18n 契约测试。
+ *
+ * 本切换刻意不改任何 locale JSON：错误文案全部走
+ * `i18n.t('learningHub:ai_edit.*', { defaultValue: 主干中文原文 })` 兜底。
+ * 因此分两层守卫：
+ * 1. source 守卫：每条错误必须经 i18n.t 且 defaultValue 与主干原文逐字相等，
+ *    不允许硬编码中文直接赋给 error；learningHub locale JSON 中不得出现
+ *    ai_edit 段（零 locale 文件改动）。
+ * 2. 行为守卫：mock `@/i18n` 复刻 i18next 的 defaultValue + {{var}} 插值语义，
+ *    断言 computeProposedContent / reject 返回给 UI 的中文与切换前完全一致。
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+const i18nMock = vi.hoisted(() => {
+  // 复刻 i18next 语义：key 未在任何 locale 注册时返回 defaultValue，并做 {{var}} 插值。
+  const t = (key: string, options?: Record<string, unknown>) => {
+    const template =
+      typeof options?.defaultValue === 'string' ? (options.defaultValue as string) : key;
+    return template.replace(/\{\{\s*([^}\s]+)\s*\}\}/g, (placeholder, name) => {
+      const value = options?.[name];
+      return value == null ? placeholder : String(value);
+    });
+  };
+  return { t };
+});
+vi.mock('@/i18n', () => ({ default: i18nMock }));
+
+import {
+  computeProposedContent,
+  useAIEditState,
+  type CanvasAIEditRequest,
+} from '../useAIEditState';
+
+const source = readFileSync(
+  resolve(process.cwd(), 'src/features/notes/hooks/useAIEditState.ts'),
+  'utf8',
+);
+
+/** key ↔ 主干中文原文（defaultValue 必须逐字相等，插值统一 {{var}}） */
+const EXPECTED_MESSAGES: Array<[key: string, defaultValue: string]> = [
+  ['append_content_empty', '追加内容为空'],
+  ['search_pattern_empty', '搜索模式为空'],
+  ['invalid_regex', '无效的正则表达式: {{message}}'],
+  ['regex_syntax_error', '语法错误'],
+  ['replace_target_not_found', '未找到要替换的内容'],
+  ['unknown_operation', '未知的操作类型: {{operation}}'],
+  ['section_not_found', '未找到章节: {{section}}'],
+  ['user_rejected', '用户拒绝修改'],
+];
+
+describe('useAIEditState i18n source contract', () => {
+  it('imports the shared i18n instance', () => {
+    expect(source).toContain("import i18n from '@/i18n';");
+  });
+
+  it('routes every user-facing error through learningHub:ai_edit.* with the original text as defaultValue', () => {
+    for (const [key, defaultValue] of EXPECTED_MESSAGES) {
+      expect(source).toContain(`i18n.t('learningHub:ai_edit.${key}'`);
+      expect(source).toContain(`defaultValue: '${defaultValue}'`);
+    }
+  });
+
+  it('no longer assigns hardcoded string literals to error fields', () => {
+    // 切换后所有 error 赋值要么是 i18n.t(...) 要么是透传变量，
+    // 不允许再出现 error: '中文' / error: `模板串` 这类硬编码。
+    expect(source).not.toMatch(/error:\s*['"`]/);
+  });
+
+  it('keeps the locale JSON files untouched (defaultValue-only contract)', () => {
+    for (const lang of ['zh-CN', 'en-US']) {
+      const bundle = JSON.parse(
+        readFileSync(resolve(process.cwd(), `src/locales/${lang}/learningHub.json`), 'utf8'),
+      ) as Record<string, unknown>;
+      expect(bundle).not.toHaveProperty('ai_edit');
+    }
+  });
+});
+
+describe('computeProposedContent keeps the original Chinese wording under defaultValue', () => {
+  const ORIGINAL = '# 标题\n\n正文内容';
+
+  const request = (overrides: Partial<CanvasAIEditRequest>): CanvasAIEditRequest => ({
+    requestId: 'req-1',
+    noteId: 'note-1',
+    operation: 'append',
+    ...overrides,
+  });
+
+  it('append with empty content', () => {
+    const result = computeProposedContent(request({ operation: 'append', content: '' }), ORIGINAL);
+    expect(result.error).toBe('追加内容为空');
+    expect(result.content).toBe(ORIGINAL);
+  });
+
+  it('append targeting a missing section interpolates the section title', () => {
+    const result = computeProposedContent(
+      request({ operation: 'append', content: '新增内容', section: '概述' }),
+      ORIGINAL,
+    );
+    expect(result.error).toBe('未找到章节: 概述');
+    expect(result.content).toBe(ORIGINAL);
+  });
+
+  it('replace with an empty search pattern', () => {
+    const result = computeProposedContent(
+      request({ operation: 'replace', search: '', replace: 'x' }),
+      ORIGINAL,
+    );
+    expect(result.error).toBe('搜索模式为空');
+    expect(result.content).toBe(ORIGINAL);
+  });
+
+  it('replace with an invalid regex keeps the prefix and carries the engine message', () => {
+    const result = computeProposedContent(
+      request({ operation: 'replace', search: '[', replace: 'x', isRegex: true }),
+      ORIGINAL,
+    );
+    expect(result.error).toMatch(/^无效的正则表达式: /);
+    expect(result.error!.length).toBeGreaterThan('无效的正则表达式: '.length);
+    expect(result.content).toBe(ORIGINAL);
+  });
+
+  it('replace with no match', () => {
+    const result = computeProposedContent(
+      request({ operation: 'replace', search: '不存在的片段', replace: 'x' }),
+      ORIGINAL,
+    );
+    expect(result.error).toBe('未找到要替换的内容');
+    expect(result.content).toBe(ORIGINAL);
+  });
+
+  it('unknown operation interpolates the operation name', () => {
+    const result = computeProposedContent(
+      request({ operation: 'delete' as CanvasAIEditRequest['operation'] }),
+      ORIGINAL,
+    );
+    expect(result.error).toBe('未知的操作类型: delete');
+    expect(result.content).toBe(ORIGINAL);
+  });
+
+  it('valid operations still succeed without error', () => {
+    const result = computeProposedContent(
+      request({ operation: 'replace', search: '正文', replace: '主体' }),
+      ORIGINAL,
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.replaceCount).toBe(1);
+    expect(result.content).toContain('主体内容');
+  });
+});
+
+describe('useAIEditState.reject keeps the original Chinese wording', () => {
+  it('returns 用户拒绝修改 on reject', () => {
+    const { result } = renderHook(() => useAIEditState());
+
+    act(() => {
+      const startError = result.current.startEdit(
+        {
+          requestId: 'req-reject',
+          noteId: 'note-1',
+          operation: 'append',
+          content: '追加一段',
+        },
+        '原文',
+      );
+      expect(startError).toBeNull();
+    });
+
+    let rejectResult: ReturnType<typeof result.current.reject> = null;
+    act(() => {
+      rejectResult = result.current.reject();
+    });
+
+    expect(rejectResult).not.toBeNull();
+    expect(rejectResult!.success).toBe(false);
+    expect(rejectResult!.error).toBe('用户拒绝修改');
+    expect(result.current.state.isActive).toBe(false);
+  });
+});

--- a/src/features/notes/hooks/useAIEditState.ts
+++ b/src/features/notes/hooks/useAIEditState.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import * as Diff from 'diff';
+import i18n from '@/i18n';
 
 export type CanvasEditOperation = 'append' | 'replace' | 'set';
 
@@ -78,7 +79,10 @@ export function computeProposedContent(
     case 'append': {
       const contentToAppend = request.content || '';
       if (!contentToAppend) {
-        return { content: originalContent, error: '追加内容为空' };
+        return {
+          content: originalContent,
+          error: i18n.t('learningHub:ai_edit.append_content_empty', { defaultValue: '追加内容为空' }),
+        };
       }
       
       if (request.section) {
@@ -101,7 +105,10 @@ export function computeProposedContent(
       const replaceWith = request.replace || '';
       
       if (!searchPattern) {
-        return { content: originalContent, error: '搜索模式为空' };
+        return {
+          content: originalContent,
+          error: i18n.t('learningHub:ai_edit.search_pattern_empty', { defaultValue: '搜索模式为空' }),
+        };
       }
       
       let newContent: string;
@@ -117,7 +124,12 @@ export function computeProposedContent(
         } catch (regexErr) {
           return {
             content: originalContent,
-            error: `无效的正则表达式: ${regexErr instanceof Error ? regexErr.message : '语法错误'}`,
+            error: i18n.t('learningHub:ai_edit.invalid_regex', {
+              defaultValue: '无效的正则表达式: {{message}}',
+              message: regexErr instanceof Error
+                ? regexErr.message
+                : i18n.t('learningHub:ai_edit.regex_syntax_error', { defaultValue: '语法错误' }),
+            }),
           };
         }
       } else {
@@ -127,14 +139,23 @@ export function computeProposedContent(
       }
 
       if (replaceCount === 0) {
-        return { content: originalContent, error: '未找到要替换的内容' };
+        return {
+          content: originalContent,
+          error: i18n.t('learningHub:ai_edit.replace_target_not_found', { defaultValue: '未找到要替换的内容' }),
+        };
       }
       
       return { content: newContent, replaceCount };
     }
     
     default:
-      return { content: originalContent, error: `未知的操作类型: ${request.operation}` };
+      return {
+        content: originalContent,
+        error: i18n.t('learningHub:ai_edit.unknown_operation', {
+          defaultValue: '未知的操作类型: {{operation}}',
+          operation: request.operation,
+        }),
+      };
   }
 }
 
@@ -150,7 +171,14 @@ function appendToSection(
   const match = content.match(sectionRegex);
 
   if (!match || match.index === undefined) {
-    return { success: false, content, error: `未找到章节: ${sectionTitle}` };
+    return {
+      success: false,
+      content,
+      error: i18n.t('learningHub:ai_edit.section_not_found', {
+        defaultValue: '未找到章节: {{section}}',
+        section: sectionTitle,
+      }),
+    };
   }
 
   const sectionLevel = match[1].length;
@@ -322,7 +350,7 @@ export function useAIEditState(): UseAIEditStateReturn {
     const result: CanvasAIEditResult = {
       requestId: current.request.requestId,
       success: false,
-      error: '用户拒绝修改',
+      error: i18n.t('learningHub:ai_edit.user_rejected', { defaultValue: '用户拒绝修改' }),
     };
     
     setState(initialState);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

画布 AI 编辑状态机把失败 `error` 写成硬编码中文。`notes.json` / `vfs.json` / `useCanvasAIEditHandler` 已被占用。不改 locale，走 `learningHub:ai_edit.*` + `defaultValue` 兜底。

### Changes
- `computeProposedContent` / `appendToSection` / `reject` 的用户可见 error 走 i18n
- 插值 `{{message}}` / `{{operation}}` / `{{section}}`
- 新增契约与行为测试；主干 `useCanvasAIEditHandler` 旧断言靠 defaultValue 仍绿
- 零 locale 文件改动

### How to test
- 跑该 PR 新增的 vitest
- 中文界面下空追加 / 拒绝建议，错误文案应与原来一致

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

