### PR TITLE
0824 隔离：enableQaPass=false 不落盘 _qa_flags

### DIFF
--- a/src-tauri/src/streaming_anki_service.rs
+++ b/src-tauri/src/streaming_anki_service.rs
@@ -4476,7 +4476,10 @@ mod tests {
     async fn parse_and_save_card_honors_qa_pass_flag_persistence_contract() {
         let (svc, _dir) = make_persisted_test_service();
         let default_enabled = StructuredOutputOptions::from_options_json("{}").qa_pass_enabled();
-        assert!(default_enabled, "QA flag persistence must remain enabled by default");
+        assert!(
+            default_enabled,
+            "QA flag persistence must remain enabled by default"
+        );
 
         for (label, qa_pass_enabled, expect_flags) in [
             ("disabled", false, false),

--- a/src-tauri/src/streaming_anki_service.rs
+++ b/src-tauri/src/streaming_anki_service.rs
@@ -1901,11 +1901,6 @@ impl StreamingAnkiService {
             .map(|(k, v)| (k.clone(), self.clean_template_placeholders(v)))
             .collect();
 
-        // enable_qa_pass=false 时不携带字段 QA 违规留痕（校验本身照跑，仅不落盘）
-        if !qa_pass_enabled {
-            cleaned_extra_fields.remove(QA_FLAGS_FIELD);
-        }
-
         // Cloze 模板兼容：若模板声明 Text 字段但当前缺失，则尝试补齐
         let needs_text_field = resolved_template_fields
             .as_ref()
@@ -1966,6 +1961,12 @@ impl StreamingAnkiService {
             crate::anki_qa_lint::duplicate_key_source(&lint_input),
         ));
         crate::anki_qa_lint::merge_flags(&mut cleaned_extra_fields, &lint_issues);
+
+        // enable_qa_pass=false 时校验仍照常执行，但字段规则与 lint 的 QA 留痕均不落盘。
+        // 必须在 merge_flags 之后移除，避免 lint 将 _qa_flags 写回。
+        if !qa_pass_enabled {
+            cleaned_extra_fields.remove(QA_FLAGS_FIELD);
+        }
 
         // 首次入库时固化生成原文，供后续用户编辑后挖掘 grounded critic 修正对。
         // entry-once helper 不覆盖模板/用户已有值；超限或序列化失败仅少一份快照，
@@ -4469,6 +4470,63 @@ mod tests {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn parse_and_save_card_honors_qa_pass_flag_persistence_contract() {
+        let (svc, _dir) = make_persisted_test_service();
+        let default_enabled = StructuredOutputOptions::from_options_json("{}").qa_pass_enabled();
+        assert!(default_enabled, "QA flag persistence must remain enabled by default");
+
+        for (label, qa_pass_enabled, expect_flags) in [
+            ("disabled", false, false),
+            ("enabled", true, true),
+            ("default", default_enabled, true),
+        ] {
+            let document_id = format!("doc-qa-pass-{label}-{}", uuid::Uuid::new_v4());
+            let task_id = format!("qa-pass-{label}-task");
+            crate::anki_qa_lint::release_document_tracker(&document_id);
+            seed_task(&svc.db, &task_id, &document_id, 0);
+
+            // front == back is a deterministic lint violation produced after field extraction.
+            let identical = format!("{label} identical content");
+            let payload = json!({ "front": identical, "back": identical }).to_string();
+            let card = svc
+                .parse_and_save_card(
+                    &payload,
+                    &task_id,
+                    &document_id,
+                    &fingerprint_options(),
+                    qa_pass_enabled,
+                    None,
+                )
+                .await
+                .expect("invalid card must still parse")
+                .expect("invalid card must still be saved");
+
+            assert_eq!(
+                card.extra_fields.contains_key(QA_FLAGS_FIELD),
+                expect_flags,
+                "{label} QA mode returned unexpected _qa_flags"
+            );
+            if expect_flags {
+                assert!(
+                    qa_flag_codes(&card)
+                        .iter()
+                        .any(|code| code == "front_back_identical"),
+                    "{label} QA mode must preserve lint flags"
+                );
+            }
+
+            let persisted = svc.db.get_cards_for_task(&task_id).expect("stored card");
+            assert_eq!(persisted.len(), 1);
+            assert_eq!(
+                persisted[0].extra_fields.contains_key(QA_FLAGS_FIELD),
+                expect_flags,
+                "{label} QA mode persisted unexpected _qa_flags"
+            );
+            crate::anki_qa_lint::release_document_tracker(&document_id);
+        }
     }
 
     // -------------------- 收尾 #4：首次入库原文快照 --------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

隔离修复 **0824 引入** 的 Anki QA 开关契约缺口：`enableQaPass=false` 时确定性 lint 仍经 `merge_flags` 把 `_qa_flags` 写回落盘，与公开 schema「不要 QA 留痕」不一致。

**不要整支 merge 本枝到 0824。** 官方写手应 cherry-pick 产品提交后再追加 MERGE-PLAN Step 22。

基座：`2d41ea8b`。隔离 tip：`d9a341ee`。

### Changes
- `streaming_anki_service.rs`：`merge_flags` 之后若 `!qa_pass_enabled` 再次移除 `_qa_flags`（lint 仍跑，仅不落盘）
- 新增 `parse_and_save_card_honors_qa_pass_flag_persistence_contract`：disabled / enabled / default 三态对照内存返回值与 DB 落盘

未改：恢复卡住文案、死 key「保存到卡库」（v0.9.44 既有）。

### How to test
- `RUSTUP_TOOLCHAIN=1.98.0 cargo test --manifest-path src-tauri/Cargo.toml --lib parse_and_save_card_honors_qa_pass_flag_persistence_contract`

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [x] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ffbe94-512c-4a8c-abad-f6378cada875?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ffbe94-512c-4a8c-abad-f6378cada875&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

