### PR TITLE
0824 发版修复：Anki 旧卡库可空 metadata

### DIFF
--- a/docs/dev/0824-rel-anki.md
+++ b/docs/dev/0824-rel-anki.md
@@ -1,0 +1,87 @@
+# 0824 Anki / Flashcards 发布回归审计
+
+## 范围
+
+基线为 `v0.9.44`（`1cf6cabc`，2026-08-09），审计当前 0824 分支的：
+
+- 只读 Generative UI 闪卡；
+- `cardAgent.startGeneration` 非阻塞制卡入口；
+- `ChatV2AnkiAdapter` / `anki_tool_call` 退役状态；
+- 空卡库 0% 进度、统计页调度器位置、任务台加载错误态；
+- 旧卡片库 / `mistakes.db` 升级；
+- critic `_qa_flags`、图像遮挡 `_occlusion` 与中英文 locale key。
+
+`v0.9.44` 的四库 schema tuple 为：
+
+```text
+vfs=20260808, chat_v2=20260806, mistakes=20260724, llm_usage=20260525
+```
+
+## 审计结论
+
+### 已符合发布裁决
+
+1. `flashcard-preview` 保持只读。Generative UI 不注册
+   `save-to-library` handler；持久化仍统一走 `anki_cards` 管线。
+2. 划词制卡与文本制卡均调用 `cardAgent.startGeneration`。该入口只启动
+   `start_enhanced_document_processing` 并返回 `documentId`，不在前端阻塞等待卡片收集。
+3. `ChatV2AnkiAdapter`、`useChatV2Anki` 与 `anki_tool_call` 监听均未恢复。
+4. 空卡库时 Today 目标数为 0、进度为 0%，显示建库引导，不显示 100% 或
+   “今日全部完成”。
+5. 正常统计态下 `SchedulerSettingsSection` 位于统计面板之后；统计加载失败时，
+   独立的调度设置仍可使用。
+6. Anki 任务台区分首次加载失败、真实空列表与“刷新失败但保留旧数据”三种状态，
+   并提供重试。
+7. `_qa_flags` 与 `_occlusion` 没有拆成新列，仍作为字符串值保存在
+   `anki_cards.extra_fields_json`。前后端解析契约一致。
+8. `en-US` / `zh-CN` 的 `anki.json`、`flashcards.json` leaf key 集合一致；
+   本次增加自动 parity 与关键发布 key 门禁。
+
+### 发现并修复的升级缺陷
+
+历史 `anki_cards` schema 中 `tags_json`、`images_json`、
+`extra_fields_json` 可为 NULL。旧 writer、导入或同步数据因此可能产生 NULL，
+但当前卡片库和 FSRS 入队正文读取把这些列直接解码成 Rust `String`。
+
+后果：
+
+- 一张旧卡即可让 `list_anki_library_cards` 整页失败；
+- 同一张卡即使能被选中，`fsrs_enqueue_cards` 也会在构造复习正文时失败；
+- Agent 卡片库读取有相同风险。
+
+修复采用两层防护：
+
+1. `V20260824__normalize_anki_card_optional_json.sql` 在升级时仅把 NULL / 空串
+   归一化为 `[]` 或 `{}`，并补齐可空来源字段；
+2. 运行时查询与 mapper 继续容忍 NULL，防止升级后又从导入 / 同步收到旧形态数据。
+
+迁移不会改写任何有效 `extra_fields_json`，所以 `_qa_flags`、`_occlusion`
+及其他模板字段原样保留。
+
+## 回归覆盖
+
+- Rust 数据库回归：构造 NULL `tags_json` / `images_json` /
+  `extra_fields_json` 卡片，验证 UI library、Agent library 与 FSRS enqueue 均可读取。
+- 生产迁移 fixture：从 `v0.9.44` 精确 schema tuple 升级到 HEAD，验证 NULL
+  JSON 被归一化，并通过 oracle 校验 `_qa_flags` / `_occlusion` 内容不变。
+- Locale 回归：验证 `anki` / `flashcards` 中英文 leaf key 完全一致，并固定
+  任务加载错误、模板渲染错误、空卡库、调度器、critic 与 occlusion 关键 key。
+- 既有定向覆盖继续验证只读闪卡、`startGeneration`、无 `anki_tool_call`、
+  空卡库 0%、调度器位于统计之后及任务台错误 / stale 状态。
+
+## 验证命令
+
+```bash
+node scripts/check-migrations.mjs
+pnpm vitest run \
+  tests/vitest/generative-ui/flashcardDisplayOnly.test.ts \
+  tests/vitest/anki/cardforge/CardAgent.test.ts \
+  tests/vitest/flashcards/todayScreenEmptyLibrary.test.tsx \
+  tests/vitest/flashcards/StatisticsScreen.test.tsx \
+  src/features/anki-tasks/__tests__/AnkiTasksApp.loadError.test.tsx \
+  tests/vitest/flashcards/localeKeys.test.ts
+cargo test --manifest-path src-tauri/Cargo.toml \
+  legacy_null_anki_json_fields_do_not_break_library_reads_or_enqueue
+cargo test --manifest-path src-tauri/Cargo.toml --features data_governance \
+  migration_compat -- --nocapture
+```

--- a/src-tauri/migrations/migration-lock.json
+++ b/src-tauri/migrations/migration-lock.json
@@ -457,6 +457,14 @@
       ]
     },
     {
+      "database": "mistakes",
+      "version": 20260824,
+      "name": "normalize_anki_card_optional_json",
+      "path": "mistakes/V20260824__normalize_anki_card_optional_json.sql",
+      "sha256": "b184526ebb7044c223b239b32f67e4a26f33a7d82abc509929f1a9cf0bc29067",
+      "dangers": []
+    },
+    {
       "database": "vfs",
       "version": 20260130,
       "name": "init",

--- a/src-tauri/migrations/mistakes/V20260824__normalize_anki_card_optional_json.sql
+++ b/src-tauri/migrations/mistakes/V20260824__normalize_anki_card_optional_json.sql
@@ -1,0 +1,31 @@
+-- ============================================================================
+-- V20260824: Normalize nullable optional fields in historical Anki cards
+-- ============================================================================
+--
+-- tags_json / images_json / extra_fields_json have always been optional at the
+-- SQLite level. Historical writers and synced rows can therefore contain NULL
+-- (or an empty string), while current library and FSRS readers expect JSON
+-- text. Normalize only missing values; valid extra_fields payloads, including
+-- `_qa_flags` and `_occlusion`, must remain byte-for-byte unchanged.
+
+UPDATE anki_cards
+SET tags_json = '[]'
+WHERE tags_json IS NULL OR trim(tags_json) = '';
+
+UPDATE anki_cards
+SET images_json = '[]'
+WHERE images_json IS NULL OR trim(images_json) = '';
+
+UPDATE anki_cards
+SET extra_fields_json = '{}'
+WHERE extra_fields_json IS NULL OR trim(extra_fields_json) = '';
+
+-- source_type/source_id are NOT NULL in the consolidated schema, but early
+-- runtime-created tables and imported/synced rows may predate that constraint.
+UPDATE anki_cards
+SET source_type = ''
+WHERE source_type IS NULL;
+
+UPDATE anki_cards
+SET source_id = ''
+WHERE source_id IS NULL;

--- a/src-tauri/src/data_governance/migration/mistakes.rs
+++ b/src-tauri/src/data_governance/migration/mistakes.rs
@@ -272,6 +272,17 @@ pub const V20260724_ANKI_DEDUP_INDEX_EXCLUDE_DELETED: MigrationDef = MigrationDe
 .with_expected_indexes(MISTAKES_V20260209_DEDUP_INDEXES)
 .idempotent();
 
+/// V20260824: 归一化历史 Anki 卡片中可空的 JSON / 来源字段。
+///
+/// 只补齐 NULL / 空串，不改写有效 extra_fields_json，确保 `_qa_flags` 与
+/// `_occlusion` 等结构化元数据在升级中原样保留。
+pub const V20260824_NORMALIZE_ANKI_CARD_OPTIONAL_JSON: MigrationDef = MigrationDef::new(
+    20260824,
+    "normalize_anki_card_optional_json",
+    include_str!("../../../migrations/mistakes/V20260824__normalize_anki_card_optional_json.sql"),
+)
+.idempotent();
+
 /// V20260720: durable FSRS -> mastery outbox marker.
 pub const V20260720_FSRS_MASTERY_OUTBOX: MigrationDef = MigrationDef::new(
     20260720,
@@ -424,6 +435,7 @@ pub const MISTAKES_MIGRATIONS: MigrationSet = MigrationSet {
         V20260722_FSRS_SCHEDULER_HARDENING,
         V20260723_TEMPLATE_USER_STATE,
         V20260724_ANKI_DEDUP_INDEX_EXCLUDE_DELETED,
+        V20260824_NORMALIZE_ANKI_CARD_OPTIONAL_JSON,
     ],
 };
 
@@ -667,9 +679,21 @@ mod tests {
         assert_eq!(anki_dedup.name, "anki_dedup_index_exclude_deleted");
         assert!(anki_dedup.idempotent);
 
+        let normalize_anki_json = MISTAKES_MIGRATIONS
+            .get(20260824)
+            .expect("V20260824 should exist");
+        assert_eq!(
+            normalize_anki_json.name,
+            "normalize_anki_card_optional_json"
+        );
+        assert!(normalize_anki_json.idempotent);
+        assert!(normalize_anki_json
+            .sql
+            .contains("WHERE extra_fields_json IS NULL"));
+
         assert_eq!(
             MISTAKES_MIGRATIONS.latest_version(),
-            20260724,
+            20260824,
             "Latest version should track the newest published mistakes migration"
         );
     }

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -240,9 +240,11 @@ fn build_existing_message_map(row: &rusqlite::Row<'_>) -> rusqlite::Result<(Stri
 }
 
 fn map_anki_card_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AnkiCard> {
-    let tags_json: String = row.get(5)?;
-    let images_json: String = row.get(6)?;
-    let extra_fields_json: String = row.get(11)?;
+    // Historical/imported/synced rows may contain NULL in these optional
+    // columns even though current writers always emit JSON text.
+    let tags_json: Option<String> = row.get(5)?;
+    let images_json: Option<String> = row.get(6)?;
+    let extra_fields_json: Option<String> = row.get(11)?;
 
     Ok(AnkiCard {
         id: row.get(0)?,
@@ -250,13 +252,22 @@ fn map_anki_card_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AnkiCard> {
         front: row.get(2)?,
         back: row.get(3)?,
         text: row.get(4)?,
-        tags: serde_json::from_str(&tags_json).unwrap_or_default(),
-        images: serde_json::from_str(&images_json).unwrap_or_default(),
+        tags: tags_json
+            .as_deref()
+            .and_then(|json| serde_json::from_str(json).ok())
+            .unwrap_or_default(),
+        images: images_json
+            .as_deref()
+            .and_then(|json| serde_json::from_str(json).ok())
+            .unwrap_or_default(),
         is_error_card: row.get::<_, i32>(7)? != 0,
         error_content: row.get(8)?,
         created_at: row.get(9)?,
         updated_at: row.get(10)?,
-        extra_fields: serde_json::from_str(&extra_fields_json).unwrap_or_default(),
+        extra_fields: extra_fields_json
+            .as_deref()
+            .and_then(|json| serde_json::from_str(json).ok())
+            .unwrap_or_default(),
         template_id: row.get(12)?,
     })
 }
@@ -265,11 +276,11 @@ fn map_anki_card_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AnkiCard> {
 /// outcomes. Columns 0..=20 intentionally match the existing UI library row;
 /// columns 21..=22 add the stable source locator.
 fn map_anki_library_record_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AnkiLibraryCardRecord> {
-    let tags_json: String = row.get(5)?;
-    let images_json: String = row.get(6)?;
-    let extra_fields_json: String = row.get(11)?;
-    let raw_source_type: String = row.get(13)?;
-    let raw_source_id: String = row.get(14)?;
+    let tags_json: Option<String> = row.get(5)?;
+    let images_json: Option<String> = row.get(6)?;
+    let extra_fields_json: Option<String> = row.get(11)?;
+    let raw_source_type: Option<String> = row.get(13)?;
+    let raw_source_id: Option<String> = row.get(14)?;
     Ok(AnkiLibraryCardRecord {
         library_card: AnkiLibraryCard {
             card: AnkiCard {
@@ -278,17 +289,26 @@ fn map_anki_library_record_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Anki
                 front: row.get(2)?,
                 back: row.get(3)?,
                 text: row.get(4)?,
-                tags: serde_json::from_str(&tags_json).unwrap_or_default(),
-                images: serde_json::from_str(&images_json).unwrap_or_default(),
+                tags: tags_json
+                    .as_deref()
+                    .and_then(|json| serde_json::from_str(json).ok())
+                    .unwrap_or_default(),
+                images: images_json
+                    .as_deref()
+                    .and_then(|json| serde_json::from_str(json).ok())
+                    .unwrap_or_default(),
                 is_error_card: row.get::<_, i32>(7)? != 0,
                 error_content: row.get(8)?,
                 created_at: row.get(9)?,
                 updated_at: row.get(10)?,
-                extra_fields: serde_json::from_str(&extra_fields_json).unwrap_or_default(),
+                extra_fields: extra_fields_json
+                    .as_deref()
+                    .and_then(|json| serde_json::from_str(json).ok())
+                    .unwrap_or_default(),
                 template_id: row.get(12)?,
             },
-            source_type: (!raw_source_type.trim().is_empty()).then_some(raw_source_type),
-            source_id: (!raw_source_id.trim().is_empty()).then_some(raw_source_id),
+            source_type: raw_source_type.filter(|value| !value.trim().is_empty()),
+            source_id: raw_source_id.filter(|value| !value.trim().is_empty()),
             state_id: row.get(15)?,
             state: row.get(16)?,
             due_ms: row.get(17)?,
@@ -7684,10 +7704,11 @@ impl Database {
 
         let data_sql = format!(
             "SELECT
-                ac.id, ac.task_id, ac.front, ac.back, ac.text, ac.tags_json, ac.images_json,
+                ac.id, ac.task_id, ac.front, ac.back, ac.text,
+                COALESCE(ac.tags_json, '[]'), COALESCE(ac.images_json, '[]'),
                 ac.is_error_card, ac.error_content, ac.created_at, ac.updated_at,
                 COALESCE(ac.extra_fields_json, '{{}}') as extra_fields_json,
-                ac.template_id, ac.source_type, ac.source_id,
+                ac.template_id, COALESCE(ac.source_type, ''), COALESCE(ac.source_id, ''),
                 fs.id, fs.state, fs.due_ms, COALESCE(fs.suspended, 0),
                 CASE WHEN fs.id IS NULL THEN 0 ELSE 1 END,
                 CASE
@@ -7708,13 +7729,21 @@ impl Database {
 
         let mut stmt = conn.prepare(&data_sql)?;
         let rows = stmt.query_map(rusqlite::params_from_iter(data_params.iter()), |row| {
-            let tags_json: String = row.get(5)?;
-            let tags: Vec<String> = serde_json::from_str(&tags_json).unwrap_or_default();
-            let images_json: String = row.get(6)?;
-            let images: Vec<String> = serde_json::from_str(&images_json).unwrap_or_default();
-            let extra_fields_json: String = row.get(11)?;
-            let extra_fields: std::collections::HashMap<String, String> =
-                serde_json::from_str(&extra_fields_json).unwrap_or_default();
+            let tags_json: Option<String> = row.get(5)?;
+            let tags: Vec<String> = tags_json
+                .as_deref()
+                .and_then(|json| serde_json::from_str(json).ok())
+                .unwrap_or_default();
+            let images_json: Option<String> = row.get(6)?;
+            let images: Vec<String> = images_json
+                .as_deref()
+                .and_then(|json| serde_json::from_str(json).ok())
+                .unwrap_or_default();
+            let extra_fields_json: Option<String> = row.get(11)?;
+            let extra_fields: std::collections::HashMap<String, String> = extra_fields_json
+                .as_deref()
+                .and_then(|json| serde_json::from_str(json).ok())
+                .unwrap_or_default();
 
             let card = AnkiCard {
                 id: row.get(0)?,
@@ -7732,18 +7761,10 @@ impl Database {
                 template_id: row.get(12)?,
             };
 
-            let raw_source_type: String = row.get(13)?;
-            let source_type = if raw_source_type.trim().is_empty() {
-                None
-            } else {
-                Some(raw_source_type)
-            };
-            let raw_source_id: String = row.get(14)?;
-            let source_id = if raw_source_id.trim().is_empty() {
-                None
-            } else {
-                Some(raw_source_id)
-            };
+            let raw_source_type: Option<String> = row.get(13)?;
+            let source_type = raw_source_type.filter(|value| !value.trim().is_empty());
+            let raw_source_id: Option<String> = row.get(14)?;
+            let source_id = raw_source_id.filter(|value| !value.trim().is_empty());
             Ok(AnkiLibraryCard {
                 card,
                 source_type,
@@ -8679,6 +8700,82 @@ mod tests {
         assert_eq!(serialized["dueMs"], json!(past_due));
         assert_eq!(serialized["isDue"], json!(true));
         assert!(serialized.get("state_id").is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_null_anki_json_fields_do_not_break_library_reads_or_enqueue() -> anyhow::Result<()> {
+        use crate::fsrs_review_service::FsrsReviewService;
+        use std::sync::Arc;
+
+        let dir = tempdir()?;
+        let db = Arc::new(setup_migrated_db(dir.path())?);
+        let now = Utc::now().to_rfc3339();
+        let task = DocumentTask {
+            id: "task-library-legacy-null".to_string(),
+            document_id: "doc-library-legacy-null".to_string(),
+            original_document_name: "v0.9.44 library".to_string(),
+            segment_index: 0,
+            content_segment: "legacy fixture".to_string(),
+            status: TaskStatus::Completed,
+            created_at: now.clone(),
+            updated_at: now.clone(),
+            error_message: None,
+            anki_generation_options_json: "{}".to_string(),
+        };
+        let card = AnkiCard {
+            id: "card-library-legacy-null".to_string(),
+            task_id: task.id.clone(),
+            front: "legacy front".to_string(),
+            back: "legacy back".to_string(),
+            text: None,
+            tags: vec!["will-be-null".to_string()],
+            images: vec!["will-be-null.png".to_string()],
+            is_error_card: false,
+            error_content: None,
+            created_at: now.clone(),
+            updated_at: now,
+            extra_fields: std::collections::HashMap::from([(
+                "will-be-null".to_string(),
+                "value".to_string(),
+            )]),
+            template_id: None,
+        };
+        db.save_document_task_with_cards_atomic(&task, &[card])?;
+        db.get_conn_safe()?.execute(
+            "UPDATE anki_cards
+             SET tags_json = NULL, images_json = NULL, extra_fields_json = NULL
+             WHERE id = ?1",
+            params!["card-library-legacy-null"],
+        )?;
+
+        let (library, total) = db.list_anki_library_cards(None, None, None, 1, 20)?;
+        assert_eq!(total, 1);
+        assert_eq!(library.len(), 1);
+        assert!(library[0].card.tags.is_empty());
+        assert!(library[0].card.images.is_empty());
+        assert!(library[0].card.extra_fields.is_empty());
+
+        let agent_page = db.list_anki_agent_library_cards(
+            AnkiLibraryScope::agent(),
+            None,
+            None,
+            AnkiLibraryScheduleFilter::All,
+            AnkiLibraryDiagnosticFilter::All,
+            1,
+            20,
+        )?;
+        assert_eq!(agent_page.total, 1);
+        assert!(agent_page.items[0].library_card.card.tags.is_empty());
+        assert!(agent_page.items[0].library_card.card.images.is_empty());
+
+        let enqueue =
+            FsrsReviewService::new(db).enqueue_cards(&["card-library-legacy-null".to_string()])?;
+        assert_eq!(enqueue.enqueued, 1);
+        assert_eq!(enqueue.review_cards.len(), 1);
+        assert!(enqueue.review_cards[0].tags.is_empty());
+        assert!(enqueue.review_cards[0].images.is_empty());
+        assert!(enqueue.review_cards[0].extra_fields.is_empty());
         Ok(())
     }
 

--- a/src-tauri/src/fsrs_review_service.rs
+++ b/src-tauri/src/fsrs_review_service.rs
@@ -1076,7 +1076,7 @@ impl FsrsReviewService {
     ) -> Result<Vec<FsrsEnqueuedCard>> {
         let mut stmt = conn
             .prepare(
-                "SELECT front, back, tags_json, text, template_id,
+                "SELECT front, back, COALESCE(tags_json, '[]'), text, template_id,
                         COALESCE(extra_fields_json, '{}'), COALESCE(images_json, '[]'),
                         COALESCE(is_error_card, 0), error_content
                  FROM anki_cards ac

--- a/src-tauri/tests/fixtures/migrations/manifest.json
+++ b/src-tauri/tests/fixtures/migrations/manifest.json
@@ -132,6 +132,26 @@
         { "database": "mistakes", "query": "SELECT enabled FROM automation_definitions WHERE id='auto_gap0000001'", "expected": "0" },
         { "database": "llm_usage", "query": "SELECT COUNT(*) FROM llm_usage_logs", "expected": "1" }
       ]
+    },
+    {
+      "id": "v0944_anki_library",
+      "kind": "bootstrap_sql",
+      "source_release": "v0.9.44 (2026-08-09), with historical Anki library rows containing nullable optional JSON",
+      "schema_tuple": { "vfs": 20260808, "chat_v2": 20260806, "mistakes": 20260724, "llm_usage": 20260525 },
+      "tags": ["release_v0_9_44", "anki_library", "nullable_json", "critic_qa_flags", "image_occlusion"],
+      "expected_semantics": "The exact v0.9.44 database tuple upgrades to HEAD; nullable Anki tags/images/extra fields normalize to valid empty JSON, while existing critic `_qa_flags` and image `_occlusion` payloads survive unchanged.",
+      "history_ops": [],
+      "allowed_extra_tables": {},
+      "seeds": {
+        "mistakes": { "file": "seeds/v0944_anki_library/mistakes.sql", "sha256": "e608a726139164871ff8736bf6db4c60e422841212681a860640f5fb6faa6ac3" }
+      },
+      "oracles": [
+        { "database": "mistakes", "query": "SELECT tags_json FROM anki_cards WHERE id='card_v0944_null_json'", "expected": "[]" },
+        { "database": "mistakes", "query": "SELECT images_json FROM anki_cards WHERE id='card_v0944_null_json'", "expected": "[]" },
+        { "database": "mistakes", "query": "SELECT extra_fields_json FROM anki_cards WHERE id='card_v0944_null_json'", "expected": "{}" },
+        { "database": "mistakes", "query": "SELECT json_extract(extra_fields_json, '$._qa_flags') FROM anki_cards WHERE id='card_v0944_qa_occlusion'", "expected": "[{\"severity\":\"warn\",\"rule\":\"maxLength\",\"message\":\"review wording\"}]" },
+        { "database": "mistakes", "query": "SELECT json_extract(extra_fields_json, '$._occlusion') FROM anki_cards WHERE id='card_v0944_qa_occlusion'", "expected": "{\"imageRef\":\"heart.png\",\"boxes\":[{\"x\":10,\"y\":20,\"width\":30,\"height\":40,\"clozeIndex\":1,\"label\":\"Left atrium\"}]}" }
+      ]
     }
   ]
 }

--- a/src-tauri/tests/fixtures/migrations/seeds/v0944_anki_library/mistakes.sql
+++ b/src-tauri/tests/fixtures/migrations/seeds/v0944_anki_library/mistakes.sql
@@ -1,0 +1,33 @@
+-- Fixture seed: mistakes.db from v0.9.44 (schema V20260724).
+--
+-- The first card models historical/imported optional JSON columns stored as
+-- NULL. The second proves critic and image-occlusion metadata survives the
+-- normalization migration without being rewritten.
+
+INSERT INTO document_tasks (
+    id, document_id, original_document_name, segment_index, content_segment,
+    status, created_at, updated_at, anki_generation_options_json
+) VALUES (
+    'task_v0944_anki_1', 'doc_v0944_anki_1', 'v0.9.44 cards', 0, 'legacy material',
+    'Completed', '2026-08-09T08:00:00Z', '2026-08-09T08:00:00Z', '{}'
+);
+
+INSERT INTO anki_cards (
+    id, task_id, front, back, tags_json, images_json, created_at, updated_at,
+    extra_fields_json, source_type, source_id
+) VALUES (
+    'card_v0944_null_json', 'task_v0944_anki_1', 'Legacy nullable card', 'Still readable',
+    NULL, NULL, '2026-08-09T08:01:00Z', '2026-08-09T08:01:00Z',
+    NULL, '', ''
+);
+
+INSERT INTO anki_cards (
+    id, task_id, front, back, tags_json, images_json, created_at, updated_at,
+    extra_fields_json, source_type, source_id
+) VALUES (
+    'card_v0944_qa_occlusion', 'task_v0944_anki_1', 'Identify the masked region', 'Left atrium',
+    '["image_occlusion"]', '["heart.png"]',
+    '2026-08-09T08:02:00Z', '2026-08-09T08:02:00Z',
+    '{"_qa_flags":"[{\"severity\":\"warn\",\"rule\":\"maxLength\",\"message\":\"review wording\"}]","_occlusion":"{\"imageRef\":\"heart.png\",\"boxes\":[{\"x\":10,\"y\":20,\"width\":30,\"height\":40,\"clozeIndex\":1,\"label\":\"Left atrium\"}]}"}',
+    'document', 'doc_v0944_anki_1'
+);

--- a/tests/vitest/flashcards/localeKeys.test.ts
+++ b/tests/vitest/flashcards/localeKeys.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import enAnki from '@/locales/en-US/anki.json';
+import zhAnki from '@/locales/zh-CN/anki.json';
+import enFlashcards from '@/locales/en-US/flashcards.json';
+import zhFlashcards from '@/locales/zh-CN/flashcards.json';
+
+function flattenLeafKeys(value: unknown, prefix = ''): string[] {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return [prefix];
+  }
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, child]) =>
+    flattenLeafKeys(child, prefix ? `${prefix}.${key}` : key),
+  );
+}
+
+function readKey(value: unknown, key: string): unknown {
+  return key.split('.').reduce<unknown>((cursor, part) => {
+    if (cursor == null || typeof cursor !== 'object' || Array.isArray(cursor)) return undefined;
+    return (cursor as Record<string, unknown>)[part];
+  }, value);
+}
+
+describe('Anki and flashcard locale contracts', () => {
+  it('keeps en-US and zh-CN leaf keys in parity', () => {
+    expect(flattenLeafKeys(enAnki).sort()).toEqual(flattenLeafKeys(zhAnki).sort());
+    expect(flattenLeafKeys(enFlashcards).sort()).toEqual(flattenLeafKeys(zhFlashcards).sort());
+  });
+
+  it.each([
+    ['anki', enAnki, zhAnki, 'taskDashboard.loadFailed'],
+    ['anki', enAnki, zhAnki, 'taskDashboard.refreshFailedStale'],
+    ['anki', enAnki, zhAnki, 'taskDashboard.retry'],
+    ['anki', enAnki, zhAnki, 'agent.critic.flaggedFlag'],
+    ['anki', enAnki, zhAnki, 'agent.occlusion.invalidSpec'],
+    ['anki', enAnki, zhAnki, 'qaFlags.cardBadge'],
+    ['flashcards', enFlashcards, zhFlashcards, 'card.renderIssue'],
+    ['flashcards', enFlashcards, zhFlashcards, 'card.renderIssueMore'],
+    ['flashcards', enFlashcards, zhFlashcards, 'today.libraryEmpty'],
+    ['flashcards', enFlashcards, zhFlashcards, 'settings.scheduler.title'],
+  ] as const)('defines %s:%s in both supported locales', (_namespace, en, zh, key) => {
+    expect(readKey(en, key)).toEqual(expect.any(String));
+    expect(readKey(zh, key)).toEqual(expect.any(String));
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
隔离枝。升级 v0.9.44 卡库时容忍 legacy nullable metadata，并补 locale 守卫。官方按文件回收。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-656cd9fd-4f6a-43d1-9677-f29d512ecde6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-656cd9fd-4f6a-43d1-9677-f29d512ecde6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

