### PR TITLE
0824 发版修复：finder/工作台/Composer 升级硬化

### DIFF
--- a/docs/dev/0824-rel-finder.md
+++ b/docs/dev/0824-rel-finder.md
@@ -1,0 +1,115 @@
+# 0824 release finder / Composer persistence audit
+
+Date: 2026-08-25
+
+## Scope and baseline
+
+- Upgrade source inspected: tag `v0.9.44`.
+- Integration baseline: `origin/cursor/0824-cde6` at `64b0e76d`.
+- Work branch: `cursor/0824-rel-finder-cde6`.
+- F surfaces inspected: Finder host buckets, workbench persisted settings/snapshot, and
+  split `Composer*` / InputBar session restoration.
+
+The v0.9.44 Finder payload is a Zustand envelope at `learning-hub-finder`:
+
+```json
+{
+  "state": {
+    "viewMode": "grid",
+    "sortBy": "updatedAt",
+    "sortOrder": "desc",
+    "quickAccessCollapsed": false
+  },
+  "version": 0
+}
+```
+
+`hostId` was not persisted in v0.9.44. This is expected: missing/undefined
+`hostId` resolves to the `default` bucket, whose key remains exactly
+`learning-hub-finder`. The Files workbench host intentionally shares that bucket.
+
+## Bugs found and fixes
+
+### 1. Finder rejected values could return during Zustand hydration
+
+`resolveInitialViewPreferences` caught storage access and JSON parse failures, but
+Zustand then read the same payload again and applied its default shallow merge.
+Structurally valid JSON with wrong field types could therefore overwrite the
+defensive initial state. It could also hydrate fields outside the preference
+allowlist if a stale payload contained them.
+
+Fix (`9176740b`):
+
+- whitelist each persisted enum/boolean;
+- use the same sanitizer for the eager legacy read and Zustand's `merge`;
+- keep the v0.9.44 singleton key and seed new host keys from its valid preferences;
+- never hydrate navigation, search, selection, or data-list state.
+
+### 2. Workbench setting JSON trusted nested field types
+
+Workbench startup and settings UI only checked that parsed JSON was an object.
+For example, an imported/corrupt image wallpaper with a non-string `value` could
+reach `WallpaperLayer` string operations, while invalid tile-margin fields could
+reach layout math.
+
+Fix (`9176740b`):
+
+- parse both local/backend JSON and live settings events through one boundary;
+- validate wallpaper `kind` and string `value`;
+- independently validate and clamp image blur/dim/vignette;
+- validate tile-margin booleans and clamp finite margins to 0–32;
+- preserve valid v0.9.44 values field-for-field.
+
+Workbench window snapshots already had version migration, record whitelisting,
+duplicate filtering, geometry validation, and read/parse exception handling; no
+additional snapshot migration was needed.
+
+### 3. Old InputBar state was only partially protected
+
+The existing restore path filtered retired v0.9.44 panel keys
+(`rag`/`search`/`learn`), but it still trusted `inputValue` to be a string.
+Malformed/imported session state could reach `.trim()`/`.slice()` in the split
+Composer and crash. Missing current panel keys also needed an explicit defaulting
+contract.
+
+Separately, Rust `PanelStates` still modeled the retired keys but omitted the
+current `skill` key. Serde silently discarded `skill` on save, so that Composer
+panel state was lost on round trip.
+
+Fix (`0a6344e1`):
+
+- normalize persisted composer state from `unknown`;
+- preserve valid v0.9.44 draft text and still-current panel booleans;
+- default missing current keys and drop retired/non-boolean keys;
+- reject non-string drafts before render;
+- add `skill` to the Rust schema while retaining old optional fields, so old rows
+  still deserialize and new rows round-trip the current panel.
+
+## IndexedDB result
+
+There is no application Finder, workbench, or Composer IndexedDB persistence in
+this tree. The only direct `indexedDB` use is the developer “clear cache” command,
+which enumerates and deletes databases. Chat InputBar state is stored in the
+Tauri SQLite session-state table (plus session-scoped text in `sessionStorage`);
+Finder/workbench browser fallbacks use `localStorage`. No IndexedDB migration was
+required.
+
+## Regression coverage and verification
+
+- Finder host/default-key mapping, exact v0.9.44 payload inheritance, corrupt
+  values, and the second Zustand hydration merge.
+- Workbench valid legacy JSON, malformed wallpaper shapes, optional image fields,
+  and partial/clamped tile margins.
+- Composer v0.9.44 draft/panel shape, missing keys, retired keys, malformed
+  drafts, and scalar/null payloads.
+- Rust old-shape deserialization and current `skill` round trip.
+
+Results:
+
+- Targeted Vitest: 3 files, 26 tests passed.
+- `npm run version:generate && npm run typecheck`: passed.
+- `cargo fmt -- --check` with stable Rust: passed.
+- Rust unit-test build reached the application build script but could not run in
+  this worktree because the bundled `src-tauri/resources/pdfium/libpdfium.so`
+  asset is absent. This is an environment/resource precondition, not a compile
+  diagnostic from the changed schema.

--- a/src-tauri/src/chat_v2/types.rs
+++ b/src-tauri/src/chat_v2/types.rs
@@ -3017,6 +3017,10 @@ pub struct PanelStates {
     /// 附件面板
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attachment: Option<bool>,
+
+    /// 技能选择面板
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skill: Option<bool>,
 }
 
 impl Default for PanelStates {
@@ -3029,6 +3033,7 @@ impl Default for PanelStates {
             model: Some(false),
             advanced: Some(false),
             attachment: Some(false),
+            skill: Some(false),
         }
     }
 }
@@ -3098,6 +3103,39 @@ impl CompactionRecord {
 mod tests {
     use super::*;
     use serde_json::{self, json};
+
+    #[test]
+    fn test_panel_states_accepts_v0944_shape_missing_skill() {
+        let panels: PanelStates = serde_json::from_value(json!({
+            "rag": true,
+            "mcp": false,
+            "search": true,
+            "learn": false,
+            "model": true,
+            "advanced": false,
+            "attachment": true
+        }))
+        .unwrap();
+
+        assert_eq!(panels.model, Some(true));
+        assert_eq!(panels.attachment, Some(true));
+        assert_eq!(panels.skill, None);
+    }
+
+    #[test]
+    fn test_panel_states_round_trips_current_skill_panel() {
+        let panels: PanelStates = serde_json::from_value(json!({
+            "mcp": false,
+            "model": false,
+            "advanced": false,
+            "attachment": false,
+            "skill": true
+        }))
+        .unwrap();
+
+        assert_eq!(panels.skill, Some(true));
+        assert_eq!(serde_json::to_value(panels).unwrap()["skill"], json!(true));
+    }
 
     #[test]
     fn test_send_options_preserves_runtime_reasoning_overrides() {

--- a/src/features/chat/core/store/__tests__/composerStateMigration.test.ts
+++ b/src/features/chat/core/store/__tests__/composerStateMigration.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeRestoredComposerState } from '../composerStateMigration';
+
+describe('normalizeRestoredComposerState', () => {
+  it('preserves v0.9.44 draft text and current panel values', () => {
+    expect(normalizeRestoredComposerState({
+      inputValue: 'unfinished question',
+      panelStates: {
+        rag: true,
+        search: true,
+        learn: true,
+        mcp: true,
+        model: false,
+        advanced: true,
+        attachment: false,
+      },
+    })).toEqual({
+      inputValue: 'unfinished question',
+      panelStates: {
+        mcp: true,
+        model: false,
+        advanced: true,
+        attachment: false,
+        skill: false,
+      },
+    });
+  });
+
+  it('fills fields missing from an old partial InputBar state', () => {
+    expect(normalizeRestoredComposerState({
+      inputValue: '',
+      panelStates: { attachment: true },
+    })).toEqual({
+      inputValue: '',
+      panelStates: {
+        mcp: false,
+        model: false,
+        advanced: false,
+        attachment: true,
+        skill: false,
+      },
+    });
+  });
+
+  it('rejects non-string drafts and non-boolean panel values', () => {
+    expect(normalizeRestoredComposerState({
+      inputValue: { text: 'would crash .trim()' },
+      panelStates: {
+        mcp: 'true',
+        model: 1,
+        advanced: null,
+        attachment: [],
+        skill: {},
+      },
+    })).toEqual({
+      inputValue: '',
+      panelStates: {
+        mcp: false,
+        model: false,
+        advanced: false,
+        attachment: false,
+        skill: false,
+      },
+    });
+  });
+
+  it('defaults null, array, and scalar payloads without throwing', () => {
+    for (const payload of [null, [], 'legacy', 44]) {
+      expect(normalizeRestoredComposerState(payload)).toEqual({
+        inputValue: '',
+        panelStates: {
+          mcp: false,
+          model: false,
+          advanced: false,
+          attachment: false,
+          skill: false,
+        },
+      });
+    }
+  });
+});

--- a/src/features/chat/core/store/composerStateMigration.ts
+++ b/src/features/chat/core/store/composerStateMigration.ts
@@ -1,0 +1,36 @@
+import {
+  COMPOSER_PANEL_KEYS,
+  createDefaultPanelStates,
+  type PanelStates,
+} from '../types/common';
+
+export interface RestoredComposerState {
+  inputValue: string;
+  panelStates: PanelStates;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Normalize the persisted InputBar state before split Composer components see
+ * it. v0.9.44 payloads may omit current keys and still contain retired
+ * rag/search/learn keys; malformed imports can also violate the TS-only shape.
+ */
+export function normalizeRestoredComposerState(state: unknown): RestoredComposerState {
+  const record = isRecord(state) ? state : {};
+  const persistedPanels = isRecord(record.panelStates) ? record.panelStates : {};
+  const panelStates = createDefaultPanelStates();
+
+  COMPOSER_PANEL_KEYS.forEach((panel) => {
+    if (typeof persistedPanels[panel] === 'boolean') {
+      panelStates[panel] = persistedPanels[panel];
+    }
+  });
+
+  return {
+    inputValue: typeof record.inputValue === 'string' ? record.inputValue : '',
+    panelStates,
+  };
+}

--- a/src/features/chat/core/store/restoreActions.ts
+++ b/src/features/chat/core/store/restoreActions.ts
@@ -6,8 +6,7 @@ import type {
   SessionRestoreBaseline,
 } from '../types';
 import type { ChatStoreState, SetState, GetState } from './types';
-import { createDefaultChatParams, createDefaultPanelStates } from './types';
-import { COMPOSER_PANEL_KEYS } from '../types/common';
+import { createDefaultChatParams } from './types';
 import { getErrorMessage } from '@/utils/errorUtils';
 import { showGlobalNotification } from '@/components/UnifiedNotification';
 import { sessionSwitchPerf } from '../../debug/sessionSwitchPerf';
@@ -24,6 +23,7 @@ import {
 import { revokeAttachmentBlobUrls } from './attachmentBlobUtils';
 import { resetTransientRuntimes } from './transientRuntimeRegistry';
 import { parsePendingContextRefsJson } from './pendingContextRefsParser';
+import { normalizeRestoredComposerState } from './composerStateMigration';
 import {
   browserToolsSkill,
   builtinToolSkills,
@@ -699,17 +699,11 @@ export function createRestoreActions(
             ...(state?.chatParams ?? {}),
           };
           const features = new Map(Object.entries(state?.features ?? {}));
-          // 只接收当前已知的面板 key，过滤旧持久化数据中已下线的幽灵面板
-          // （'rag'/'search'/'learn' 等），避免恢复出无渲染路径的 true 状态
-          const persistedPanelStates = (state?.panelStates ?? {}) as Record<string, unknown>;
-          const panelStates = createDefaultPanelStates();
-          COMPOSER_PANEL_KEYS.forEach((panel) => {
-            if (typeof persistedPanelStates[panel] === 'boolean') {
-              panelStates[panel] = persistedPanelStates[panel] as boolean;
-            }
-          });
+          // InputBar/Composer state is an external persistence boundary:
+          // preserve valid v0.9.44 fields, fill missing current keys, and drop
+          // retired or malformed values before render paths call string APIs.
+          const { inputValue, panelStates } = normalizeRestoredComposerState(state);
           const modeState = state?.modeState ?? null;
-          const inputValue = state?.inputValue ?? '';
 
           // 🆕 Prompt 7: 恢复待发送的上下文引用
           //

--- a/src/features/learning-hub/stores/finderStore.ts
+++ b/src/features/learning-hub/stores/finderStore.ts
@@ -441,6 +441,39 @@ export const DEFAULT_FINDER_VIEW_PREFERENCES: FinderViewPreferences = {
 
 type PersistStorageLike = Pick<Storage, 'getItem'>;
 
+const FINDER_VIEW_MODES = new Set<ViewMode>(['grid', 'list', 'columns']);
+const FINDER_SORT_FIELDS = new Set<SortBy>(['name', 'updatedAt', 'createdAt', 'type', 'size']);
+const FINDER_SORT_ORDERS = new Set<SortOrder>(['asc', 'desc']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Whitelist persisted Finder preferences at the storage boundary.
+ *
+ * Zustand's default merge trusts structurally valid JSON. A stale/corrupt value
+ * such as `{ viewMode: {} }` would therefore replace the typed initial state
+ * after our first read and later crash render/sort paths.
+ */
+export function sanitizeFinderViewPreferences(input: unknown): Partial<FinderViewPreferences> {
+  if (!isRecord(input)) return {};
+  const result: Partial<FinderViewPreferences> = {};
+  if (FINDER_VIEW_MODES.has(input.viewMode as ViewMode)) {
+    result.viewMode = input.viewMode as ViewMode;
+  }
+  if (FINDER_SORT_FIELDS.has(input.sortBy as SortBy)) {
+    result.sortBy = input.sortBy as SortBy;
+  }
+  if (FINDER_SORT_ORDERS.has(input.sortOrder as SortOrder)) {
+    result.sortOrder = input.sortOrder as SortOrder;
+  }
+  if (typeof input.quickAccessCollapsed === 'boolean') {
+    result.quickAccessCollapsed = input.quickAccessCollapsed;
+  }
+  return result;
+}
+
 function readPersistedPreferences(
   storage: PersistStorageLike,
   key: string,
@@ -453,8 +486,10 @@ function readPersistedPreferences(
   }
   if (!raw) return null;
   try {
-    const parsed = JSON.parse(raw) as { state?: Partial<FinderViewPreferences> };
-    return parsed?.state && typeof parsed.state === 'object' ? parsed.state : null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    const preferences = sanitizeFinderViewPreferences(parsed.state);
+    return Object.keys(preferences).length > 0 ? preferences : null;
   } catch {
     return null;
   }
@@ -1204,6 +1239,13 @@ export function createFinderStore(bucketId: string) {
         sortBy: state.sortBy,
         sortOrder: state.sortOrder,
         quickAccessCollapsed: state.quickAccessCollapsed,
+      }),
+      // The eager seed above and Zustand's hydration both read the same
+      // payload. Keep the second read behind the same whitelist; otherwise the
+      // default shallow merge can re-introduce values rejected by migration.
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        ...sanitizeFinderViewPreferences(persistedState),
       }),
     }
   )

--- a/src/features/settings/components/WorkbenchSettingsSection.tsx
+++ b/src/features/settings/components/WorkbenchSettingsSection.tsx
@@ -28,6 +28,11 @@ import { APP_EVENTS, dispatchAppEvent } from '@/events';
 import { workbenchBus } from '@/features/workbench/core/workbenchBus';
 import { setMaterialTier, type MaterialTierSetting } from '@/features/workbench/core/materialTier';
 import { listWorkbenchShortcuts } from '@/features/workbench/core/shortcuts';
+import {
+  parsePersistedTileMargins,
+  parsePersistedWallpaper,
+  type PersistedTileMargins,
+} from '@/features/workbench/core/persistedSettings';
 import { WALLPAPER_PRESETS, DEFAULT_WALLPAPER, type WallpaperConfig } from '@/features/workbench/components/WallpaperLayer';
 import {
   parseTitleBarDoubleClickAction,
@@ -96,10 +101,7 @@ export const PERFORMANCE_PROFILE_PRESETS: Record<
 
 export type WallpaperSetting = WallpaperConfig;
 
-export interface TileMarginsSetting {
-  enabled: boolean;
-  px: number;
-}
+export type TileMarginsSetting = PersistedTileMargins;
 
 const DEFAULT_TILE_MARGINS: TileMarginsSetting = { enabled: true, px: 8 };
 const TILE_MARGIN_MIN = 0;
@@ -124,17 +126,6 @@ async function closeBrowserForDisabledGate(): Promise<void> {
     // Browser may be unavailable or already closed; the persisted gate remains authoritative.
     console.warn('[WorkbenchSettings] browser gate cleanup failed:', getErrorMessage(error));
   }
-}
-
-function parseJsonSetting<T>(raw: unknown, fallback: T): T {
-  if (typeof raw !== 'string' || !raw.trim()) return fallback;
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === 'object') return { ...fallback, ...(parsed as Partial<T>) };
-  } catch {
-    // 坏数据回退默认值
-  }
-  return fallback;
 }
 
 function parseProfile(raw: unknown): PerformanceProfile {
@@ -252,9 +243,9 @@ export const WorkbenchSettingsSection: React.FC<WorkbenchSettingsSectionProps> =
       setMode(modeResult.enabled);
       setPerformanceProfile(parseProfile(profileVal));
       setMaterialTierState(parseMaterialTier(tierVal));
-      const wp = parseJsonSetting<WallpaperSetting>(wallpaperVal, DEFAULT_WALLPAPER);
+      const wp = parsePersistedWallpaper(wallpaperVal, DEFAULT_WALLPAPER);
       setWallpaper(wp);
-      setTileMargins(parseJsonSetting<TileMarginsSetting>(marginsVal, DEFAULT_TILE_MARGINS));
+      setTileMargins(parsePersistedTileMargins(marginsVal, DEFAULT_TILE_MARGINS));
       setDockSize(parseDockSize(dockSizeVal));
       setDockAutohide(String(autohideVal ?? '') === 'true');
       setRestoreSession(String(restoreSessionVal ?? '') === 'true');

--- a/src/features/workbench/components/WorkbenchDesktop.tsx
+++ b/src/features/workbench/components/WorkbenchDesktop.tsx
@@ -81,6 +81,11 @@ import {
 import { installImeScrollContainment } from '../core/imeScrollContainment';
 import { ContentCloseConfirmationHost } from '../apps/content/ContentCloseConfirmation';
 import { QuickLookHost } from '../apps/preview/quickLook';
+import {
+  parsePersistedTileMargins,
+  parsePersistedWallpaper,
+  type PersistedTileMargins,
+} from '../core/persistedSettings';
 
 // 仅诊断参数启动时开启交互时间线采集（普通 dev 默认关）
 if (isWorkbenchDiagnosticsRequested()) {
@@ -103,12 +108,7 @@ const SETTING_KEYS = {
   devPanel: 'desktop.workbenchDevPanel',
 } as const;
 
-interface TileMarginsSetting {
-  enabled: boolean;
-  px: number;
-}
-
-const DEFAULT_TILE_MARGINS: TileMarginsSetting = { enabled: true, px: 8 };
+const DEFAULT_TILE_MARGINS: PersistedTileMargins = { enabled: true, px: 8 };
 const DOCK_SIZE_MIN = 75;
 const DOCK_SIZE_MAX = 125;
 const DOCK_SIZE_DEFAULT = 100;
@@ -136,17 +136,6 @@ async function readSetting(key: string): Promise<string | null> {
   } catch {
     return null;
   }
-}
-
-function parseJson<T>(raw: string | null, fallback: T): T {
-  if (typeof raw !== 'string' || !raw.trim()) return fallback;
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === 'object') return { ...fallback, ...(parsed as Partial<T>) };
-  } catch {
-    /* 坏数据回退默认值 */
-  }
-  return fallback;
 }
 
 // ---------------------------------------------------------------------------
@@ -274,7 +263,7 @@ export const WorkbenchDesktop: React.FC = () => {
 
   // ---- 设置状态（启动回放 + workbench:settings-changed 热更新）----
   const [wallpaper, setWallpaper] = useState<WallpaperConfig>(DEFAULT_WALLPAPER);
-  const [tileMargins, setTileMargins] = useState<TileMarginsSetting>(DEFAULT_TILE_MARGINS);
+  const [tileMargins, setTileMargins] = useState<PersistedTileMargins>(DEFAULT_TILE_MARGINS);
   const [dockSize, setDockSize] = useState(DOCK_SIZE_DEFAULT);
   const [dockAutohide, setDockAutohide] = useState(false);
   const [desktopWidgets, setDesktopWidgets] = useState(true);
@@ -330,8 +319,8 @@ export const WorkbenchDesktop: React.FC = () => {
           ? (tier as MaterialTierSetting)
           : 'auto',
       );
-      setWallpaper(parseJson<WallpaperConfig>(wallpaperVal, DEFAULT_WALLPAPER));
-      setTileMargins(parseJson<TileMarginsSetting>(marginsVal, DEFAULT_TILE_MARGINS));
+      setWallpaper(parsePersistedWallpaper(wallpaperVal, DEFAULT_WALLPAPER));
+      setTileMargins(parsePersistedTileMargins(marginsVal, DEFAULT_TILE_MARGINS));
       setDockSize(parseDockSize(dockSizeVal));
       setDockAutohide(String(autohideVal ?? '') === 'true');
       // 桌面组件缺省显示（保持现状），只有显式 'false' 才隐藏
@@ -348,12 +337,10 @@ export const WorkbenchDesktop: React.FC = () => {
       const { key, value } = (e as CustomEvent<{ key?: string; value?: unknown }>).detail ?? {};
       switch (key) {
         case SETTING_KEYS.wallpaper:
-          if (value && typeof value === 'object') setWallpaper(value as WallpaperConfig);
+          setWallpaper(parsePersistedWallpaper(value, DEFAULT_WALLPAPER));
           break;
         case SETTING_KEYS.tileMargins:
-          if (value && typeof value === 'object') {
-            setTileMargins({ ...DEFAULT_TILE_MARGINS, ...(value as Partial<TileMarginsSetting>) });
-          }
+          setTileMargins(parsePersistedTileMargins(value, DEFAULT_TILE_MARGINS));
           break;
         case SETTING_KEYS.dockAutohide:
           setDockAutohide(value === true);

--- a/src/features/workbench/core/persistedSettings.ts
+++ b/src/features/workbench/core/persistedSettings.ts
@@ -1,0 +1,76 @@
+import type { WallpaperConfig } from '../components/WallpaperLayer';
+
+export interface PersistedTileMargins {
+  enabled: boolean;
+  px: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseRecord(value: unknown): Record<string, unknown> | null {
+  if (isRecord(value)) return value;
+  if (typeof value !== 'string' || !value.trim()) return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Parse wallpaper settings from either the settings backend/localStorage JSON
+ * or the workbench settings-changed event payload.
+ */
+export function parsePersistedWallpaper(
+  value: unknown,
+  fallback: WallpaperConfig,
+): WallpaperConfig {
+  const parsed = parseRecord(value);
+  if (
+    !parsed
+    || (parsed.kind !== 'theme' && parsed.kind !== 'image')
+    || typeof parsed.value !== 'string'
+    || parsed.value.length === 0
+  ) {
+    return { ...fallback };
+  }
+
+  if (parsed.kind === 'theme') {
+    return { kind: 'theme', value: parsed.value };
+  }
+
+  const result: WallpaperConfig = { kind: 'image', value: parsed.value };
+  const imageBlur = finiteNumber(parsed.imageBlur);
+  const imageDim = finiteNumber(parsed.imageDim);
+  if (imageBlur !== null) result.imageBlur = clamp(imageBlur, 0, 40);
+  if (imageDim !== null) result.imageDim = clamp(imageDim, 0, 0.6);
+  if (typeof parsed.imageVignette === 'boolean') {
+    result.imageVignette = parsed.imageVignette;
+  }
+  return result;
+}
+
+/** Parse and clamp the workbench tiling margin preference field-by-field. */
+export function parsePersistedTileMargins(
+  value: unknown,
+  fallback: PersistedTileMargins,
+): PersistedTileMargins {
+  const parsed = parseRecord(value);
+  if (!parsed) return { ...fallback };
+  const px = finiteNumber(parsed.px);
+  return {
+    enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : fallback.enabled,
+    px: px === null ? fallback.px : clamp(px, 0, 32),
+  };
+}

--- a/tests/vitest/learning-hub/finder-host-buckets.test.ts
+++ b/tests/vitest/learning-hub/finder-host-buckets.test.ts
@@ -22,6 +22,7 @@ import {
   resolveFinderHostId,
   resolveInitialViewPreferences,
   resetFinderStoreRegistryForTests,
+  sanitizeFinderViewPreferences,
   setActiveFinderHostId,
   useActiveFinderState,
   useFinderStore,
@@ -233,6 +234,43 @@ describe('finderStore persisted preference migration', () => {
     expect(
       resolveInitialViewPreferences('page', { getItem: () => 'not json' }),
     ).toEqual(DEFAULT_FINDER_VIEW_PREFERENCES);
+  });
+
+  it('whitelists structurally valid JSON instead of trusting persisted field types', () => {
+    expect(sanitizeFinderViewPreferences({
+      viewMode: { value: 'list' },
+      sortBy: 'name',
+      sortOrder: 'sideways',
+      quickAccessCollapsed: 'yes',
+      currentPath: { folderId: 'must-not-hydrate' },
+    })).toEqual({ sortBy: 'name' });
+  });
+
+  it('does not let Zustand hydration re-inject rejected v0 preferences', () => {
+    const bucketId = 'corrupt-upgrade-test';
+    const key = finderPersistKey(bucketId);
+    window.localStorage.setItem(key, JSON.stringify({
+      state: {
+        viewMode: null,
+        sortBy: 'name',
+        sortOrder: ['desc'],
+        quickAccessCollapsed: 1,
+        currentPath: { folderId: 'stale-folder' },
+      },
+      version: 0,
+    }));
+
+    try {
+      const store = createFinderStore(bucketId);
+      expect(store.getState().viewMode).toBe(DEFAULT_FINDER_VIEW_PREFERENCES.viewMode);
+      expect(store.getState().sortBy).toBe('name');
+      expect(store.getState().sortOrder).toBe(DEFAULT_FINDER_VIEW_PREFERENCES.sortOrder);
+      expect(store.getState().quickAccessCollapsed)
+        .toBe(DEFAULT_FINDER_VIEW_PREFERENCES.quickAccessCollapsed);
+      expect(store.getState().currentPath.folderId).toBeNull();
+    } finally {
+      window.localStorage.removeItem(key);
+    }
   });
 
   it('writes each bucket to its own persist key', () => {

--- a/tests/vitest/workbench/workbench-persisted-settings.test.ts
+++ b/tests/vitest/workbench/workbench-persisted-settings.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parsePersistedTileMargins,
+  parsePersistedWallpaper,
+} from '@/features/workbench/core/persistedSettings';
+
+const wallpaperFallback = { kind: 'theme' as const, value: 'mountain-mist' };
+const marginFallback = { enabled: true, px: 8 };
+
+describe('workbench persisted setting compatibility', () => {
+  it('accepts valid v0.9.44 JSON without changing user choices', () => {
+    expect(parsePersistedWallpaper(
+      JSON.stringify({ kind: 'theme', value: 'nebula' }),
+      wallpaperFallback,
+    )).toEqual({ kind: 'theme', value: 'nebula' });
+    expect(parsePersistedTileMargins(
+      JSON.stringify({ enabled: false, px: 16 }),
+      marginFallback,
+    )).toEqual({ enabled: false, px: 16 });
+  });
+
+  it('rejects malformed wallpaper shapes before WallpaperLayer string operations', () => {
+    for (const value of [
+      'not-json',
+      '[]',
+      JSON.stringify({ kind: 'image', value: 123 }),
+      JSON.stringify({ kind: 'unknown', value: '/tmp/wallpaper.png' }),
+    ]) {
+      expect(parsePersistedWallpaper(value, wallpaperFallback)).toEqual(wallpaperFallback);
+    }
+  });
+
+  it('sanitizes optional image adaptation fields independently', () => {
+    expect(parsePersistedWallpaper({
+      kind: 'image',
+      value: '/tmp/wallpaper.png',
+      imageBlur: 500,
+      imageDim: -2,
+      imageVignette: false,
+      injected: 'ignored',
+    }, wallpaperFallback)).toEqual({
+      kind: 'image',
+      value: '/tmp/wallpaper.png',
+      imageBlur: 40,
+      imageDim: 0,
+      imageVignette: false,
+    });
+  });
+
+  it('keeps valid margin fields while defaulting or clamping invalid fields', () => {
+    expect(parsePersistedTileMargins(
+      JSON.stringify({ enabled: false, px: 'wide' }),
+      marginFallback,
+    )).toEqual({ enabled: false, px: 8 });
+    expect(parsePersistedTileMargins(
+      { enabled: 'yes', px: 999 },
+      marginFallback,
+    )).toEqual({ enabled: true, px: 32 });
+    expect(parsePersistedTileMargins([], marginFallback)).toEqual(marginFallback);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
相对 v0.9.44 升级：Zustand/工作台 persist 不再信任脏嵌套值；旧 Composer draft 非字符串不再崩；Rust 不再静默丢掉 `skill` panel state。

官方按提交回收 `9176740b` / `0a6344e1`，勿整支合并。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-656cd9fd-4f6a-43d1-9677-f29d512ecde6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-656cd9fd-4f6a-43d1-9677-f29d512ecde6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

