### PR TITLE
0824 leftovers：移植 #160 缺失回归测试

### DIFF
--- a/docs/dev/0824-leftover-160.md
+++ b/docs/dev/0824-leftover-160.md
@@ -52,3 +52,34 @@ The VM default Cargo 1.83.0 cannot parse edition-2024 dependencies, so the
 successful Rust gate used the repository/CI-compatible stable 1.98.0
 toolchain. The PDFium downloader's tracked license-file rewrite was reverted;
 no verification artifact remains in the Git diff.
+
+## Absorption record (2026-08-25)
+
+Official `cursor/0824-cde6` @ `188500e0` ("docs: record latest step 13 cloud
+increment") already contains every INCLUDE item from this isolation branch.
+The absorbing commits — both ancestors of `188500e0` — are:
+
+- `f38d0041` "test(0824): port #160 load-error and today-progress regression
+  tests"
+- `41587d48` "feat(flashcards): move scheduler settings below statistics +
+  brand token aliases (from #303 / #160 leftovers)"
+
+Per-file status against official `188500e0`:
+
+| Item | Absorbed | Evidence |
+|---|---|---|
+| `src/features/anki-tasks/__tests__/AnkiTasksApp.loadError.test.tsx` | Yes (`f38d0041`) | Present in official; identical assertions and coverage. Only cosmetic variance vs this branch (zh-CN vs English comments, line wrapping, test-name phrasing). Official's version supersedes. |
+| `tests/vitest/flashcards/todayScreenEmptyLibrary.test.tsx` | Yes (`f38d0041`) | Present in official; identical assertions and coverage. Same cosmetic-only variance as above. |
+| `StatisticsScreen` scheduler-below-stats | Yes (`41587d48`) | `src/features/flashcards/screens/StatisticsScreen.tsx` and the ordering assertion in `tests/vitest/flashcards/StatisticsScreen.test.tsx` ("places scheduler settings after the statistics panels") are byte-identical between official and this branch. |
+| `brandColorTokenContract` / `theme-colors` brand aliases | Yes (`41587d48`) | `tests/vitest/brandColorTokenContract.test.ts` and the `--brand-secondary` / `--brand-accent` light+dark definitions in `src/styles/theme-colors.css` are byte-identical between official and this branch. |
+
+Remaining unique content on this isolation branch vs official `0824`:
+
+- The only file `0824` lacks is this document, `docs/dev/0824-leftover-160.md`
+  — docs only. The two ported test files carry cosmetic comment/format
+  differences that official's absorbed versions supersede; there is no
+  product (`src/`, `src-tauri/`) diff that this branch would add.
+
+Recommendation for the parent: close PR #303 as absorbed, or leave it open
+purely as an absorbed-record — merging it would add no product or test
+coverage beyond what `188500e0` already carries.

--- a/docs/dev/0824-leftover-160.md
+++ b/docs/dev/0824-leftover-160.md
@@ -1,0 +1,43 @@
+# 0824 #160 leftover port
+
+Date: 2026-08-25
+
+- Isolation branch: `cursor/0824-leftover-160-cde6`
+- Base: `origin/cursor/0824-rehearse-cloud-latest-cde6` @
+  `2630dc95f5ea1bb1422ddedc7cc8eb8adcacd85b`
+- Source inspected without merging: `refs/pull/160/head` @
+  `7c1a50945`
+- Disposition: **INCLUDE 4 / ALREADY 10 / DROP 0**
+
+## Per-commit disposition
+
+| Source SHA | Disposition | File-level evidence |
+|---|---|---|
+| `7c1a50945` | INCLUDE | Added `src/features/anki-tasks/__tests__/AnkiTasksApp.loadError.test.tsx`. It covers the existing `AnkiTasksApp.tsx` first-load alert/retry path and stale-data banner/retry path with real `zh-CN/anki.json` copy. |
+| `89191388b` | INCLUDE | Added `tests/vitest/flashcards/todayScreenEmptyLibrary.test.tsx`. The existing `TodayScreen.emptyLibrary.test.tsx` covered only the empty-library branch; the port also locks non-empty/all-done and non-empty/nothing-due behavior against the current store API and current `today.goLibrary` CTA. |
+| `eff6d54c2` | ALREADY | `src/components/practice/PracticeModeSelector.tsx` is absent; `src/components/practice/index.ts` and `PracticeLauncher.tsx` do not export/import it. The deleted component stays deleted. |
+| `cf4f69ad5` | ALREADY | `src/stores/questionBankStore.ts` contains `practiceSession`, `ensurePracticeSession`, and `recordPracticeSessionAnswer`; `src/components/QuestionBankEditor.tsx` reads the store-backed streak/correct counts and records answered IDs. |
+| `abb415e52` | INCLUDE | Moved `SchedulerSettingsSection` below the successful statistics panels in `src/features/flashcards/screens/StatisticsScreen.tsx`; the independent error branch still exposes settings. Added the ordering assertion to `tests/vitest/flashcards/StatisticsScreen.test.tsx`. |
+| `7f9e7c0f3` | ALREADY | `src/features/pomodoro/components/GlobalPomodoroWidget.tsx` derives `hasVisibleWindowHost` from `useWindowStore` for non-minimized `pomodoro`/`todo` hosts and suppresses the pill; current mini-window/workbench arbitration remains intact. |
+| `77e8a0fde` | ALREADY | `ReviewQuestionsView.tsx`, `EssayGradingWorkbench.tsx`, `GradingMain.tsx`, and `ResultPanel.tsx` expose missed-question/grading-result card generation; paired `review.json`/`essay_grading.json` locales exist. `src/features/anki/generateCardsFromText.ts` uses the required nonblocking `cardAgent.startGeneration` path and has no production `ChatV2AnkiAdapter`. |
+| `514c9f142` | ALREADY | `LibraryScreen.tsx` exposes manual creation and `.apkg` import, while `store/libraryStore.ts` implements `createCard` and `importApkg` through `import_apkg_to_library`; the current library CSS and touch-target adaptations remain untouched. |
+| `dc1d6cf09` | ALREADY | `src/features/anki-tasks/AnkiTasksApp.tsx` has `loadError`, `anki-tasks-load-error`, and `anki-tasks-stale-banner`; both `src/locales/{en-US,zh-CN}/anki.json` files contain `loadFailed`, `refreshFailedStale`, and `retry`. |
+| `0a355d30d` | ALREADY | `TodayScreen.tsx` computes zero progress when the target is zero and separates `libraryEmpty`, `showDoneState`, and idle states. `flashcards-dashboard.css` retains the 44px coarse-pointer empty-state CTA rules, and both flashcard locale files contain the empty-library copy. |
+| `8f08b3c9c` | ALREADY | `src/components/ui/buttonPrimitiveContract.ts` uses `text-ui` in button/shell bases and default/md sizes while retaining tokenized 44px touch geometry. |
+| `bc392d54a` | ALREADY | `src/components/ErrorBoundary.tsx` calls `this.resetError` with `error_boundary.retry`; both common locale files define retry copy, and `tests/vitest/errorBoundaryCopy.test.tsx` contains the retry/remount contract. |
+| `6fa9382aa` | ALREADY | `src/features/learning-hub/icons/ResourceIcons.tsx` routes palette, paper, fold, and folder colors through `--resource-icon-*` tokens with fallbacks. |
+| `416f6fa44` | INCLUDE | The current tree already had failure-surface/resource-icon tokens and stronger variable-driven dark shadows (`failurePathSurfaceTokenContract.test.ts`, `darkShadowElevationContract.test.ts`), but `tailwind.config.js` still referenced undefined `--brand-secondary`/`--brand-accent`. Added light/dark definitions in `src/styles/theme-colors.css` and `tests/vitest/brandColorTokenContract.test.ts`. |
+
+## Guard-rail audit
+
+- No changes were made to the D flashcard write/read ownership paths.
+- `src/features/anki/generateCardsFromText.ts` still calls
+  `cardAgent.startGeneration`; no production `ChatV2AnkiAdapter` was added.
+- No G safe-area or 44px rules were replaced. The scheduler change only moves
+  an existing section, and the Today production/CSS files were not edited.
+- `PracticeModeSelector` remains deleted.
+- `cursor/0824-cde6` was not checked out or pushed.
+
+## Verification
+
+Verification results are recorded after the implementation commit is pushed.

--- a/docs/dev/0824-leftover-160.md
+++ b/docs/dev/0824-leftover-160.md
@@ -40,4 +40,15 @@ Date: 2026-08-25
 
 ## Verification
 
-Verification results are recorded after the implementation commit is pushed.
+| Gate | Result |
+|---|---|
+| `npm ci` | PASS — 1,192 lockfile packages installed. |
+| `npx vitest run src/features/anki-tasks/__tests__/AnkiTasksApp.loadError.test.tsx tests/vitest/flashcards/todayScreenEmptyLibrary.test.tsx tests/vitest/flashcards/StatisticsScreen.test.tsx tests/vitest/brandColorTokenContract.test.ts` | PASS — 4 files, 11 tests. |
+| `npm run version:generate && npm run typecheck` | PASS — zero TypeScript errors. (`typecheck` alone initially reported the expected missing generated `src/version.ts`.) |
+| `npx vite build` | PASS — 19,809 modules transformed; only existing circular/dynamic-import and chunk-size warnings. |
+| `rustup run stable cargo check --manifest-path src-tauri/Cargo.toml --lib` | PASS with Rust/Cargo 1.98.0 after installing the CI Linux libraries and PDFium resource; 28 existing warnings. |
+
+The VM default Cargo 1.83.0 cannot parse edition-2024 dependencies, so the
+successful Rust gate used the repository/CI-compatible stable 1.98.0
+toolchain. The PDFium downloader's tracked license-file rewrite was reverted;
+no verification artifact remains in the Git diff.

--- a/src/features/anki-tasks/__tests__/AnkiTasksApp.loadError.test.tsx
+++ b/src/features/anki-tasks/__tests__/AnkiTasksApp.loadError.test.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import zhAnki from '@/locales/zh-CN/anki.json';
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
+vi.mock('@/hooks/useViewVisibility', () => ({ useViewVisibility: () => ({ isActive: false }) }));
+vi.mock('@/components/UnifiedNotification', () => ({ showGlobalNotification: vi.fn() }));
+vi.mock('@/components/custom-scroll-area', () => ({
+  CustomScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/layout', () => ({
+  useMobileHeader: vi.fn(),
+  MobileSlidingLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/shared/CommonTooltip', () => ({
+  CommonTooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/ui/SegmentedControl', () => ({
+  SegmentedControl: () => <div data-testid="segmented-control" />,
+}));
+vi.mock('@/features/chat/anki', () => ({
+  exportCardsAsApkg: vi.fn(async () => ({ success: true })),
+}));
+vi.mock('@/debug-panel/debugMasterSwitch', () => ({
+  debugLog: { error: vi.fn() },
+}));
+
+// Use real zh-CN copy so a missing locale key degrades to the key and fails.
+vi.mock('react-i18next', () => {
+  const lookup = (key: string): string | undefined => {
+    let cursor: unknown = zhAnki;
+    for (const part of key.split('.')) {
+      if (cursor == null || typeof cursor !== 'object') return undefined;
+      cursor = (cursor as Record<string, unknown>)[part];
+    }
+    return typeof cursor === 'string' ? cursor : undefined;
+  };
+  return {
+    useTranslation: () => ({
+      t: (key: string, options?: Record<string, unknown>) => {
+        const template = lookup(key);
+        if (template == null) return key;
+        if (!options) return template;
+        return template.replace(
+          /\{\{\s*([^}\s]+)\s*\}\}/g,
+          (placeholder, name: string) => (
+            options[name] == null ? placeholder : String(options[name])
+          ),
+        );
+      },
+      i18n: { language: 'zh-CN' },
+    }),
+    initReactI18next: { type: '3rdParty', init: () => undefined },
+  };
+});
+
+import { AnkiTasksApp } from '../AnkiTasksApp';
+
+interface TestSession {
+  documentId: string;
+  documentName: string;
+  sourceSessionId: string | null;
+  totalTasks: number;
+  completedTasks: number;
+  failedTasks: number;
+  activeTasks: number;
+  pausedTasks: number;
+  lastUpdated: string;
+  createdAt: string;
+  totalCards: number;
+}
+
+function makeSession(name: string): TestSession {
+  return {
+    documentId: `doc-${name}`,
+    documentName: name,
+    sourceSessionId: null,
+    totalTasks: 1,
+    completedTasks: 1,
+    failedTasks: 0,
+    activeTasks: 0,
+    pausedTasks: 0,
+    lastUpdated: '2026-08-20T08:00:00.000Z',
+    createdAt: '2026-08-20T08:00:00.000Z',
+    // Keep the session name unique in the DOM by omitting it from the ranking.
+    totalCards: 0,
+  };
+}
+
+const emptyStats = {
+  totalCards: 0,
+  totalDocuments: 0,
+  errorCards: 0,
+  templateCount: 0,
+};
+const dashboard = zhAnki.taskDashboard;
+
+describe('AnkiTasksApp load failures', () => {
+  /** Each load consumes one response; Error rejects list_document_sessions. */
+  let sessionResponses: Array<TestSession[] | Error>;
+
+  beforeEach(() => {
+    sessionResponses = [];
+    invokeMock.mockReset();
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'list_document_sessions') {
+        const next = sessionResponses.shift();
+        if (next === undefined) {
+          return Promise.reject(new Error('Unexpected list_document_sessions call'));
+        }
+        return next instanceof Error ? Promise.reject(next) : Promise.resolve(next);
+      }
+      if (command === 'get_anki_stats') return Promise.resolve(emptyStats);
+      return Promise.resolve(false);
+    });
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(() => true),
+      })),
+    });
+  });
+
+  it('reports a first-load failure as an error with retry, not as no tasks', async () => {
+    sessionResponses.push(new Error('list_document_sessions is offline'));
+
+    render(<AnkiTasksApp isVisible />);
+
+    const errorPanel = await screen.findByTestId('anki-tasks-load-error');
+    expect(errorPanel).toHaveAttribute('role', 'alert');
+    expect(errorPanel).toHaveTextContent(dashboard.loadFailed);
+    expect(errorPanel).toHaveTextContent('list_document_sessions is offline');
+    expect(screen.queryByText(dashboard.empty)).not.toBeInTheDocument();
+    expect(screen.queryByText(dashboard.emptyHint)).not.toBeInTheDocument();
+
+    sessionResponses.push([makeSession('recovered doc')]);
+    fireEvent.click(screen.getByRole('button', { name: dashboard.retry }));
+
+    expect(await screen.findByText('recovered doc')).toBeInTheDocument();
+    expect(screen.queryByTestId('anki-tasks-load-error')).not.toBeInTheDocument();
+  });
+
+  it('keeps the last known sessions behind a stale banner when refresh fails', async () => {
+    sessionResponses.push([makeSession('already loaded doc')]);
+
+    render(<AnkiTasksApp isVisible />);
+    expect(await screen.findByText('already loaded doc')).toBeInTheDocument();
+    expect(screen.queryByTestId('anki-tasks-stale-banner')).not.toBeInTheDocument();
+
+    sessionResponses.push(new Error('refresh is offline'));
+    fireEvent.click(screen.getByRole('button', { name: dashboard.refresh }));
+
+    const banner = await screen.findByTestId('anki-tasks-stale-banner');
+    expect(banner).toHaveAttribute('role', 'status');
+    expect(banner).toHaveTextContent(dashboard.refreshFailedStale);
+    expect(screen.getByText('already loaded doc')).toBeInTheDocument();
+    expect(screen.queryByTestId('anki-tasks-load-error')).not.toBeInTheDocument();
+
+    sessionResponses.push([makeSession('fresh doc')]);
+    fireEvent.click(within(banner).getByRole('button', { name: dashboard.retry }));
+
+    expect(await screen.findByText('fresh doc')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByTestId('anki-tasks-stale-banner')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/flashcards/screens/StatisticsScreen.tsx
+++ b/src/features/flashcards/screens/StatisticsScreen.tsx
@@ -313,7 +313,6 @@ export const StatisticsScreen: React.FC = () => {
           className="min-h-0 flex-1"
         >
           <div className="wb-fcx-scroll">
-          <SchedulerSettingsSection />
           <section className="wb-fcx-panel" data-testid="fsrs-statistics">
             <div className="wb-fcx-panel-head">
               <h3 className="wb-fcx-panel-title">
@@ -484,6 +483,10 @@ export const StatisticsScreen: React.FC = () => {
               </div>
             </section>
           </div>
+
+          {/* Statistics are the primary content; keep scheduler controls as the
+              secondary action after the data panels. */}
+          <SchedulerSettingsSection />
           </div>
         </CustomScrollArea>
       ) : null}

--- a/src/styles/theme-colors.css
+++ b/src/styles/theme-colors.css
@@ -264,6 +264,10 @@
   --text-muted: hsl(var(--muted-foreground));
   --text-inverse: hsl(var(--primary-foreground));
 
+  /* Tailwind's brand.secondary / brand.accent mappings consume complete colors
+     directly, so both aliases must be defined rather than bare HSL channels. */
+  --brand-secondary: hsl(var(--info));
+  --brand-accent: color-mix(in oklab, hsl(var(--primary)) 50%, hsl(var(--info)) 50%);
   /* Brand palette + gradients */
   --brand-gradient: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--info)) 100%);
   --brand-gradient-hover: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--info)) 80%, hsl(var(--primary)) 100%);
@@ -440,6 +444,10 @@
   --settings-nav-accent-green: hsl(157 55% 58%);
   --settings-nav-accent-sky: hsl(208 70% 70%);
   --settings-nav-accent-pink: hsl(327 52% 74%);
+
+  /* Keep brand utility colors legible on the dark shell. */
+  --brand-secondary: color-mix(in oklab, hsl(var(--info)) 80%, hsl(var(--foreground)) 20%);
+  --brand-accent: color-mix(in oklab, var(--brand-secondary) 50%, hsl(var(--primary)) 50%);
 
   /* 资源图标：底更沉、边更实、前景往 --foreground 提亮，
      -bg / -fg / -border 的 color-mix 公式在亮色档已写好，这里只翻比例。

--- a/tests/vitest/brandColorTokenContract.test.ts
+++ b/tests/vitest/brandColorTokenContract.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const themeSource = readFileSync(
+  resolve(process.cwd(), 'src/styles/theme-colors.css'),
+  'utf-8',
+);
+const tailwindSource = readFileSync(
+  resolve(process.cwd(), 'tailwind.config.js'),
+  'utf-8',
+);
+
+function blockOf(selector: string): string {
+  const start = themeSource.indexOf(`${selector} {`);
+  expect(start, `${selector} should exist in theme-colors.css`).toBeGreaterThan(-1);
+  return themeSource.slice(start, themeSource.indexOf('\n}', start));
+}
+
+function declarationOf(block: string, token: string): string | undefined {
+  return block.match(new RegExp(`${token}:\\s*([^;]+);`))?.[1]?.trim();
+}
+
+describe('brand color token contract', () => {
+  const lightRoot = blockOf(':where(:root)');
+  const darkRoot = blockOf(':root.dark');
+
+  it('defines complete colors for every Tailwind brand mapping', () => {
+    expect(tailwindSource).toContain("secondary: 'var(--brand-secondary)'");
+    expect(tailwindSource).toContain("accent: 'var(--brand-accent)'");
+
+    for (const token of ['--brand-secondary', '--brand-accent']) {
+      expect(declarationOf(lightRoot, token)).toMatch(/hsl\(|color-mix\(/);
+      expect(declarationOf(darkRoot, token)).toMatch(/hsl\(|color-mix\(/);
+    }
+  });
+});

--- a/tests/vitest/flashcards/StatisticsScreen.test.tsx
+++ b/tests/vitest/flashcards/StatisticsScreen.test.tsx
@@ -78,6 +78,18 @@ describe('StatisticsScreen', () => {
     expect(mocks.getStats).toHaveBeenCalledTimes(2);
   });
 
+  it('places scheduler settings after the statistics panels', async () => {
+    mocks.getStats.mockResolvedValueOnce(firstStats);
+
+    render(<StatisticsScreen />);
+    const statistics = await screen.findByTestId('fsrs-statistics');
+    const settings = screen.getByTestId('fsrs-scheduler-settings');
+
+    expect(
+      statistics.compareDocumentPosition(settings) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it('shows backend errors and retries successfully', async () => {
     mocks.getStats
       .mockRejectedValueOnce(new Error('stats backend is offline'))

--- a/tests/vitest/flashcards/todayScreenEmptyLibrary.test.tsx
+++ b/tests/vitest/flashcards/todayScreenEmptyLibrary.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import zhFlashcards from '@/locales/zh-CN/flashcards.json';
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
+
+// Use real zh-CN copy so a missing locale key degrades to the key and fails.
+vi.mock('react-i18next', () => {
+  const lookup = (key: string): string | undefined => {
+    let cursor: unknown = zhFlashcards;
+    for (const part of key.split('.')) {
+      if (cursor == null || typeof cursor !== 'object') return undefined;
+      cursor = (cursor as Record<string, unknown>)[part];
+    }
+    return typeof cursor === 'string' ? cursor : undefined;
+  };
+  return {
+    useTranslation: () => ({
+      t: (key: string, options?: Record<string, unknown>) => {
+        const template = lookup(key);
+        if (template == null) return key;
+        if (!options) return template;
+        return template.replace(
+          /\{\{\s*([^}\s]+)\s*\}\}/g,
+          (placeholder, name: string) => (
+            options[name] == null ? placeholder : String(options[name])
+          ),
+        );
+      },
+      i18n: { language: 'zh-CN' },
+    }),
+    initReactI18next: { type: '3rdParty', init: () => undefined },
+  };
+});
+
+import { TodayScreen } from '@/features/flashcards/screens/TodayScreen';
+import { useFsrsReviewStore } from '@/features/flashcards/store/fsrsReviewStore';
+
+interface StatsOverrides {
+  total?: number;
+  due?: number;
+  newCount?: number;
+  reviewsToday?: number;
+}
+
+function stats(overrides: StatsOverrides = {}) {
+  return {
+    total: 0,
+    due: 0,
+    newCount: 0,
+    learning: 0,
+    review: 0,
+    relearning: 0,
+    suspended: 0,
+    reviewsToday: 0,
+    ...overrides,
+  };
+}
+
+const setScreen = vi.fn();
+const loadDue = vi.fn(async () => true);
+
+/** Return the aggregate and valid empty review-activity data from the backend. */
+function mockBackend(statsPayload: ReturnType<typeof stats>) {
+  invokeMock.mockImplementation(async (command: string) => {
+    if (command === 'fsrs_get_stats') return statsPayload;
+    if (command === 'fsrs_get_review_statistics') {
+      return {
+        dailyReviews: [],
+        ratingDistribution: { again: 0, hard: 0, good: 0, easy: 0, total: 0 },
+      };
+    }
+    return null;
+  });
+}
+
+function renderToday() {
+  render(<TodayScreen />);
+  return waitFor(() => expect(invokeMock).toHaveBeenCalledWith('fsrs_get_stats'));
+}
+
+describe('TodayScreen progress and empty states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useFsrsReviewStore.setState({
+      screen: 'today',
+      dueCards: [],
+      dueTotal: 0,
+      loading: false,
+      error: null,
+      loadDue,
+      setScreen,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('keeps an empty card library off 100% and routes to library building', async () => {
+    mockBackend(stats({ total: 0, reviewsToday: 0 }));
+
+    await renderToday();
+
+    const ring = await screen.findByRole('img', {
+      name: '今日已复习 0 张，还剩 0 张到期',
+    });
+    expect(ring).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('0%')).toBeInTheDocument());
+    expect(screen.queryByText('100%')).not.toBeInTheDocument();
+
+    expect(screen.getByText(zhFlashcards.today.libraryEmpty)).toBeInTheDocument();
+    expect(screen.getByText(zhFlashcards.today.libraryEmptyHint)).toBeInTheDocument();
+    expect(screen.queryByText(zhFlashcards.today.allDone)).not.toBeInTheDocument();
+    expect(screen.queryByText(zhFlashcards.today.empty)).not.toBeInTheDocument();
+
+    const cta = screen.getByRole('button', { name: zhFlashcards.today.goLibrary });
+    fireEvent.click(cta);
+    expect(setScreen).toHaveBeenCalledWith('library');
+  });
+
+  it('still reports 100% and all-done once a non-empty library is fully reviewed', async () => {
+    mockBackend(stats({ total: 12, reviewsToday: 7 }));
+
+    await renderToday();
+
+    await waitFor(() => expect(screen.getByText('100%')).toBeInTheDocument());
+    expect(screen.getByText(zhFlashcards.today.allDone)).toBeInTheDocument();
+    expect(screen.queryByText(zhFlashcards.today.libraryEmpty)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: zhFlashcards.today.goLibrary }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the nothing-due idle state when cards exist', async () => {
+    mockBackend(stats({ total: 12, newCount: 5, reviewsToday: 0 }));
+
+    await renderToday();
+
+    await waitFor(() => {
+      expect(document.querySelector('.wb-fcx-count[data-tone="new"]')).toHaveTextContent('5');
+    });
+    expect(screen.getByText(zhFlashcards.today.empty)).toBeInTheDocument();
+    expect(screen.getByText('0%')).toBeInTheDocument();
+    expect(screen.queryByText(zhFlashcards.today.allDone)).not.toBeInTheDocument();
+    expect(screen.queryByText(zhFlashcards.today.libraryEmpty)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: zhFlashcards.today.goLibrary }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
隔离记录枝。官方 0824 已吸收全部 #160 INCLUDE（loadError、空卡库 Today、统计页调度下移、brand token）。本枝相对官方只多 `docs/dev/0824-leftover-160.md`，无产品 diff。

勿整支合并。可作吸收记录保留，或之后关闭。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-656cd9fd-4f6a-43d1-9677-f29d512ecde6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-656cd9fd-4f6a-43d1-9677-f29d512ecde6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

