### PR TITLE
fix: harden APKG import counts and critic gold provenance

### DIFF
--- a/src-tauri/src/anki_critic.rs
+++ b/src-tauri/src/anki_critic.rs
@@ -57,7 +57,7 @@ use tracing::{info, warn};
 /// critic 裁决的 `_qa_flags` 条目 code（flag 裁决留痕）。
 pub const CRITIC_FLAG_CODE: &str = "llm_critic";
 /// revise 裁决写入的审计条目 code（前端 QA 面板可按码过滤）。
-pub const CRITIC_REVISED_CODE: &str = "llm_critic_revised";
+pub const CRITIC_REVISED_CODE: &str = crate::anki_gold_set::CRITIC_REVISED_QA_CODE;
 /// 修订轮硬上限：revise 后的卡不再复审（成本与收敛性约束）。
 pub const MAX_REVISION_ROUNDS_HARD_CAP: u32 = 1;
 /// 模型调用防悬挂超时（秒）：超时按降级处理，不阻塞任务收尾。
@@ -732,6 +732,8 @@ fn timestamp_ms(rfc3339: &str) -> i64 {
 ///
 /// - `exclude_task_id`：当前收尾任务的卡片剔除——它们刚生成、尚无用户编辑
 ///   信号，且正是待评审对象，不能既当裁判参照又当被告；
+/// - 带 `_qa_flags.code = llm_critic_revised` 的模型自动修订卡剔除，禁止把
+///   critic 自己的改写伪装成用户金标再回灌；
 /// - 只有携带 `_original_generation` 快照且被用户实际编辑过的兄弟卡才可能
 ///   产出修正对（挖掘语义完全复用 `anki_gold_set::classify_candidate`）；
 /// - 金标端过 `select_grounded_reference_pairs` 的 lint 门槛（脏金标不注入）。
@@ -748,6 +750,7 @@ pub fn gold_references_from_cards(
     let candidates: Vec<gold::GoldCandidate> = cards
         .iter()
         .filter(|card| card.task_id != exclude_task_id && !card.is_error_card)
+        .filter(|card| !gold::has_critic_revision_marker(&card.extra_fields))
         .filter_map(|card| {
             let original = gold::extract_original_from_extras(&card.extra_fields)?;
             Some(gold::GoldCandidate {
@@ -765,6 +768,7 @@ pub fn gold_references_from_cards(
                 again_count: 0,
                 was_error_card: false,
                 is_error_card: card.is_error_card,
+                critic_revised: false,
             })
         })
         .collect();
@@ -1568,6 +1572,32 @@ mod tests {
         error_card.is_error_card = true;
         let refs = gold_references_from_cards(&[self_card, error_card], "task-current", &cfg);
         assert!(refs.is_empty(), "当前任务卡与错误卡都不得进入参照集");
+    }
+
+    #[test]
+    fn gold_references_exclude_critic_revised_cards() {
+        let cfg = CriticConfig::default();
+        let mut critic_revised = card_with_original(
+            "critic-revised",
+            "task-old",
+            "critic 修订后的问题？",
+            "critic 修订后的答案",
+            "模型原问题（答案泄露）",
+            "模型原答案",
+        );
+        critic_revised.extra_fields.insert(
+            anki_qa_lint::QA_FLAGS_FIELD.to_string(),
+            serde_json::json!([{
+                "code": CRITIC_REVISED_CODE,
+                "field": "card",
+                "message": "LLM critic 修订",
+                "severity": "info"
+            }])
+            .to_string(),
+        );
+
+        let refs = gold_references_from_cards(&[critic_revised], "task-current", &cfg);
+        assert!(refs.is_empty(), "critic 自动修订不得作为用户修正金标回灌");
     }
 
     #[test]

--- a/src-tauri/src/anki_gold_set.rs
+++ b/src-tauri/src/anki_gold_set.rs
@@ -33,13 +33,17 @@
 //! - JS 侧：eval harness（`scripts/anki-eval/lib/cardLint.mjs`）的对齐测试
 //!   解析本常量，断言其 Rust-aligned 码全部落在契约内、eval-only 码不与契约冲突。
 
-use crate::anki_qa_lint::{lint_card, CardLintInput, LintConfig, LintSeverity};
+use crate::anki_qa_lint::{lint_card, CardLintInput, LintConfig, LintSeverity, QA_FLAGS_FIELD};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
 /// `extra_fields_json` 中保存"生成时原文快照"的键名（plan §2 P0 方案）。
 pub const ORIGINAL_GENERATION_FIELD: &str = "_original_generation";
+/// critic 自动修订写入 `_qa_flags` 的稳定来源码。
+///
+/// 带该标记的内容不是用户修改，必须从用户金标挖掘中排除。
+pub const CRITIC_REVISED_QA_CODE: &str = "llm_critic_revised";
 
 /// `_original_generation` 值本身的 UTF-8 字节硬上限。
 ///
@@ -140,6 +144,9 @@ pub struct GoldCandidate {
     pub was_error_card: bool,
     /// 当前仍是错误卡。
     pub is_error_card: bool,
+    /// 当前内容由 critic 自动修订，而非用户编辑。
+    #[serde(default)]
+    pub critic_revised: bool,
 }
 
 /// 标注结果（plan §3 label 步骤 + 错误卡修复通道）。
@@ -301,6 +308,22 @@ pub fn extract_original_from_extras(extras: &HashMap<String, String>) -> Option<
     serde_json::from_value::<CardSnapshot>(obj).ok()
 }
 
+/// 判断内存态卡片是否带 critic 自动修订来源标记。
+///
+/// `_qa_flags` 非法或不是数组时保守地视为未命中；只有结构化稳定 code
+/// `llm_critic_revised` 能触发排除。
+pub fn has_critic_revision_marker(extras: &HashMap<String, String>) -> bool {
+    let Some(raw) = extras.get(QA_FLAGS_FIELD) else {
+        return false;
+    };
+    let Ok(Value::Array(flags)) = serde_json::from_str::<Value>(raw) else {
+        return false;
+    };
+    flags
+        .iter()
+        .any(|flag| flag.get("code").and_then(Value::as_str) == Some(CRITIC_REVISED_QA_CODE))
+}
+
 // ============================================================================
 // 编辑距离
 // ============================================================================
@@ -356,12 +379,13 @@ pub fn edit_ratio(original: &CardSnapshot, edited: &CardSnapshot) -> f64 {
 
 /// 对单个候选做确定性标注。决策树：
 ///
-/// 1. 已删除 → 早删且零复习 = `DeletedEarly`，否则 `Unlabeled`（删除动机不明）；
-/// 2. 当前仍是错误卡 → `Unlabeled`（没有可用的"修复后"内容）；
-/// 3. 曾是错误卡且已修好 → `ErrorCardRepaired`（需 original 才能构成修正对）；
-/// 4. 有 original 且内容有变 → 按编辑距离比分 `EditedMinor` / `EditedMajor`；
-/// 5. 内容未变（或无 original 且时间戳未超宽限）→ 复习信号达标 = `KeptUnedited`；
-/// 6. 其余 → `Unlabeled`，reason 说明缺哪路信号。
+/// 1. critic 自动修订 → `Unlabeled`（模型自改不能充当用户金标）；
+/// 2. 已删除 → 早删且零复习 = `DeletedEarly`，否则 `Unlabeled`（删除动机不明）；
+/// 3. 当前仍是错误卡 → `Unlabeled`（没有可用的"修复后"内容）；
+/// 4. 曾是错误卡且已修好 → `ErrorCardRepaired`（需 original 才能构成修正对）；
+/// 5. 有 original 且内容有变 → 按编辑距离比分 `EditedMinor` / `EditedMajor`；
+/// 6. 内容未变（或无 original 且时间戳未超宽限）→ 复习信号达标 = `KeptUnedited`；
+/// 7. 其余 → `Unlabeled`，reason 说明缺哪路信号。
 pub fn classify_candidate(c: &GoldCandidate, cfg: &GoldMiningConfig) -> GoldSample {
     let sample = |label, reason: String, pair| GoldSample {
         card_id: c.card_id.clone(),
@@ -370,7 +394,16 @@ pub fn classify_candidate(c: &GoldCandidate, cfg: &GoldMiningConfig) -> GoldSamp
         repair_pair: pair,
     };
 
-    // 1. 删除通道
+    // 1. 来源通道：critic 自改不能伪装成用户编辑或用户认可的未编辑正例。
+    if c.critic_revised {
+        return sample(
+            GoldLabel::Unlabeled,
+            "带 llm_critic_revised 来源标记，模型自动修订不得进入用户金标".to_string(),
+            None,
+        );
+    }
+
+    // 2. 删除通道
     if let Some(deleted_at) = c.deleted_at_ms {
         let age = deleted_at - c.created_at_ms;
         if c.review_count == 0 && age <= cfg.early_delete_window_ms {
@@ -387,7 +420,7 @@ pub fn classify_candidate(c: &GoldCandidate, cfg: &GoldMiningConfig) -> GoldSamp
         );
     }
 
-    // 2. 当前仍是错误卡
+    // 3. 当前仍是错误卡
     if c.is_error_card {
         return sample(
             GoldLabel::Unlabeled,
@@ -396,7 +429,7 @@ pub fn classify_candidate(c: &GoldCandidate, cfg: &GoldMiningConfig) -> GoldSamp
         );
     }
 
-    // 3. 错误卡修复通道
+    // 4. 错误卡修复通道
     if c.was_error_card {
         if c.current.is_blank() {
             return sample(
@@ -426,7 +459,7 @@ pub fn classify_candidate(c: &GoldCandidate, cfg: &GoldMiningConfig) -> GoldSamp
         };
     }
 
-    // 4. 编辑通道（original 在场时以内容 diff 为准，时间戳仅作后备信号）
+    // 5. 编辑通道（original 在场时以内容 diff 为准，时间戳仅作后备信号）
     if let Some(orig) = &c.original {
         if *orig != c.current {
             let ratio = edit_ratio(orig, &c.current);
@@ -463,7 +496,7 @@ pub fn classify_candidate(c: &GoldCandidate, cfg: &GoldMiningConfig) -> GoldSamp
         );
     }
 
-    // 5. 未编辑：留存信号定夺
+    // 6. 未编辑：留存信号定夺
     let lapse_rate = if c.review_count == 0 {
         0.0
     } else {
@@ -759,6 +792,7 @@ mod tests {
             again_count: 0,
             was_error_card: false,
             is_error_card: false,
+            critic_revised: false,
         }
     }
 
@@ -920,6 +954,29 @@ mod tests {
         assert!(extract_original_generation(r#"{"_original_generation":"not-json"}"#).is_none());
     }
 
+    #[test]
+    fn critic_revision_marker_requires_structured_stable_code() {
+        let marked = HashMap::from([(
+            QA_FLAGS_FIELD.to_string(),
+            json!([
+                {"code": "answer_leak", "field": "front"},
+                {"code": CRITIC_REVISED_QA_CODE, "field": "card"}
+            ])
+            .to_string(),
+        )]);
+        assert!(has_critic_revision_marker(&marked));
+
+        let unrelated = HashMap::from([(
+            QA_FLAGS_FIELD.to_string(),
+            json!([{"message": CRITIC_REVISED_QA_CODE}]).to_string(),
+        )]);
+        assert!(!has_critic_revision_marker(&unrelated));
+        assert!(!has_critic_revision_marker(&HashMap::from([(
+            QA_FLAGS_FIELD.to_string(),
+            "not-json".to_string(),
+        )])));
+    }
+
     // -------- edit_distance / edit_ratio --------
 
     #[test]
@@ -1010,6 +1067,19 @@ mod tests {
         let s = classify_candidate(&c, &GoldMiningConfig::default());
         assert_eq!(s.label, GoldLabel::EditedMajor);
         assert!(s.repair_pair.expect("pair").distance_ratio >= 0.25);
+    }
+
+    #[test]
+    fn critic_revised_content_is_never_mined_as_user_gold() {
+        let mut c = base_candidate("critic-revised");
+        c.original = Some(snap("模型原问题（答案泄露）", "模型原答案"));
+        c.critic_revised = true;
+        c.review_count = 10;
+
+        let sample = classify_candidate(&c, &GoldMiningConfig::default());
+        assert_eq!(sample.label, GoldLabel::Unlabeled);
+        assert!(sample.repair_pair.is_none());
+        assert!(sample.reason.contains(CRITIC_REVISED_QA_CODE));
     }
 
     #[test]

--- a/src-tauri/src/anki_image_occlusion.rs
+++ b/src-tauri/src/anki_image_occlusion.rs
@@ -8,9 +8,9 @@
 //! 1. **校验**：`validate_spec` 把外部（LLM / 前端编辑器）产出的
 //!    [`OcclusionSpec`] 收敛为 [`ValidatedOcclusionSpec`]（越界 / 过度重叠 /
 //!    空盒 / 非法 cloze 序号一律结构化拒绝，绝不静默修剪语义）。
-//! 2. **导出**：`build_card_fields` 生成与既有 APKG 导出器兼容的
-//!    Cloze 字段约定（`Text` 含 `<img>` + `{{cN::label}}`，
-//!    `extra_fields["_occlusion"]` 存归一化 spec JSON 供原生渲染/再编辑）。
+//! 2. **草稿字段**：`build_card_fields` 生成候选 Cloze `Text` 与
+//!    `extra_fields["_occlusion"]` spec，供应用内渲染及后续导出接线使用。
+//!    当前生产入库/导出尚未消费完整字段集合，因此产品只呈现草稿预览语义。
 //! 3. **启发式建议**：`propose_boxes_from_image_desc` 从 VlmFull/VlmLight
 //!    已产出的 `[IMAGE_DESC: ...]` 条目文本中提取标签并按网格布局出候选盒，
 //!    作为「无坐标 VLM → 有坐标遮挡」的零成本首版桥（无图测试不碰模型）。
@@ -19,16 +19,15 @@
 //!
 //! - 模块内一律使用 **归一化坐标**：`x/y/w/h ∈ [0,1]`，原点左上角。
 //!   归一化让 spec 与图片实际分辨率解耦——同一 spec 可套用缩略图与原图。
-//! - 像素换算只发生在渲染/导出边界（`to_pixel_boxes`），带
+//! - 像素换算只发生在渲染/字段构造边界（`to_pixel_boxes`），带
 //!   四舍五入 + 边界收敛 + 最小 1px 保证，有测试锁定。
 //!
-//! ## 与 Anki 的兼容性
+//! ## 当前产品边界
 //!
 //! Anki 23.10+ 原生 Image Occlusion note type 的 `Occlusion` 字段本质是
-//! cloze 语法包裹的矩形描述。本模块首版不引入新 note type，而是复用
-//! 仓库既有 Cloze 导出路径（`apkg_exporter_service` 的 `Text`/`Extra` 字段），
-//! 保证任何 Anki 版本可导入可复习；结构化 spec 以 `_occlusion` extra 字段
-//! 随卡携带，后续版本可无损升级为原生 IO note type（见 round4 文档）。
+//! cloze 语法包裹的矩形描述。本模块只构造草稿字段；生产管线目前没有把候选
+//! `Text`、图片媒体和 `_occlusion` 转换为 APKG/AnkiConnect 可复习 note。
+//! 在该转换与端到端测试接通前，不得宣称与 Anki 图像遮挡导出兼容。
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -41,7 +40,7 @@ use std::collections::HashMap;
 /// 与 `_qa_flags` 同风格：下划线前缀表示机器协议字段，非用户内容。
 pub const OCCLUSION_FIELD: &str = "_occlusion";
 
-/// 自动生成卡片附带的 tag，前端/导出侧可按此识别遮挡卡。
+/// 自动生成卡片附带的 tag，前端及后续转换侧可按此识别遮挡草稿。
 pub const OCCLUSION_TAG: &str = "image-occlusion";
 
 /// VlmFull → 流式生成之间传递遮挡草稿的内部行协议。
@@ -118,8 +117,7 @@ pub struct OcclusionSpec {
 }
 
 /// 校验通过后的 spec：所有盒都有合法 cloze 序号与非空标签。
-/// 只能通过 [`validate_spec`] 构造，是后续导出/渲染 API 的唯一输入类型，
-/// 用类型系统保证「未校验的 spec 不可能被导出」。
+/// 只能通过 [`validate_spec`] 构造，是后续字段构造/渲染 API 的唯一输入类型。
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ValidatedOcclusionSpec {
@@ -169,7 +167,7 @@ pub struct PixelBox {
     pub cloze_index: u32,
 }
 
-/// 导出字段约定产物：调用方据此填充 `AnkiCard`。
+/// 遮挡草稿字段约定产物；后续接通转换器时可据此填充 `AnkiCard`。
 ///
 /// - `text` → `AnkiCard.text`（Cloze note type 的 `Text` 字段）；
 /// - `extra_fields` → 合并进 `AnkiCard.extra_fields`
@@ -373,7 +371,7 @@ fn truncate_chars(s: &str, max_chars: usize) -> String {
 }
 
 // ============================================================================
-// 像素换算（渲染/导出边界）
+// 像素换算（渲染/字段构造边界）
 // ============================================================================
 
 /// 把归一化盒换算为像素盒。
@@ -410,10 +408,12 @@ pub fn to_pixel_boxes(spec: &ValidatedOcclusionSpec, img_w: u32, img_h: u32) -> 
 }
 
 // ============================================================================
-// 导出字段约定
+// 草稿字段约定
 // ============================================================================
 
-/// 从校验后的 spec 生成 Cloze 导出字段。
+/// 从校验后的 spec 生成候选 Cloze 字段。
+///
+/// 当前生产入库/导出尚未消费完整返回值；本函数本身不代表导出闭环已接通。
 ///
 /// `Text` 字段形如（`image_file_name` 是 APKG 包内媒体文件名，
 /// 由调用方从 `image_ref` 解析后传入；为 `None` 时省略 `<img>`，
@@ -471,7 +471,7 @@ pub fn build_card_fields(
     }
 }
 
-/// 从 `extra_fields` 解析回遮挡 spec（前端/导出回读路径）。
+/// 从 `extra_fields` 解析回遮挡 spec（前端/后续转换回读路径）。
 /// 返回 `None` 表示无 `_occlusion` 字段或 JSON 不合法。
 pub fn parse_occlusion_field(extra_fields: &HashMap<String, String>) -> Option<OcclusionSpec> {
     let raw = extra_fields.get(OCCLUSION_FIELD)?;

--- a/src-tauri/src/apkg_importer_service.rs
+++ b/src-tauri/src/apkg_importer_service.rs
@@ -46,6 +46,7 @@ pub const MEDIA_SKIP_REASON_MEDIA_DIR_UNAVAILABLE: &str = "media_dir_unavailable
 pub const MEDIA_SKIP_REASON_UNSAFE_FILENAME: &str = "unsafe_filename";
 pub const MEDIA_SKIP_REASON_ENTRY_MISSING: &str = "entry_missing";
 pub const MEDIA_SKIP_REASON_ENTRY_OVERSIZED: &str = "entry_oversized";
+pub const MEDIA_SKIP_REASON_FILENAME_CONFLICT: &str = "filename_conflict";
 pub const MEDIA_SKIP_REASON_IO_ERROR: &str = "io_error";
 pub const MEDIA_SKIP_REASON_ORPHAN_ENTRY: &str = "orphan_entry";
 /// 每个跳过原因在报告中最多列出的文件名数（count 始终是全量计数）。
@@ -117,7 +118,7 @@ pub struct ApkgMediaSkip {
 pub struct ApkgMediaReport {
     /// 包内声明的媒体条目总数（media 清单键 ∪ zip 数字媒体条目，去重）。
     pub declared: usize,
-    /// 成功落盘（或按文件名复用已有文件）的媒体数。
+    /// 成功落盘（或同名且内容逐字节一致而复用）的媒体条目数。
     pub imported: usize,
     /// declared - imported。
     pub skipped: usize,
@@ -653,7 +654,7 @@ fn sanitize_media_filename(raw: &str) -> Option<String> {
 
 /// 把媒体清单声明且包内存在的媒体流式解出到 `media_dir`。
 /// 返回（「清单文件名 → 落盘绝对路径」映射, 成功导入的清单键数）；
-/// 同名文件复用只落盘一次但每个清单键都计入成功。
+/// 同名文件仅在包内条目与既有文件逐字节一致时复用；内容冲突必须跳过。
 /// 所有非致命问题写入 `warnings`，并同步记入结构化 `skip_tracker`（禁止静默丢弃）。
 /// `modern_package` 为 true（anki21b 包）时媒体条目本身通常是 zstd 帧，需先解压。
 #[allow(clippy::too_many_arguments)]
@@ -703,28 +704,8 @@ fn extract_declared_media<R: Read + Seek>(
             skip_tracker.record(MEDIA_SKIP_REASON_UNSAFE_FILENAME, raw_name.clone());
             continue;
         }
-        match std::fs::symlink_metadata(&target) {
-            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
-                // `Path::exists` follows links, so a dangling symlink used to
-                // fall through to File::create and create/truncate its target
-                // outside media_dir. Never reuse or follow non-regular entries.
-                warnings.push(format!("媒体目标已存在但不是普通文件，已跳过: {file_name}"));
-                skip_tracker.record(MEDIA_SKIP_REASON_IO_ERROR, file_name.clone());
-                continue;
-            }
-            Ok(_) => {
-                // Anki 媒体按文件名寻址：既有同名普通文件视为同一媒体，直接复用
-                media_paths.insert(raw_name.clone(), target.to_string_lossy().to_string());
-                imported_keys += 1;
-                continue;
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => {
-                warnings.push(format!("检查媒体目标失败，已跳过 {file_name}: {error}"));
-                skip_tracker.record(MEDIA_SKIP_REASON_IO_ERROR, file_name.clone());
-                continue;
-            }
-        }
+        // 必须先读取包内条目，再考虑复用同名目标。否则清单缺失的条目会因本地
+        // 恰有同名文件而被误报成功。
         let mut entry = match archive.by_name(key) {
             Ok(entry) => entry,
             Err(_) => {
@@ -735,6 +716,74 @@ fn extract_declared_media<R: Read + Seek>(
                 continue;
             }
         };
+        let existing_metadata = match std::fs::symlink_metadata(&target) {
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+                // `Path::exists` follows links, so a dangling symlink used to
+                // fall through to File::create and create/truncate its target
+                // outside media_dir. Never reuse or follow non-regular entries.
+                warnings.push(format!("媒体目标已存在但不是普通文件，已跳过: {file_name}"));
+                skip_tracker.record(MEDIA_SKIP_REASON_IO_ERROR, file_name.clone());
+                continue;
+            }
+            Ok(metadata) => Some(metadata),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => {
+                warnings.push(format!("检查媒体目标失败，已跳过 {file_name}: {error}"));
+                skip_tracker.record(MEDIA_SKIP_REASON_IO_ERROR, file_name.clone());
+                continue;
+            }
+        };
+        if existing_metadata.is_some() {
+            // 先把包内（现代包为解压后的）内容写入有界临时文件，再与既有目标
+            // 逐字节比较。只凭文件名复用会让卡片静默链接到旧内容。
+            let mut staged = match NamedTempFile::new() {
+                Ok(file) => file,
+                Err(error) => {
+                    warnings.push(format!(
+                        "创建媒体校验临时文件失败，已跳过 {file_name}: {error}"
+                    ));
+                    skip_tracker.record(MEDIA_SKIP_REASON_IO_ERROR, file_name.clone());
+                    continue;
+                }
+            };
+            let copy_result = copy_media_entry(
+                &mut entry,
+                staged.as_file_mut(),
+                limits.max_entry_bytes,
+                modern_package,
+            );
+            match copy_result {
+                Ok(written) if written > limits.max_entry_bytes => {
+                    warnings.push(format!(
+                        "媒体文件解压后超过 {} 字节上限，已跳过: {file_name}",
+                        limits.max_entry_bytes
+                    ));
+                    skip_tracker.record(MEDIA_SKIP_REASON_ENTRY_OVERSIZED, file_name.clone());
+                }
+                Ok(_) => match media_files_have_equal_contents(staged.path(), &target) {
+                    Ok(true) => {
+                        media_paths.insert(raw_name.clone(), target.to_string_lossy().to_string());
+                        imported_keys += 1;
+                    }
+                    Ok(false) => {
+                        warnings.push(format!(
+                            "媒体目录已有同名但内容不同的文件，已跳过: {file_name}"
+                        ));
+                        skip_tracker.record(MEDIA_SKIP_REASON_FILENAME_CONFLICT, file_name.clone());
+                    }
+                    Err(error) => {
+                        warnings.push(format!("校验同名媒体内容失败，已跳过 {file_name}: {error}"));
+                        skip_tracker.record(MEDIA_SKIP_REASON_IO_ERROR, file_name.clone());
+                    }
+                },
+                Err(error) => {
+                    warnings.push(format!("解压媒体文件失败，已跳过 {file_name}: {error}"));
+                    skip_tracker.record(MEDIA_SKIP_REASON_IO_ERROR, file_name.clone());
+                }
+            }
+            continue;
+        }
+
         // create_new maps to O_CREAT|O_EXCL on Unix and refuses symlinks. This
         // closes the check/create race without ever truncating an existing path.
         let mut output = match OpenOptions::new()
@@ -750,12 +799,12 @@ fn extract_declared_media<R: Read + Seek>(
             }
         };
         // 解压炸弹防护：实际解压量超过单条目上限时中止并删除半成品
-        let copy_result = if modern_package {
-            copy_possibly_zstd_media(&mut entry, &mut output, limits.max_entry_bytes)
-        } else {
-            let mut limited = entry.by_ref().take(limits.max_entry_bytes + 1);
-            std::io::copy(&mut limited, &mut output).map_err(|error| error.to_string())
-        };
+        let copy_result = copy_media_entry(
+            &mut entry,
+            &mut output,
+            limits.max_entry_bytes,
+            modern_package,
+        );
         match copy_result {
             Ok(written) if written > limits.max_entry_bytes => {
                 drop(output);
@@ -779,6 +828,42 @@ fn extract_declared_media<R: Read + Seek>(
         }
     }
     (media_paths, imported_keys)
+}
+
+/// 把单个媒体条目按包版本流式解出，最多读取 `max_bytes + 1` 字节。
+fn copy_media_entry<R: Read>(
+    entry: &mut R,
+    output: &mut File,
+    max_bytes: u64,
+    modern_package: bool,
+) -> Result<u64, String> {
+    if modern_package {
+        copy_possibly_zstd_media(entry, output, max_bytes)
+    } else {
+        let mut limited = entry.take(max_bytes + 1);
+        std::io::copy(&mut limited, output).map_err(|error| error.to_string())
+    }
+}
+
+/// 逐字节比较两个普通文件；长度先行可避免不必要的全量读取。
+fn media_files_have_equal_contents(left: &Path, right: &Path) -> std::io::Result<bool> {
+    if std::fs::metadata(left)?.len() != std::fs::metadata(right)?.len() {
+        return Ok(false);
+    }
+    let mut left = File::open(left)?;
+    let mut right = File::open(right)?;
+    let mut left_buffer = [0u8; 64 * 1024];
+    let mut right_buffer = [0u8; 64 * 1024];
+    loop {
+        let left_read = left.read(&mut left_buffer)?;
+        let right_read = right.read(&mut right_buffer)?;
+        if left_read != right_read || left_buffer[..left_read] != right_buffer[..right_read] {
+            return Ok(false);
+        }
+        if left_read == 0 {
+            return Ok(true);
+        }
+    }
 }
 
 /// 现代 APKG 的媒体条目通常是 zstd 帧：探测 magic 后解压写入；
@@ -3953,16 +4038,16 @@ mod tests {
         assert!(value.get("documentId").is_some());
     }
 
-    /// 同名文件复用：同一文件名声明两次只落盘一次，两个清单键都算导入成功。
+    /// 同名且内容相同可安全复用：同一文件名声明两次只落盘一次。
     #[test]
-    fn media_import_reuses_existing_file_for_duplicate_names() {
+    fn media_import_reuses_duplicate_names_only_when_contents_match() {
         let (db, _dir) = setup_migrated_db();
         let media_dir = tempdir().expect("media dir");
         let apkg = make_apkg(vec![
             ("collection.anki2", make_basic_collection("front")),
             ("media", br#"{"0":"dup.png","1":"dup.png"}"#.to_vec()),
             ("0", b"dup-bytes".to_vec()),
-            ("1", b"other-bytes".to_vec()),
+            ("1", b"dup-bytes".to_vec()),
         ]);
         let result = ApkgImporterService::new(db)
             .with_media_dir(media_dir.path().to_path_buf())
@@ -3971,10 +4056,108 @@ mod tests {
         assert_eq!(result.media_imported, 2);
         assert_eq!(result.media_skipped, 0);
         assert!(result.media_report.skips.is_empty());
-        // 首个来源生效（Anki 按文件名寻址）
         assert_eq!(
             std::fs::read(media_dir.path().join("dup.png")).expect("dup bytes"),
             b"dup-bytes"
+        );
+    }
+
+    #[test]
+    fn media_import_rejects_duplicate_name_with_different_contents() {
+        let (db, _dir) = setup_migrated_db();
+        let media_dir = tempdir().expect("media dir");
+        let apkg = make_apkg(vec![
+            ("collection.anki2", make_basic_collection("front")),
+            ("media", br#"{"0":"dup.png","1":"dup.png"}"#.to_vec()),
+            ("0", b"first-bytes".to_vec()),
+            ("1", b"different-bytes".to_vec()),
+        ]);
+
+        let result = ApkgImporterService::new(db)
+            .with_media_dir(media_dir.path().to_path_buf())
+            .import_bytes(&apkg, Some("dup-conflict.apkg"), None)
+            .expect("content conflict must not block card import");
+
+        assert_eq!(result.media_imported, 1);
+        assert_eq!(result.media_skipped, 1);
+        assert_eq!(result.media_report.skips.len(), 1);
+        assert_eq!(
+            result.media_report.skips[0].reason,
+            MEDIA_SKIP_REASON_FILENAME_CONFLICT
+        );
+        assert_eq!(result.media_report.skips[0].filenames, vec!["dup.png"]);
+        assert_eq!(
+            std::fs::read(media_dir.path().join("dup.png")).expect("first media remains"),
+            b"first-bytes"
+        );
+    }
+
+    #[test]
+    fn media_import_does_not_reuse_preexisting_name_with_different_contents() {
+        let (db, _dir) = setup_migrated_db();
+        let media_dir = tempdir().expect("media dir");
+        std::fs::write(media_dir.path().join("same-name.png"), b"old-library-bytes")
+            .expect("seed existing media");
+        let collection = make_collection(
+            json!({ "100": model_json(0, &[("Front", 0), ("Back", 1)]) }),
+            &[(1, 100, "", "front <img src=\"same-name.png\">\u{1f}back")],
+            &[(10, 1, 0)],
+        );
+        let apkg = make_apkg(vec![
+            ("collection.anki2", collection),
+            ("media", br#"{"0":"same-name.png"}"#.to_vec()),
+            ("0", b"new-package-bytes".to_vec()),
+        ]);
+
+        let result = ApkgImporterService::new(db.clone())
+            .with_media_dir(media_dir.path().to_path_buf())
+            .import_bytes(&apkg, Some("existing-conflict.apkg"), None)
+            .expect("content conflict must not block card import");
+
+        assert_eq!(result.media_imported, 0);
+        assert_eq!(result.media_skipped, 1);
+        assert_eq!(
+            result.media_report.skips[0].reason,
+            MEDIA_SKIP_REASON_FILENAME_CONFLICT
+        );
+        assert_eq!(
+            std::fs::read(media_dir.path().join("same-name.png")).expect("existing media remains"),
+            b"old-library-bytes"
+        );
+        let cards = db
+            .get_cards_for_document(&result.document_id)
+            .expect("imported cards");
+        assert!(
+            cards[0].images.is_empty(),
+            "conflicting local media must not be linked to the imported card"
+        );
+    }
+
+    #[test]
+    fn media_import_does_not_reuse_existing_name_when_archive_entry_is_missing() {
+        let (db, _dir) = setup_migrated_db();
+        let media_dir = tempdir().expect("media dir");
+        std::fs::write(media_dir.path().join("existing.png"), b"old-bytes")
+            .expect("seed existing media");
+        let apkg = make_apkg(vec![
+            ("collection.anki2", make_basic_collection("front")),
+            ("media", br#"{"0":"existing.png"}"#.to_vec()),
+        ]);
+
+        let result = ApkgImporterService::new(db)
+            .with_media_dir(media_dir.path().to_path_buf())
+            .import_bytes(&apkg, Some("missing-existing.apkg"), None)
+            .expect("missing media entry must degrade without blocking cards");
+
+        assert_eq!(result.media_imported, 0);
+        assert_eq!(result.media_skipped, 1);
+        assert_eq!(
+            result.media_report.skips[0].reason,
+            MEDIA_SKIP_REASON_ENTRY_MISSING
+        );
+        assert_eq!(
+            std::fs::read(media_dir.path().join("existing.png")).expect("existing media remains"),
+            b"old-bytes"
         );
     }
 

--- a/src/command-palette/modules/anki.commands.ts
+++ b/src/command-palette/modules/anki.commands.ts
@@ -14,11 +14,11 @@ import type { Command } from '../registry/types';
 
 /** 后端 import_apkg_to_library 返回结构（字段与 Rust ApkgImportResult serde 输出一致） */
 interface ApkgImportResult {
-  document_id: string;
-  imported_cards: number;
-  imported_templates: number;
-  media_skipped: number;
-  media_imported: number;
+  documentId: string;
+  importedCards: number;
+  importedTemplates: number;
+  mediaSkipped: number;
+  mediaImported: number;
   warnings?: string[];
 }
 
@@ -49,7 +49,7 @@ export const ankiCommands: Command[] = [
         deps.showNotification(
           'success',
           i18next.t('command_palette:notifications.apkg_import_success', {
-            cards: result.imported_cards,
+            cards: result.importedCards,
             defaultValue: 'Anki deck imported: {{cards}} cards',
           }),
         );

--- a/src/features/flashcards/store/libraryStore.ts
+++ b/src/features/flashcards/store/libraryStore.ts
@@ -370,10 +370,10 @@ export const useFlashcardsLibraryStore = create<FlashcardsLibraryState>((set, ge
           filters: [{ name: 'Anki Deck', extensions: ['apkg'] }],
         });
         if (!path) return { status: 'canceled' as const };
-        const result = await invoke<{ imported_cards?: number }>('import_apkg_to_library', { path });
+        const result = await invoke<{ importedCards?: number }>('import_apkg_to_library', { path });
         requestFlashcardsDueRefresh();
         await get().refresh();
-        return { status: 'imported' as const, importedCards: result?.imported_cards ?? 0 };
+        return { status: 'imported' as const, importedCards: result?.importedCards ?? 0 };
       } catch (error) {
         const message = getErrorMessage(error) || i18n.t('flashcards:library.import.failed');
         set({ actionError: message });

--- a/src/locales/en-US/anki.json
+++ b/src/locales/en-US/anki.json
@@ -1101,9 +1101,9 @@
       "disabledHint": "This run did not use your review history"
     },
     "occlusion": {
-      "title": "Image occlusion",
-      "previewBadge": "Image occlusion",
-      "draftHint": "This is an automatically generated occlusion draft; check mask placement and answers before exporting",
+      "title": "Image occlusion draft preview",
+      "previewBadge": "Occlusion draft preview",
+      "draftHint": "This is an in-app draft preview; it is not currently exported as a reviewable Anki image-occlusion card",
       "imageAlt": "Image occlusion card",
       "imageUnavailable": "The occlusion image could not be loaded; text content was preserved",
       "invalidSpec": "Invalid occlusion data was ignored and the card is shown normally",

--- a/src/locales/en-US/chatV2.json
+++ b/src/locales/en-US/chatV2.json
@@ -762,8 +762,8 @@
       "synced": "Synced",
       "syncToAnki": "Sync to Anki",
       "occlusion": {
-        "badge": "Image occlusion",
-        "draftHint": "Automatically generated occlusion draft; check it before exporting",
+        "badge": "Occlusion draft preview",
+        "draftHint": "In-app preview only; it is not currently exported as a reviewable Anki image-occlusion card",
         "imageAlt": "Image occlusion card",
         "imageUnavailable": "The occlusion image could not be loaded; text content was preserved"
       },

--- a/src/locales/zh-CN/anki.json
+++ b/src/locales/zh-CN/anki.json
@@ -1101,9 +1101,9 @@
       "disabledHint": "本次制卡未参考历史复习数据"
     },
     "occlusion": {
-      "title": "图像遮挡",
-      "previewBadge": "图像遮挡",
-      "draftHint": "这是自动生成的遮挡草稿，请在导出前检查遮挡位置和答案",
+      "title": "图像遮挡草稿预览",
+      "previewBadge": "遮挡草稿预览",
+      "draftHint": "这是应用内草稿预览；当前不会导出为可复习的 Anki 图像遮挡卡",
       "imageAlt": "图像遮挡卡片",
       "imageUnavailable": "无法加载遮挡卡图片，已保留文字内容",
       "invalidSpec": "遮挡数据无效，已按普通卡片显示",

--- a/src/locales/zh-CN/chatV2.json
+++ b/src/locales/zh-CN/chatV2.json
@@ -762,8 +762,8 @@
       "synced": "已同步",
       "syncToAnki": "同步到 Anki",
       "occlusion": {
-        "badge": "图像遮挡",
-        "draftHint": "自动遮挡草稿，请在导出前检查",
+        "badge": "遮挡草稿预览",
+        "draftHint": "仅供应用内预览，当前不会导出为可复习的 Anki 图像遮挡卡",
         "imageAlt": "图像遮挡卡片",
         "imageUnavailable": "遮挡图片无法加载，已保留文字内容"
       },

--- a/tests/vitest/flashcards/LibraryScreen.test.tsx
+++ b/tests/vitest/flashcards/LibraryScreen.test.tsx
@@ -21,30 +21,40 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, fallback?: unknown) => ({
-      'library.title': '卡片库',
-      'library.loading': '加载中…',
-      'library.total': '卡片总数',
-      'library.refresh': '刷新',
-      'library.searchLabel': '搜索卡片',
-      'library.searchPlaceholder': '搜索正面 / 背面 / 标签',
-      'library.search': '搜索',
-      'library.dismiss': '关闭',
-      'library.retry': '重试',
-      'library.empty': '库中暂无卡片',
-      'library.state.notEnqueued': '未入队',
-      'library.state.new': '新卡',
-      'library.state.review': '复习中',
-      'library.startReview': '复习',
-      'library.enqueue': '入队',
-      'library.resume': '恢复',
-      'library.suspend': '暂停',
-      'library.delete': '删除',
-      'library.previous': '上一页',
-      'library.next': '下一页',
-      'library.confirmDelete': '确定删除这张卡片吗？',
-      'common:cancel': '取消',
-    }[key] ?? (typeof fallback === 'string' ? fallback : key)),
+    t: (key: string, fallback?: unknown) => {
+      if (
+        key === 'library.import.success'
+        && typeof fallback === 'object'
+        && fallback !== null
+        && 'count' in fallback
+      ) {
+        return `成功导入 ${String(fallback.count)} 张卡片`;
+      }
+      return {
+        'library.title': '卡片库',
+        'library.loading': '加载中…',
+        'library.total': '卡片总数',
+        'library.refresh': '刷新',
+        'library.searchLabel': '搜索卡片',
+        'library.searchPlaceholder': '搜索正面 / 背面 / 标签',
+        'library.search': '搜索',
+        'library.dismiss': '关闭',
+        'library.retry': '重试',
+        'library.empty': '库中暂无卡片',
+        'library.state.notEnqueued': '未入队',
+        'library.state.new': '新卡',
+        'library.state.review': '复习中',
+        'library.startReview': '复习',
+        'library.enqueue': '入队',
+        'library.resume': '恢复',
+        'library.suspend': '暂停',
+        'library.delete': '删除',
+        'library.previous': '上一页',
+        'library.next': '下一页',
+        'library.confirmDelete': '确定删除这张卡片吗？',
+        'common:cancel': '取消',
+      }[key] ?? (typeof fallback === 'string' ? fallback : key);
+    },
   }),
   initReactI18next: { type: '3rdParty', init: () => undefined },
 }));
@@ -135,7 +145,7 @@ describe('LibraryScreen', () => {
     mocks.suspendCard.mockResolvedValue({ state: {}, changed: true });
     mocks.unsuspendCard.mockResolvedValue({ state: {}, changed: true });
     mocks.pickSingleFile.mockResolvedValue('/tmp/deck.apkg');
-    mocks.invoke.mockResolvedValue({ imported_cards: 12 });
+    mocks.invoke.mockResolvedValue({ importedCards: 12 });
   });
 
   afterEach(() => {
@@ -299,7 +309,7 @@ describe('LibraryScreen', () => {
     expect(mocks.listCards).toHaveBeenCalledTimes(2);
     expect(mocks.showGlobalNotification).toHaveBeenCalledWith(
       'success',
-      'library.import.success',
+      '成功导入 12 张卡片',
     );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

收口 APKG 导入计数/同名媒体错链，以及 critic 修订污染金标。图像遮挡在完整导出闭环未完成前改为草稿预览语义，去掉「任何 Anki 版本可导入可复习」类宣称。

### Changes
- 前端按 camelCase `importedCards` 读导入结果，测试 mock 同步纠正
- 同名媒体按内容校验，不同内容不得复用
- gold-set / critic 收集排除 `llm_critic_revised`
- 遮挡相关文案降级为草稿预览

### How to test
- 窄测：`LibraryScreen` / APKG importer / gold-set 相关用例
- 本 PR 未跑全量 `npm run build` / `cargo build`

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ffbe94-512c-4a8c-abad-f6378cada875?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ffbe94-512c-4a8c-abad-f6378cada875&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

