### PR TITLE
fix(essay): 批改图片解码上限 10MB→50MB

### DIFF
--- a/src-tauri/src/essay_grading/pipeline.rs
+++ b/src-tauri/src/essay_grading/pipeline.rs
@@ -40,10 +40,10 @@ const CONFIG_DEFAULT_TEMPERATURE: f32 = 0.7;
 
 /// 多模态图片上限：每类（作文原图/题目参考图）最多张数
 const MAX_IMAGES_PER_KIND: usize = 6;
-/// 单张图片 base64 解码后最大字节数（10MB）
-const MAX_IMAGE_DECODED_BYTES: usize = 10 * 1024 * 1024;
-/// 两类图片解码后合计最大字节数（40MB）
-const MAX_TOTAL_IMAGE_DECODED_BYTES: usize = 40 * 1024 * 1024;
+/// 单张图片 base64 解码后最大字节数（50MB，与前端图片上限一致）
+const MAX_IMAGE_DECODED_BYTES: usize = 50 * 1024 * 1024;
+/// 两类图片解码后合计最大字节数（100MB）
+const MAX_TOTAL_IMAGE_DECODED_BYTES: usize = 100 * 1024 * 1024;
 
 /// 流式响应空闲超时（秒）：距上一个数据块超过该时长判定为服务端/网络挂起。
 /// 略小于前端 useEssayGradingStream 的 120s 滑动超时，保证后端先给出明确错误。
@@ -1694,7 +1694,7 @@ mod tests {
             Some("count")
         );
 
-        // 单张体积超限（构造超过 10MB 解码体积的 base64 长度，不实际解码）
+        // 单张体积超限（构造超过单张上限解码体积的 base64 长度，不实际解码）
         let oversized = "A".repeat((MAX_IMAGE_DECODED_BYTES / 3 + 1) * 4);
         let err =
             validate_image_payloads(&[oversized.as_str()], &[]).expect_err("单张体积超限应报错");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

作文批改链路的单张图片解码上限仍是 10MB，和产品 50MB 图片上限不一致。不改被占用的 VFS `handlers.rs`，只上调批改 pipeline。

### Changes
- `MAX_IMAGE_DECODED_BYTES` 10MB → 50MB
- `MAX_TOTAL_IMAGE_DECODED_BYTES` 40MB → 100MB
- 超限中文格式串措辞不变，插值数字跟常量走
- 已有 oversized 测试按常量构造，自动跟上

### How to test
- `cargo test --lib essay_grading::pipeline`
- 用约 20–40MB 图片走作文批改，不应再报单张 10MB 超限

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457d0134-8421-4040-a104-01e6dafe0b49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457d0134-8421-4040-a104-01e6dafe0b49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

