### PR TITLE
fix: commit restore crypto keys with slot cutover

### DIFF
--- a/src-tauri/src/data_governance/backup/mod.rs
+++ b/src-tauri/src/data_governance/backup/mod.rs
@@ -344,6 +344,40 @@ fn remove_crypto_path(path: &Path) -> std::io::Result<()> {
     }
 }
 
+fn rollback_published_crypto(
+    target_master: &Path,
+    target_secure: &Path,
+    rollback_master: &Path,
+    rollback_secure: &Path,
+    installed_master: bool,
+    installed_secure: bool,
+    moved_master: bool,
+    moved_secure: bool,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+    if installed_master {
+        if let Err(error) = remove_crypto_path(target_master) {
+            errors.push(format!("删除新主密钥失败: {}", error));
+        }
+    }
+    if installed_secure {
+        if let Err(error) = remove_crypto_path(target_secure) {
+            errors.push(format!("删除新安全目录失败: {}", error));
+        }
+    }
+    if moved_master {
+        if let Err(error) = fs::rename(rollback_master, target_master) {
+            errors.push(format!("恢复旧主密钥失败: {}", error));
+        }
+    }
+    if moved_secure {
+        if let Err(error) = fs::rename(rollback_secure, target_secure) {
+            errors.push(format!("恢复旧安全目录失败: {}", error));
+        }
+    }
+    errors
+}
+
 /// 生成安全且高概率唯一的备份 ID（目录名）
 ///
 /// 约束：
@@ -3518,12 +3552,29 @@ impl BackupManager {
         manifest: &BackupManifest,
         backup_subdir: &Path,
     ) -> Result<usize, BackupError> {
+        self.restore_crypto_keys_from_manifest_transactional(manifest, backup_subdir, |_| Ok(()))
+    }
+
+    /// Publish manifest-verified crypto material and keep the previous global
+    /// generation available until `after_publish` durably commits the matching
+    /// restore cutover. If that commit fails, both `.master_key` and `.secure`
+    /// are restored to their exact pre-publication state.
+    pub(crate) fn restore_crypto_keys_from_manifest_transactional<F>(
+        &self,
+        manifest: &BackupManifest,
+        backup_subdir: &Path,
+        after_publish: F,
+    ) -> Result<usize, BackupError>
+    where
+        F: FnOnce(usize) -> Result<(), BackupError>,
+    {
         let plan = manifest
             .crypto_restore_plan()
             .ok_or_else(|| BackupError::Manifest("备份缺少 crypto restore plan".to_string()))?;
         let actual_files = Self::collect_backup_files_under(backup_subdir, "crypto")?;
         if matches!(plan.status, CoverageStatus::Absent | CoverageStatus::Empty) {
             if actual_files.is_empty() {
+                after_publish(0)?;
                 return Ok(0);
             }
             return Err(BackupError::Manifest(
@@ -3556,7 +3607,7 @@ impl BackupManager {
             }
         }
         Self::verify_crypto_material(manifest, backup_subdir)?;
-        self.restore_crypto_keys(backup_subdir)
+        self.restore_crypto_keys_transactional(backup_subdir, after_publish)
     }
 
     /// 从备份目录恢复加密密钥文件到应用数据目录
@@ -3564,6 +3615,17 @@ impl BackupManager {
     /// 恢复 `.master_key` 和 `.secure/` 目录，使跨设备恢复后 API 密钥可正常解密。
     /// 仅在备份中包含 crypto/ 子目录时执行。
     pub fn restore_crypto_keys(&self, backup_subdir: &Path) -> Result<usize, BackupError> {
+        self.restore_crypto_keys_transactional(backup_subdir, |_| Ok(()))
+    }
+
+    fn restore_crypto_keys_transactional<F>(
+        &self,
+        backup_subdir: &Path,
+        after_publish: F,
+    ) -> Result<usize, BackupError>
+    where
+        F: FnOnce(usize) -> Result<(), BackupError>,
+    {
         let backup_metadata = fs::symlink_metadata(backup_subdir).map_err(|e| {
             BackupError::RestoreFailed(format!("无法检查备份目录，目标密钥保持不变: {}", e))
         })?;
@@ -3575,7 +3637,10 @@ impl BackupManager {
 
         let crypto_src = backup_subdir.join("crypto");
         match fs::symlink_metadata(&crypto_src) {
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                after_publish(0)?;
+                return Ok(0);
+            }
             Ok(metadata) if !metadata.file_type().is_symlink() && metadata.is_dir() => {}
             Ok(_) => {
                 return Err(BackupError::RestoreFailed(
@@ -3726,6 +3791,7 @@ impl BackupManager {
             })?;
         }
         if !has_master && !has_secure {
+            after_publish(0)?;
             return Ok(0);
         }
 
@@ -3779,27 +3845,16 @@ impl BackupManager {
         })();
 
         if let Err(commit_error) = commit_result {
-            let mut rollback_errors = Vec::new();
-            if installed_master {
-                if let Err(e) = remove_crypto_path(&target_master) {
-                    rollback_errors.push(format!("删除新主密钥失败: {}", e));
-                }
-            }
-            if installed_secure {
-                if let Err(e) = remove_crypto_path(&target_secure) {
-                    rollback_errors.push(format!("删除新安全目录失败: {}", e));
-                }
-            }
-            if moved_master {
-                if let Err(e) = fs::rename(&rollback_master, &target_master) {
-                    rollback_errors.push(format!("恢复旧主密钥失败: {}", e));
-                }
-            }
-            if moved_secure {
-                if let Err(e) = fs::rename(&rollback_secure, &target_secure) {
-                    rollback_errors.push(format!("恢复旧安全目录失败: {}", e));
-                }
-            }
+            let rollback_errors = rollback_published_crypto(
+                &target_master,
+                &target_secure,
+                &rollback_master,
+                &rollback_secure,
+                installed_master,
+                installed_secure,
+                moved_master,
+                moved_secure,
+            );
             return Err(BackupError::RestoreFailed(if rollback_errors.is_empty() {
                 format!("密钥原子提交失败，已恢复原目标: {}", commit_error)
             } else {
@@ -3811,20 +3866,50 @@ impl BackupManager {
             }));
         }
 
-        if has_master {
-            crate::secure_store::SecureStore::restrict_permissions(&target_master, false);
-        }
-        if has_secure {
-            crate::secure_store::SecureStore::restrict_permissions(&target_secure, true);
-            for entry in fs::read_dir(&target_secure)? {
-                let entry = entry?;
-                if entry.file_type()?.is_file() {
-                    crate::secure_store::SecureStore::restrict_permissions(&entry.path(), false);
+        let restored = usize::from(has_master) + secure_file_count;
+        let publish_result = (|| -> Result<(), BackupError> {
+            if has_master {
+                crate::secure_store::SecureStore::restrict_permissions(&target_master, false);
+            }
+            if has_secure {
+                crate::secure_store::SecureStore::restrict_permissions(&target_secure, true);
+                for entry in fs::read_dir(&target_secure)? {
+                    let entry = entry?;
+                    if entry.file_type()?.is_file() {
+                        crate::secure_store::SecureStore::restrict_permissions(
+                            &entry.path(),
+                            false,
+                        );
+                    }
                 }
             }
-        }
+            after_publish(restored)
+        })();
 
-        let restored = usize::from(has_master) + secure_file_count;
+        if let Err(cutover_error) = publish_result {
+            let rollback_errors = rollback_published_crypto(
+                &target_master,
+                &target_secure,
+                &rollback_master,
+                &rollback_secure,
+                installed_master,
+                installed_secure,
+                moved_master,
+                moved_secure,
+            );
+            return Err(BackupError::RestoreFailed(if rollback_errors.is_empty() {
+                format!(
+                    "密钥发布后的恢复切槽提交失败，已恢复旧密钥: {}",
+                    cutover_error
+                )
+            } else {
+                format!(
+                    "密钥发布后的恢复切槽提交失败且旧密钥回滚不完整: {}; {}",
+                    cutover_error,
+                    rollback_errors.join("; ")
+                )
+            }));
+        }
         info!("[Restore] 加密密钥原子恢复完成: {} 个文件", restored);
         Ok(restored)
     }

--- a/src-tauri/src/data_governance/commands_restore.rs
+++ b/src-tauri/src/data_governance/commands_restore.rs
@@ -81,6 +81,30 @@ fn write_restore_activation_marker(
     )
 }
 
+fn publish_restore_keys_and_commit_cutover<F>(
+    manager: &super::backup::BackupManager,
+    manifest: &super::backup::BackupManifest,
+    backup_subdir: &Path,
+    commit_cutover: F,
+) -> Result<usize, String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    let keys_required = manifest.key_policy == super::backup::BackupKeyPolicy::IncludedLocal;
+    manager
+        .restore_crypto_keys_from_manifest_transactional(manifest, backup_subdir, move |restored| {
+            if keys_required && restored == 0 {
+                return Err(super::backup::BackupError::RestoreFailed(
+                    "备份声明包含加密密钥，但未恢复任何密钥文件".to_string(),
+                ));
+            }
+            commit_cutover().map_err(|error| {
+                super::backup::BackupError::RestoreFailed(format!("登记恢复切槽失败: {}", error))
+            })
+        })
+        .map_err(|error| error.to_string())
+}
+
 /// Commit device/cursor generation only after the restored slot has become
 /// active and its migrations have succeeded during startup.
 pub(crate) fn finalize_restore_activation(active_dir: &Path) -> Result<bool, String> {
@@ -857,27 +881,6 @@ async fn execute_restore_with_progress(
         return;
     }
 
-    // ============ 阶段 3a: 恢复加密密钥（跨设备恢复支持） ============
-    manager.set_app_data_dir(inactive_dir.clone());
-    match manager.restore_crypto_keys(&backup_subdir) {
-        Ok(count) => {
-            if manifest.key_policy == super::backup::BackupKeyPolicy::IncludedLocal && count == 0 {
-                job_ctx.fail("备份声明包含加密密钥，但未恢复任何密钥文件".to_string());
-                return;
-            }
-            if count > 0 {
-                info!(
-                    "[data_governance] 加密密钥恢复完成: {} 个文件（API 密钥可跨设备解密）",
-                    count
-                );
-            }
-        }
-        Err(e) => {
-            job_ctx.fail(format!("加密密钥恢复失败: {}", e));
-            return;
-        }
-    }
-
     // ============ 阶段 3b: Replace/Assets (80-92%) - 恢复资产文件 ============
     if restore_assets == Some(false) {
         job_ctx.fail("完整快照恢复不能跳过资产；请使用完整恢复".to_string());
@@ -1082,11 +1085,29 @@ async fn execute_restore_with_progress(
         return;
     }
 
-    if let Err(e) = data_space_manager.mark_restore_cutover_pending(inactive_slot, &backup_id) {
-        let _ = set_restore_cutover_maintenance(&app, false);
-        let _ = std::fs::remove_file(inactive_dir.join(RESTORE_ACTIVATION_MARKER));
-        job_ctx.fail(format!("登记恢复切槽失败: {}", e));
-        return;
+    // The candidate is fully restored, migrated, baselined and protected by
+    // the maintenance barrier. Keep the previous global crypto generation in
+    // the publication rollback directory until pending-slot registration is
+    // durable; a registration failure restores the old keys before returning.
+    let restored_crypto_keys =
+        match publish_restore_keys_and_commit_cutover(&manager, &manifest, &backup_subdir, || {
+            data_space_manager
+                .mark_restore_cutover_pending(inactive_slot, &backup_id)
+                .map_err(|error| error.to_string())
+        }) {
+            Ok(count) => count,
+            Err(error) => {
+                let _ = set_restore_cutover_maintenance(&app, false);
+                let _ = std::fs::remove_file(inactive_dir.join(RESTORE_ACTIVATION_MARKER));
+                job_ctx.fail(format!("提交恢复密钥与切槽失败: {}", error));
+                return;
+            }
+        };
+    if restored_crypto_keys > 0 {
+        info!(
+            "[data_governance] 加密密钥与恢复切槽原子提交完成: {} 个文件",
+            restored_crypto_keys
+        );
     }
     info!(
         "[data_governance] 已原子登记下次启动切换到 {}",
@@ -1174,7 +1195,46 @@ async fn execute_restore_with_progress(
 
 #[cfg(test)]
 mod tests {
-    use super::atomic_restore_unavailable_error;
+    use super::{atomic_restore_unavailable_error, publish_restore_keys_and_commit_cutover};
+    use crate::data_governance::backup::{
+        calculate_file_sha256, BackupFile, BackupKeyPolicy, BackupManager, BackupManifest,
+        CoverageStatus,
+    };
+    use crate::data_space::{DataSpaceManager, Slot};
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn crypto_restore_manifest(backup_subdir: &Path) -> BackupManifest {
+        let paths = ["crypto/.master_key", "crypto/.secure/.key_seed"];
+        let files = paths
+            .iter()
+            .map(|relative| {
+                let path = backup_subdir.join(relative);
+                BackupFile {
+                    path: (*relative).to_string(),
+                    size: fs::metadata(&path).unwrap().len(),
+                    sha256: calculate_file_sha256(&path).unwrap(),
+                    database_id: None,
+                }
+            })
+            .collect::<Vec<_>>();
+        let mut manifest = BackupManifest::new("test");
+        manifest.key_policy = BackupKeyPolicy::IncludedLocal;
+        manifest.files = files;
+        let crypto = manifest
+            .coverage
+            .as_mut()
+            .unwrap()
+            .domains
+            .get_mut("crypto")
+            .unwrap();
+        crypto.status = CoverageStatus::Complete;
+        crypto.paths = paths.iter().map(|path| (*path).to_string()).collect();
+        crypto.file_count = crypto.paths.len();
+        crypto.total_size = manifest.files.iter().map(|file| file.size).sum();
+        manifest
+    }
 
     #[test]
     fn atomic_restore_unavailable_refusal_has_stable_code() {
@@ -1184,6 +1244,87 @@ mod tests {
             "atomic-restore refusal must carry a stable code: {error}"
         );
         assert!(error.contains("写入任何恢复数据前中止"));
+    }
+
+    #[test]
+    fn post_key_publication_failure_restores_old_global_keys_and_active_slot() {
+        for old_keys_exist in [true, false] {
+            let app_data = TempDir::new().unwrap();
+            let data_space = DataSpaceManager::new(app_data.path().to_path_buf());
+            data_space.ensure_layout().unwrap();
+            fs::write(data_space.slot_dir(Slot::A).join("active.db"), b"old-slot").unwrap();
+            fs::write(
+                data_space.slot_dir(Slot::B).join("candidate.db"),
+                b"new-slot",
+            )
+            .unwrap();
+
+            if old_keys_exist {
+                fs::write(app_data.path().join(".master_key"), b"old-master").unwrap();
+                let old_secure = app_data.path().join(".secure");
+                fs::create_dir_all(&old_secure).unwrap();
+                fs::write(old_secure.join(".key_seed"), b"old-seed").unwrap();
+                fs::write(old_secure.join("old.enc"), b"old-credential").unwrap();
+            }
+
+            let backup_root = TempDir::new().unwrap();
+            let backup_subdir = backup_root.path().join("snapshot");
+            let backup_secure = backup_subdir.join("crypto/.secure");
+            fs::create_dir_all(&backup_secure).unwrap();
+            fs::write(
+                backup_subdir.join("crypto/.master_key"),
+                b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            )
+            .unwrap();
+            let new_seed = "aa".repeat(32);
+            fs::write(backup_secure.join(".key_seed"), &new_seed).unwrap();
+            let manifest = crypto_restore_manifest(&backup_subdir);
+
+            let mut manager = BackupManager::new(backup_root.path().join("manager"));
+            manager.set_app_data_dir(app_data.path().to_path_buf());
+            let mut failure_injected_after_publication = false;
+            let error = publish_restore_keys_and_commit_cutover(
+                &manager,
+                &manifest,
+                &backup_subdir,
+                || {
+                    failure_injected_after_publication = true;
+                    assert_eq!(
+                        fs::read(app_data.path().join(".master_key")).unwrap(),
+                        b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                    );
+                    assert_eq!(
+                        fs::read_to_string(app_data.path().join(".secure/.key_seed")).unwrap(),
+                        new_seed
+                    );
+                    assert_eq!(data_space.active_slot(), Slot::A);
+                    Err("injected post-key-publication failure".to_string())
+                },
+            )
+            .expect_err("cutover failure after key publication must abort");
+
+            assert!(failure_injected_after_publication);
+            assert!(error.contains("已恢复旧密钥"), "{error}");
+            assert_eq!(data_space.active_slot(), Slot::A);
+            assert!(data_space.restore_cutover_pending().unwrap().is_none());
+            if old_keys_exist {
+                assert_eq!(
+                    fs::read(app_data.path().join(".master_key")).unwrap(),
+                    b"old-master"
+                );
+                assert_eq!(
+                    fs::read(app_data.path().join(".secure/.key_seed")).unwrap(),
+                    b"old-seed"
+                );
+                assert_eq!(
+                    fs::read(app_data.path().join(".secure/old.enc")).unwrap(),
+                    b"old-credential"
+                );
+            } else {
+                assert!(!app_data.path().join(".master_key").exists());
+                assert!(!app_data.path().join(".secure").exists());
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

整槽恢复不再在候选槽验证前永久替换全局密钥。密钥与切槽一起提交，失败应回到旧密钥。

### Changes
- `commands_restore.rs` / backup 密钥恢复延后到切槽提交
- 失败路径不留下「新密钥 + 旧活跃槽」

### How to test
- 窄测：恢复编排相关 Rust 用例
- 本 PR 未跑全量 `npm run build` / `cargo build`，未做会清空数据槽的真实恢复

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ffbe94-512c-4a8c-abad-f6378cada875?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ffbe94-512c-4a8c-abad-f6378cada875&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

