### PR TITLE
fix(i18n): 空资源默认名复用已有 learningHub/mindmap/RAG key

### DIFF
--- a/src/dstu/__tests__/emptyResourceTemplates.test.ts
+++ b/src/dstu/__tests__/emptyResourceTemplates.test.ts
@@ -1,0 +1,88 @@
+/**
+ * EMPTY_RESOURCE_TEMPLATES 默认名 i18n 契约测试
+ *
+ * 约束：
+ * 1. defaultName / mindmap content 的可本地化字段是 getter，按当前语言经 i18n 求值；
+ *    无译文（仅 defaultValue 兜底）时必须与主干原文完全一致，不改产品文案。
+ * 2. 无完全相等已有 key 的名称（新教材/新题目集/新翻译/新作文）保持字面量。
+ * 3. factory.ts 不做任何改动：本地化通过 types.ts 的 getter 对 factory 透明生效。
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { EMPTY_RESOURCE_TEMPLATES } from '../types';
+
+const { translations } = vi.hoisted(() => ({
+  translations: new Map<string, string>(),
+}));
+
+vi.mock('@/i18n', () => ({
+  default: {
+    t: (key: string, options?: { defaultValue?: string }) =>
+      translations.get(key) ?? options?.defaultValue ?? key,
+  },
+}));
+
+afterEach(() => {
+  translations.clear();
+});
+
+describe('EMPTY_RESOURCE_TEMPLATES defaultName i18n', () => {
+  it('无译文时（defaultValue 兜底）与主干原文完全一致', () => {
+    expect(EMPTY_RESOURCE_TEMPLATES.note.defaultName).toBe('无标题笔记');
+    expect(EMPTY_RESOURCE_TEMPLATES.mindmap.defaultName).toBe('新思维导图');
+    expect(EMPTY_RESOURCE_TEMPLATES.retrieval.defaultName).toBe('检索结果');
+  });
+
+  it('无完全相等已有 key 的名称保持字面量', () => {
+    expect(EMPTY_RESOURCE_TEMPLATES.textbook.defaultName).toBe('新教材');
+    expect(EMPTY_RESOURCE_TEMPLATES.exam.defaultName).toBe('新题目集');
+    expect(EMPTY_RESOURCE_TEMPLATES.translation.defaultName).toBe('新翻译');
+    expect(EMPTY_RESOURCE_TEMPLATES.essay.defaultName).toBe('新作文');
+  });
+
+  it('defaultName 是 getter：每次读取按当前语言重新求值', () => {
+    translations.set('learningHub:contextMenu.untitledNote', 'Untitled Note');
+    translations.set('mindmap:embed.newMindMap', 'New Mind Map');
+    translations.set('enhanced_rag:rag_search.results_title', 'Search Results');
+
+    expect(EMPTY_RESOURCE_TEMPLATES.note.defaultName).toBe('Untitled Note');
+    expect(EMPTY_RESOURCE_TEMPLATES.mindmap.defaultName).toBe('New Mind Map');
+    expect(EMPTY_RESOURCE_TEMPLATES.retrieval.defaultName).toBe('Search Results');
+
+    translations.clear();
+    expect(EMPTY_RESOURCE_TEMPLATES.note.defaultName).toBe('无标题笔记');
+  });
+});
+
+describe('EMPTY_RESOURCE_TEMPLATES.mindmap.content i18n', () => {
+  it('无译文时中心主题与主干原文一致，JSON 结构不变', () => {
+    const parsed = JSON.parse(EMPTY_RESOURCE_TEMPLATES.mindmap.content ?? '');
+    expect(parsed.version).toBe('1.0');
+    expect(parsed.root).toMatchObject({ id: 'root', text: '中心主题', children: [] });
+    expect(typeof parsed.meta.createdAt).toBe('string');
+  });
+
+  it('content 是 getter：stringify 时才取译文，语言切换后重新求值', () => {
+    translations.set('mindmap:placeholder.root', 'Central Topic');
+    const localized = JSON.parse(EMPTY_RESOURCE_TEMPLATES.mindmap.content ?? '');
+    expect(localized.root.text).toBe('Central Topic');
+
+    translations.clear();
+    const fallback = JSON.parse(EMPTY_RESOURCE_TEMPLATES.mindmap.content ?? '');
+    expect(fallback.root.text).toBe('中心主题');
+  });
+});
+
+describe('factory.ts 未被改动（本地化对 factory 透明）', () => {
+  const factorySource = readFileSync(
+    fileURLToPath(new URL('../factory.ts', import.meta.url)),
+    'utf-8',
+  );
+
+  it('factory.ts 不引入 i18n，仍直接读 template.defaultName', () => {
+    expect(factorySource).not.toMatch(/i18n/);
+    expect(factorySource).toContain('template.defaultName');
+  });
+});

--- a/src/dstu/__tests__/emptyResourceTemplates.test.ts
+++ b/src/dstu/__tests__/emptyResourceTemplates.test.ts
@@ -8,7 +8,7 @@
  * 3. factory.ts 不做任何改动：本地化通过 types.ts 的 getter 对 factory 透明生效。
  */
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { EMPTY_RESOURCE_TEMPLATES } from '../types';
@@ -76,10 +76,8 @@ describe('EMPTY_RESOURCE_TEMPLATES.mindmap.content i18n', () => {
 });
 
 describe('factory.ts 未被改动（本地化对 factory 透明）', () => {
-  const factorySource = readFileSync(
-    fileURLToPath(new URL('../factory.ts', import.meta.url)),
-    'utf-8',
-  );
+  // vitest 以项目根为 cwd 运行
+  const factorySource = readFileSync(resolve(process.cwd(), 'src/dstu/factory.ts'), 'utf-8');
 
   it('factory.ts 不引入 i18n，仍直接读 template.defaultName', () => {
     expect(factorySource).not.toMatch(/i18n/);

--- a/src/dstu/types.ts
+++ b/src/dstu/types.ts
@@ -7,6 +7,8 @@
  * 数据契约来源：21-VFS虚拟文件系统架构设计.md 第四章 4.2
  */
 
+import i18n from '@/i18n';
+
 // ============================================================================
 // 核心类型
 // ============================================================================
@@ -455,13 +457,20 @@ export interface DstuEmptyResourceTemplate {
  * 各资源类型的空文件模板
  *
  * 新建资源时使用这些默认值
+ *
+ * 注意：defaultName / content 中可本地化的字段实现为 getter，
+ * 读取时按当前语言经 i18n 求值（模块加载时机早于 locale 就绪，
+ * 普通属性会把中文字面量冻死）。仅复用取值与原文完全相等的已有 key；
+ * 无对应 key 的名称保持字面量，避免改动产品文案。
  */
 export const EMPTY_RESOURCE_TEMPLATES: Record<
   Exclude<DstuNodeType, 'folder' | 'file' | 'image'>,
   DstuEmptyResourceTemplate
 > = {
   note: {
-    defaultName: '无标题笔记',
+    get defaultName() {
+      return i18n.t('learningHub:contextMenu.untitledNote', { defaultValue: '无标题笔记' });
+    },
     content: '',
     metadata: { tags: [] },
     previewType: 'markdown',
@@ -498,23 +507,29 @@ export const EMPTY_RESOURCE_TEMPLATES: Record<
     previewType: 'markdown',
   },
   mindmap: {
-    defaultName: '新思维导图',
-    content: JSON.stringify({
-      version: '1.0',
-      root: {
-        id: 'root',
-        text: '中心主题',
-        children: []
-      },
-      meta: {
-        createdAt: new Date().toISOString()
-      }
-    }),
+    get defaultName() {
+      return i18n.t('mindmap:embed.newMindMap', { defaultValue: '新思维导图' });
+    },
+    get content() {
+      return JSON.stringify({
+        version: '1.0',
+        root: {
+          id: 'root',
+          text: i18n.t('mindmap:placeholder.root', { defaultValue: '中心主题' }),
+          children: []
+        },
+        meta: {
+          createdAt: new Date().toISOString()
+        }
+      });
+    },
     metadata: { theme: 'default', defaultView: 'mindmap' },
     previewType: 'mindmap',
   },
   retrieval: {
-    defaultName: '检索结果',
+    get defaultName() {
+      return i18n.t('enhanced_rag:rag_search.results_title', { defaultValue: '检索结果' });
+    },
     content: '',
     metadata: { type: 'rag_result', query: '' },
     previewType: 'markdown',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

新建资源的默认名写成硬编码中文。`factory.ts` 已被占用，不改它：把对得上已有 key 的字段改成 getter，读取时按当前语言求值。

### Changes
- `无标题笔记` → `learningHub:contextMenu.untitledNote`
- `新思维导图` → `mindmap:embed.newMindMap`
- `中心主题` → `mindmap:placeholder.root`（`content` 改为 getter）
- `检索结果` → `enhanced_rag:rag_search.results_title`
- `新教材` / `新题目集` / `新翻译` / `新作文` 保持字面量
- 零 locale 文件改动，不改 `factory.ts`

### How to test
- 跑该 PR 新增的 vitest
- 英文界面下新建笔记 / 思维导图，默认名应为已有英文译文

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

