### PR TITLE
0824 主题仓 C：Generative UI 稳定化（#214 + i18n/Rust）

### DIFF
--- a/src-tauri/src/chat_v2/tools/generative_ui_executor.rs
+++ b/src-tauri/src/chat_v2/tools/generative_ui_executor.rs
@@ -303,7 +303,8 @@ impl ToolExecutor for GenerativeUiExecutor {
             .get("meta")
             .and_then(|m| m.get("title"))
             .and_then(Value::as_str);
-        let hpias_question = title.or(extract_question_from_intent(&intent).as_deref());
+        let extracted_question = extract_question_from_intent(&intent);
+        let hpias_question = title.or(extracted_question.as_deref());
 
         let content_str =
             serde_json::to_string(&intent).map_err(|e| format!("intent 序列化失败: {}", e))?;

--- a/src/features/generative-ui/bridge/resolveGenerativeUIChatActionHandlers.ts
+++ b/src/features/generative-ui/bridge/resolveGenerativeUIChatActionHandlers.ts
@@ -2,6 +2,7 @@
  * Chat generative_ui 块 — 按 modeState + toolInput 解析 actionHandlers
  */
 
+import i18n from '@/i18n';
 import type { GenerativeActionDefinition, GenerativeUIIntent } from '../types';
 import { withGenerativeActionInstrumentation } from '../actions';
 import { intentHasResearchBlocks } from '../bridge/hpiasEventBridge';
@@ -44,6 +45,14 @@ import {
   EXPORT_INTENT_ACTION_ID,
   createExportIntentActionHandlers,
 } from '../handlers/exportIntentActionHandlers';
+
+/**
+ * 未传 labels 时的兜底文案：复用 generativeUi 命名空间既有 key，
+ * defaultValue 保留原中文，覆盖延迟命名空间尚未加载完成的窗口期。
+ */
+function fallbackLabel(key: string, defaultValue: string): string {
+  return String(i18n.t(`generativeUi:${key}`, { defaultValue }));
+}
 
 export const NOTE_EDIT_ACTION_IDS = ['apply-note-edit', 'dismiss-note-suggestion'] as const;
 export const FLASHCARD_ACTION_IDS = ['save-to-library'] as const;
@@ -101,8 +110,8 @@ export function resolveGenerativeUIChatActionHandlers(
         createNotesEditActionHandlers(
           { noteId: input.canvasNoteId, ...noteEdit },
           input.noteEditLabels ?? {
-            applyEdit: '应用到笔记',
-            dismissSuggestion: '忽略建议',
+            applyEdit: fallbackLabel('notes.edit_apply', '应用到笔记'),
+            dismissSuggestion: fallbackLabel('notes.edit_dismiss', '忽略建议'),
           },
         ),
       );
@@ -116,7 +125,9 @@ export function resolveGenerativeUIChatActionHandlers(
       createFlashcardSaveActionHandlers(
         input.intent,
         input.flashcardContext ?? {},
-        input.flashcardLabels ?? { saveToLibrary: '保存到闪卡库' },
+        input.flashcardLabels ?? {
+          saveToLibrary: fallbackLabel('flashcard.save_to_library', '保存到闪卡库'),
+        },
       ),
     );
   }
@@ -139,9 +150,9 @@ export function resolveGenerativeUIChatActionHandlers(
           getIntent: () => input.intent,
         },
         input.researchLabels ?? {
-          copyReport: '复制报告',
-          exportPlan: '导出计划',
-          exportIntent: '导出全部意图',
+          copyReport: fallbackLabel('research.actions.copy_report', '复制报告'),
+          exportPlan: fallbackLabel('research.actions.export_plan', '导出计划'),
+          exportIntent: fallbackLabel('research.actions.export_intent', '导出全部意图'),
         },
         input.intentExportLabels,
       ),
@@ -154,7 +165,9 @@ export function resolveGenerativeUIChatActionHandlers(
       handlers,
       createCopyIntentActionHandlers(
         input.intent,
-        input.copyIntentLabels ?? { copyIntent: '复制意图' },
+        input.copyIntentLabels ?? {
+          copyIntent: fallbackLabel('action.copy_intent', '复制意图'),
+        },
       ),
     );
   }
@@ -165,7 +178,9 @@ export function resolveGenerativeUIChatActionHandlers(
       handlers,
       createCopyBlockActionHandlers(
         input.intent,
-        input.copyBlockLabels ?? { copyBlock: '复制该组件' },
+        input.copyBlockLabels ?? {
+          copyBlock: fallbackLabel('action.copy_block', '复制该组件'),
+        },
       ),
     );
   }
@@ -179,7 +194,9 @@ export function resolveGenerativeUIChatActionHandlers(
       createExportIntentActionHandlers(
         input.intent,
         {
-          exportMarkdown: input.researchLabels?.exportIntent ?? '导出全部意图',
+          exportMarkdown:
+            input.researchLabels?.exportIntent ??
+            fallbackLabel('research.actions.export_intent', '导出全部意图'),
         },
         input.intentExportLabels,
       ),

--- a/src/features/generative-ui/utils/dispatchCanvasAIEditRequest.ts
+++ b/src/features/generative-ui/utils/dispatchCanvasAIEditRequest.ts
@@ -5,8 +5,14 @@
  * @see docs/generative-ui/NOTES_INTEGRATION.md
  */
 
+import i18n from '@/i18n';
 import type { CanvasEditOperation } from '@/features/notes/hooks/useAIEditState';
 import { noteEditPayloadSchema } from './extractNoteEditPayload';
+
+/** 派发护栏文案走 generativeUi:notes.*；defaultValue 兜底延迟命名空间加载窗口。 */
+function dispatchReason(key: string, defaultValue: string): string {
+  return String(i18n.t(`generativeUi:notes.${key}`, { defaultValue }));
+}
 
 export interface CanvasAIEditDispatchPayload {
   requestId: string;
@@ -42,19 +48,25 @@ export function dispatchCanvasAIEditRequest(
   options?: { onSettled?: () => void },
 ): CanvasAIEditDispatchResult {
   if (typeof window === 'undefined') {
-    return { claimed: false, reason: '当前环境没有可用的建议面板' };
+    return {
+      claimed: false,
+      reason: dispatchReason('edit_dispatch_no_panel', '当前环境没有可用的建议面板'),
+    };
   }
 
   // Defense in depth for direct handler callers that bypass extractNoteEditPayload.
   // In particular, never forward model-controlled regular expressions to the editor.
   const validation = noteEditPayloadSchema.safeParse(payload);
   if (!validation.success) {
-    return { claimed: false, reason: '笔记编辑建议无效或内容过大' };
+    return {
+      claimed: false,
+      reason: dispatchReason('edit_dispatch_invalid', '笔记编辑建议无效或内容过大'),
+    };
   }
 
   let result: CanvasAIEditDispatchResult = {
     claimed: false,
-    reason: '没有匹配的笔记编辑器认领建议',
+    reason: dispatchReason('edit_dispatch_unclaimed', '没有匹配的笔记编辑器认领建议'),
   };
 
   window.dispatchEvent(

--- a/src/features/notes/hooks/useAIEditState.ts
+++ b/src/features/notes/hooks/useAIEditState.ts
@@ -1,5 +1,18 @@
 import { useState, useCallback, useRef } from 'react';
 import * as Diff from 'diff';
+import i18n from '@/i18n';
+
+/**
+ * 护栏文案统一走 notes:aiDiff.errors.*；defaultValue 保留原中文，
+ * 覆盖延迟命名空间尚未加载完成的窗口期（i18n.ts 按 import.meta.glob 异步注入）。
+ */
+function guardText(
+  key: string,
+  defaultValue: string,
+  vars?: Record<string, string | number>
+): string {
+  return String(i18n.t(`notes:aiDiff.errors.${key}`, { defaultValue, ...vars }));
+}
 
 export type CanvasEditOperation = 'append' | 'replace' | 'set';
 
@@ -77,7 +90,11 @@ function projectedOutputTooLarge(byteLength: number): boolean {
 }
 
 function outputTooLargeError(): string {
-  return `建议后的笔记超过 ${MAX_AI_EDIT_PROJECTED_OUTPUT_BYTES} 字节上限`;
+  return guardText(
+    'output_too_large',
+    `建议后的笔记超过 ${MAX_AI_EDIT_PROJECTED_OUTPUT_BYTES} 字节上限`,
+    { maxBytes: MAX_AI_EDIT_PROJECTED_OUTPUT_BYTES }
+  );
 }
 
 /**
@@ -93,7 +110,7 @@ export function computeProposedContent(
     case 'append': {
       const contentToAppend = request.content || '';
       if (!contentToAppend) {
-        return { content: originalContent, error: '追加内容为空' };
+        return { content: originalContent, error: guardText('append_empty', '追加内容为空') };
       }
 
       // Use a conservative newline allowance so no oversized string is constructed first.
@@ -127,7 +144,7 @@ export function computeProposedContent(
       const replaceWith = request.replace || '';
       
       if (!searchPattern) {
-        return { content: originalContent, error: '搜索模式为空' };
+        return { content: originalContent, error: guardText('search_empty', '搜索模式为空') };
       }
       
       let newContent: string;
@@ -141,9 +158,13 @@ export function computeProposedContent(
             return replaceWith;
           });
         } catch (regexErr) {
+          const message =
+            regexErr instanceof Error
+              ? regexErr.message
+              : guardText('regex_syntax_error', '语法错误');
           return {
             content: originalContent,
-            error: `无效的正则表达式: ${regexErr instanceof Error ? regexErr.message : '语法错误'}`,
+            error: guardText('invalid_regex', `无效的正则表达式: ${message}`, { message }),
           };
         }
       } else {
@@ -167,14 +188,22 @@ export function computeProposedContent(
       }
 
       if (replaceCount === 0) {
-        return { content: originalContent, error: '未找到要替换的内容' };
+        return {
+          content: originalContent,
+          error: guardText('replace_not_found', '未找到要替换的内容'),
+        };
       }
       
       return { content: newContent, replaceCount };
     }
     
     default:
-      return { content: originalContent, error: `未知的操作类型: ${request.operation}` };
+      return {
+        content: originalContent,
+        error: guardText('unknown_operation', `未知的操作类型: ${request.operation}`, {
+          operation: request.operation,
+        }),
+      };
   }
 }
 
@@ -190,7 +219,13 @@ function appendToSection(
   const match = content.match(sectionRegex);
 
   if (!match || match.index === undefined) {
-    return { success: false, content, error: `未找到章节: ${sectionTitle}` };
+    return {
+      success: false,
+      content,
+      error: guardText('section_not_found', `未找到章节: ${sectionTitle}`, {
+        section: sectionTitle,
+      }),
+    };
   }
 
   const sectionLevel = match[1].length;
@@ -362,7 +397,7 @@ export function useAIEditState(): UseAIEditStateReturn {
     const result: CanvasAIEditResult = {
       requestId: current.request.requestId,
       success: false,
-      error: '用户拒绝修改',
+      error: guardText('user_rejected', '用户拒绝修改'),
     };
     
     setState(initialState);

--- a/src/locales/en-US/generativeUi.json
+++ b/src/locales/en-US/generativeUi.json
@@ -147,7 +147,10 @@
     "edit_preview_title": "Change preview",
     "edit_apply": "Apply to note",
     "edit_dismiss": "Dismiss",
-    "edit_suggestion_markdown_title": "Suggestion notes"
+    "edit_suggestion_markdown_title": "Suggestion notes",
+    "edit_dispatch_no_panel": "No suggestion panel is available in this environment",
+    "edit_dispatch_invalid": "The note edit suggestion is invalid or its content is too large",
+    "edit_dispatch_unclaimed": "No matching note editor claimed the suggestion"
   },
   "exam": {
     "briefing_label": "AI question bank briefing",

--- a/src/locales/en-US/notes.json
+++ b/src/locales/en-US/notes.json
@@ -75,6 +75,17 @@
     "accept": "Accept",
     "reject": "Reject",
     "no_changes": "No changes detected",
+    "errors": {
+      "output_too_large": "The suggested note exceeds the {{maxBytes}}-byte limit",
+      "append_empty": "Append content is empty",
+      "search_empty": "Search pattern is empty",
+      "invalid_regex": "Invalid regular expression: {{message}}",
+      "regex_syntax_error": "syntax error",
+      "replace_not_found": "No matching content found to replace",
+      "unknown_operation": "Unknown operation type: {{operation}}",
+      "section_not_found": "Section not found: {{section}}",
+      "user_rejected": "Edit rejected by user"
+    },
     "summary": {
       "meta_title": "Change summary",
       "meta_description": "Deterministic preview from diff stats",

--- a/src/locales/zh-CN/generativeUi.json
+++ b/src/locales/zh-CN/generativeUi.json
@@ -147,7 +147,10 @@
     "edit_preview_title": "变更预览",
     "edit_apply": "应用到笔记",
     "edit_dismiss": "忽略建议",
-    "edit_suggestion_markdown_title": "建议说明"
+    "edit_suggestion_markdown_title": "建议说明",
+    "edit_dispatch_no_panel": "当前环境没有可用的建议面板",
+    "edit_dispatch_invalid": "笔记编辑建议无效或内容过大",
+    "edit_dispatch_unclaimed": "没有匹配的笔记编辑器认领建议"
   },
   "exam": {
     "briefing_label": "AI 题库简报",

--- a/src/locales/zh-CN/notes.json
+++ b/src/locales/zh-CN/notes.json
@@ -75,6 +75,17 @@
     "accept": "接受",
     "reject": "拒绝",
     "no_changes": "未检测到变更",
+    "errors": {
+      "output_too_large": "建议后的笔记超过 {{maxBytes}} 字节上限",
+      "append_empty": "追加内容为空",
+      "search_empty": "搜索模式为空",
+      "invalid_regex": "无效的正则表达式: {{message}}",
+      "regex_syntax_error": "语法错误",
+      "replace_not_found": "未找到要替换的内容",
+      "unknown_operation": "未知的操作类型: {{operation}}",
+      "section_not_found": "未找到章节: {{section}}",
+      "user_rejected": "用户拒绝修改"
+    },
     "summary": {
       "meta_title": "变更摘要",
       "meta_description": "基于 diff 统计的确定性预览",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

主题仓 C。#214 已作为 Step 1 合入 0824。本仓在 #214 之上补了 useAIEditState 等 i18n 护栏，并修了 `generative_ui_executor.rs` E0716。若 0824 已含 Rust 修复，归并时只需移植 i18n 提交。

### Changes
- #214 底座稳定化
- 硬编码中文护栏改走现有 i18n
- executor 借用修复

### How to test
- `npm run typecheck` / `npx vite build` / `cargo check --manifest-path src-tauri/Cargo.toml --lib`

### Checklist
- [x] 主题仓编译已通过
- [ ] i18n 增量已归并进 0824
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-656cd9fd-4f6a-43d1-9677-f29d512ecde6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-656cd9fd-4f6a-43d1-9677-f29d512ecde6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

