### PR TITLE
fix: keep default HPIAS research honest

### DIFF
--- a/docs/generative-ui/PROGRESS.md
+++ b/docs/generative-ui/PROGRESS.md
@@ -280,6 +280,13 @@ CI `32704302688`（head `af00a73c`）仍 queued，**本轮不 push**。
 - [x] **`generativeUITauriE2E.contract.test.ts`** — Tauri E2E 静态验收
 - [x] SOTA_CHECKLIST 标记 Tauri E2E 完成
 
+## HPIAS honesty fix（2026-08-26）
+
+- [x] Chat 默认禁用 HPIAS 动态 pipeline，研究块只渲染静态 intent；`stub` 仅可显式启用
+- [x] retrieval 依赖不可用时 fail closed，不再静默回退演示 stub
+- [x] Rust plan queries 与前端同样封顶 12 并去重；修复 stub citation id 格式化
+- [x] `research-report` 复用安全的 Chat MarkdownRenderer
+
 ## Round 25（2026-08-24）
 
 - [x] **`hpias/synthesis.rs`** — `generate_synthesis_with_llm`（Model2 Markdown + 90s 超时）
@@ -291,7 +298,7 @@ CI `32704302688`（head `af00a73c`）仍 queued，**本轮不 push**。
 
 - [x] **`hpias/retrieval_backend.rs`** — `RetrievalHpiasResearchService` 经 `VfsUnifiedRetriever` 真实检索
 - [x] `HpiasResearchDeps` — executor 注入 vfs_db / lance_store / llm_manager
-- [x] `DEEP_STUDENT_HPIAS_BACKEND=retrieval` + VFS 不可用时自动回退 stub
+- [x] `DEEP_STUDENT_HPIAS_BACKEND=retrieval` 后端（VFS 不可用时由 Round 26 改为 fail closed）
 - [x] 确定性 `build_synthesis_markdown`（LLM 综合待续）
 - [x] contract / SOTA / ARCHITECTURE 更新
 
@@ -299,7 +306,7 @@ CI `32704302688`（head `af00a73c`）仍 queued，**本轮不 push**。
 
 - [x] **`allBlocksFixture.ts`** + **`generativeUIAllBlocksRuntime.test.tsx`** — 14 块全量运行时渲染 SOTA 验收
 - [x] **`generativeUIChatBlockHpiasRuntime.integration.test.tsx`** — Chat 块 + 真实 `useHpiasEventBridge` + mock Tauri listen 全链路
-- [x] **`HpiasBackendKind`** — `DEEP_STUDENT_HPIAS_BACKEND` 环境变量扩展点（默认 stub）
+- [x] **`HpiasBackendKind`** — `DEEP_STUDENT_HPIAS_BACKEND` 环境变量扩展点（Round 26 改为默认禁用）
 - [x] **`SOTA_CHECKLIST.md`** — 目标态验收清单与剩余项
 - [x] SOTA acceptance 扩展 all-blocks / chat-hpias / checklist 要求
 - [x] vitest 全绿

--- a/src-tauri/src/chat_v2/tools/generative_ui_executor.rs
+++ b/src-tauri/src/chat_v2/tools/generative_ui_executor.rs
@@ -303,7 +303,8 @@ impl GenerativeUiExecutor {
         );
     }
 
-    /// researchSessionId 存在时 emit `hpias_event` session_started，并 spawn pipeline orchestrator
+    /// 显式启用 HPIAS 后端时 emit `session_started` 并启动 pipeline。
+    /// 默认禁用态直接返回，让 Chat 只渲染 intent 中的静态研究块。
     fn emit_hpias_session_started_if_needed(
         ctx: &ExecutionContext,
         session_id: &str,
@@ -317,19 +318,21 @@ impl GenerativeUiExecutor {
         let Some(window) = window else {
             return;
         };
-        let emitter = HpiasEventEmitter::new(window.clone());
+        let deps = HpiasResearchDeps {
+            vfs_db: ctx.vfs_db.clone(),
+            vfs_lance_store: ctx.vfs_lance_store.clone(),
+            llm_manager: ctx.llm_manager.clone(),
+        };
+        let Some(backend) = create_research_backend(window.clone(), deps) else {
+            return;
+        };
+        let emitter = HpiasEventEmitter::new(window);
         if let Err(error) = emitter.emit_session_started(session_id, question) {
             log::warn!(
                 "[GenerativeUiExecutor] hpias_event session_started emit failed: {}",
                 error
             );
         }
-        let deps = HpiasResearchDeps {
-            vfs_db: ctx.vfs_db.clone(),
-            vfs_lance_store: ctx.vfs_lance_store.clone(),
-            llm_manager: ctx.llm_manager.clone(),
-        };
-        let backend = create_research_backend(window, deps);
         backend.start_research_session(HpiasResearchSessionRequest {
             session_id,
             question,

--- a/src-tauri/src/hpias/payloads.rs
+++ b/src-tauri/src/hpias/payloads.rs
@@ -2,9 +2,12 @@
 //!
 //! 纯函数便于单测；orchestrator 与 `HpiasEventEmitter` 共用。
 
+use std::collections::HashSet;
+
 use serde_json::{json, Value};
 
 const RESEARCH_BLOCK_TYPES: [&str; 3] = ["research-plan", "research-report", "paper-digest"];
+const MAX_RESEARCH_PLAN_QUERIES: usize = 12;
 
 /// intent 是否含 Research 类块（与前端 `intentHasResearchBlocks` 对齐）
 pub fn intent_has_research_blocks(intent: &Value) -> bool {
@@ -70,12 +73,15 @@ pub fn extract_plan_queries_from_intent(intent: &Value) -> Vec<String> {
         else {
             continue;
         };
+        let mut seen = HashSet::new();
         let queries: Vec<String> = steps
             .iter()
             .filter_map(|step| step.get("label").and_then(Value::as_str))
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(str::to_string)
+            .filter(|query| seen.insert(query.clone()))
+            .take(MAX_RESEARCH_PLAN_QUERIES)
             .collect();
         if !queries.is_empty() {
             return queries;
@@ -301,7 +307,7 @@ pub fn build_pipeline_timeline(
             sub_id,
             3,
             &format!("子代理 {} 已完成检索与摘要。", sub_id),
-            json!([["paper-{}", sub_id]]),
+            json!([[format!("paper-{}", sub_id), sub_id]]),
         ));
     }
 
@@ -357,6 +363,25 @@ mod tests {
     }
 
     #[test]
+    fn extract_plan_queries_deduplicates_and_caps_at_frontend_limit() {
+        let steps: Vec<Value> = std::iter::once(json!({ "label": "Query 0" }))
+            .chain(std::iter::once(json!({ "label": "Query 0" })))
+            .chain((1..20).map(|index| json!({ "label": format!("Query {}", index) })))
+            .collect();
+        let intent = json!({
+            "blocks": [{
+                "type": "research-plan",
+                "props": { "steps": steps }
+            }]
+        });
+
+        let queries = extract_plan_queries_from_intent(&intent);
+        assert_eq!(queries.len(), MAX_RESEARCH_PLAN_QUERIES);
+        assert_eq!(queries.first().map(String::as_str), Some("Query 0"));
+        assert_eq!(queries.last().map(String::as_str), Some("Query 11"));
+    }
+
+    #[test]
     fn build_pipeline_timeline_includes_lifecycle_events() {
         let timeline = build_pipeline_timeline("s1", Some("Q?"), None);
         let types: Vec<&str> = timeline
@@ -387,6 +412,24 @@ mod tests {
             synthesis.get("synthesis").and_then(Value::as_str),
             Some("Custom synthesis body")
         );
+    }
+
+    #[test]
+    fn build_pipeline_timeline_formats_stub_citation_ids() {
+        let intent = json!({
+            "blocks": [{
+                "type": "research-plan",
+                "props": { "steps": [{ "label": "Query A" }] }
+            }]
+        });
+        let timeline = build_pipeline_timeline("s1", None, Some(&intent));
+        let completed = timeline
+            .iter()
+            .find(|event| event.get("type") == Some(&json!("subagent_completed")))
+            .expect("subagent_completed event");
+
+        assert_eq!(completed["citations"], json!([["paper-1", 1]]));
+        assert!(!completed.to_string().contains("paper-{}"));
     }
 
     #[test]

--- a/src-tauri/src/hpias/retrieval_backend.rs
+++ b/src-tauri/src/hpias/retrieval_backend.rs
@@ -1,7 +1,7 @@
 //! HPIAS retrieval 后端 — VFS UnifiedRetriever 驱动真实检索 pipeline（Round 24）
 //!
 //! `DEEP_STUDENT_HPIAS_BACKEND=retrieval` 且 ExecutionContext 注入 VFS/LLM 时启用；
-//! 否则回退 stub。Round 25：synthesis 优先 LLM 综合，失败回退确定性拼接。
+//! 依赖不可用时 fail closed。Round 25：synthesis 优先 LLM 综合，失败回退确定性拼接。
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -16,7 +16,6 @@ use crate::vfs::retrieval_planner::{FusedRetrievalHit, QueryModality};
 use crate::vfs::{UnifiedRetrievalRequest, VfsUnifiedRetriever};
 
 use super::events::HpiasEventEmitter;
-use super::orchestrator::HpiasPipelineOrchestrator;
 use super::payloads::{
     build_plan_generated_payload, build_retrieval_completed_payload, build_round_started_payload,
     build_selection_completed_payload, build_session_completed_payload,
@@ -270,16 +269,6 @@ pub fn build_synthesis_markdown(
         }
     }
     md
-}
-
-/// retrieval 不可用时回退 stub orchestrator
-pub fn spawn_stub_fallback(
-    window: Window,
-    session_id: &str,
-    question: Option<&str>,
-    intent: &Value,
-) {
-    HpiasPipelineOrchestrator::spawn_from_intent(window, session_id, question, intent);
 }
 
 #[cfg(test)]

--- a/src-tauri/src/hpias/service.rs
+++ b/src-tauri/src/hpias/service.rs
@@ -1,6 +1,6 @@
 //! HPIAS 研究服务 — 后端 pipeline 入口（Round 22–24）
 //!
-//! `StubHpiasResearchService` — Style Lab 时间线 stub（默认）
+//! `StubHpiasResearchService` — 仅供 Style Lab / 显式测试启用的时间线 stub
 //! `RetrievalHpiasResearchService` — VFS UnifiedRetriever 真实检索（`DEEP_STUDENT_HPIAS_BACKEND=retrieval`）
 
 use serde_json::Value;
@@ -13,7 +13,9 @@ use super::retrieval_backend::{HpiasResearchDeps, RetrievalHpiasResearchService}
 /// HPIAS 后端实现种类（环境变量 `DEEP_STUDENT_HPIAS_BACKEND`）
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HpiasBackendKind {
-    /// Style Lab 时间线 stub（默认）
+    /// Chat 默认禁用动态 pipeline，研究块只渲染 intent 中的静态内容
+    Disabled,
+    /// Style Lab / 测试时间线 stub（仅显式配置 `stub` 时启用）
     Stub,
     /// VFS UnifiedRetriever 驱动检索 + LLM synthesis（失败回退确定性拼接）
     Retrieval,
@@ -21,19 +23,26 @@ pub enum HpiasBackendKind {
 
 impl HpiasBackendKind {
     pub fn from_env() -> Self {
-        match std::env::var("DEEP_STUDENT_HPIAS_BACKEND")
-            .unwrap_or_else(|_| "stub".to_string())
+        let configured = std::env::var("DEEP_STUDENT_HPIAS_BACKEND").ok();
+        Self::from_config(configured.as_deref())
+    }
+
+    fn from_config(configured: Option<&str>) -> Self {
+        match configured
+            .map(str::trim)
+            .unwrap_or_default()
             .to_ascii_lowercase()
             .as_str()
         {
-            "stub" | "" => Self::Stub,
+            "" | "disabled" | "off" => Self::Disabled,
+            "stub" => Self::Stub,
             "retrieval" => Self::Retrieval,
             other => {
                 log::warn!(
-                    "[HpiasResearchService] Unknown DEEP_STUDENT_HPIAS_BACKEND={:?}, using stub",
+                    "[HpiasResearchService] Unknown DEEP_STUDENT_HPIAS_BACKEND={:?}; pipeline disabled",
                     other
                 );
-                Self::Stub
+                Self::Disabled
             }
         }
     }
@@ -76,21 +85,22 @@ impl HpiasResearchBackend for StubHpiasResearchService {
     }
 }
 
-/// 后端工厂：`retrieval` 模式在 VFS/LLM 不可用时自动回退 stub
+/// 后端工厂：默认不启动 pipeline；显式 retrieval 依赖不可用时也 fail closed。
 pub fn create_research_backend(
     window: Window,
     deps: HpiasResearchDeps,
-) -> Box<dyn HpiasResearchBackend> {
+) -> Option<Box<dyn HpiasResearchBackend>> {
     match HpiasBackendKind::from_env() {
-        HpiasBackendKind::Stub => Box::new(StubHpiasResearchService::new(window)),
+        HpiasBackendKind::Disabled => None,
+        HpiasBackendKind::Stub => Some(Box::new(StubHpiasResearchService::new(window))),
         HpiasBackendKind::Retrieval => {
             if deps.can_run_retrieval() {
-                Box::new(RetrievalHpiasResearchService::new(window, deps))
+                Some(Box::new(RetrievalHpiasResearchService::new(window, deps)))
             } else {
                 log::warn!(
-                    "[HpiasResearchService] retrieval backend requested but VFS/LLM unavailable; using stub"
+                    "[HpiasResearchService] retrieval backend requested but VFS/LLM unavailable; pipeline disabled"
                 );
-                Box::new(StubHpiasResearchService::new(window))
+                None
             }
         }
     }
@@ -116,22 +126,38 @@ mod tests {
     }
 
     #[test]
-    fn backend_kind_defaults_to_stub() {
-        std::env::remove_var("DEEP_STUDENT_HPIAS_BACKEND");
-        assert_eq!(HpiasBackendKind::from_env(), HpiasBackendKind::Stub);
+    fn backend_kind_defaults_to_disabled() {
+        assert_eq!(
+            HpiasBackendKind::from_config(None),
+            HpiasBackendKind::Disabled
+        );
+        assert_eq!(
+            HpiasBackendKind::from_config(Some("")),
+            HpiasBackendKind::Disabled
+        );
     }
 
     #[test]
     fn backend_kind_reads_env_stub() {
-        std::env::set_var("DEEP_STUDENT_HPIAS_BACKEND", "stub");
-        assert_eq!(HpiasBackendKind::from_env(), HpiasBackendKind::Stub);
-        std::env::remove_var("DEEP_STUDENT_HPIAS_BACKEND");
+        assert_eq!(
+            HpiasBackendKind::from_config(Some("stub")),
+            HpiasBackendKind::Stub
+        );
     }
 
     #[test]
     fn backend_kind_reads_env_retrieval() {
-        std::env::set_var("DEEP_STUDENT_HPIAS_BACKEND", "retrieval");
-        assert_eq!(HpiasBackendKind::from_env(), HpiasBackendKind::Retrieval);
-        std::env::remove_var("DEEP_STUDENT_HPIAS_BACKEND");
+        assert_eq!(
+            HpiasBackendKind::from_config(Some("retrieval")),
+            HpiasBackendKind::Retrieval
+        );
+    }
+
+    #[test]
+    fn backend_kind_unknown_value_fails_closed() {
+        assert_eq!(
+            HpiasBackendKind::from_config(Some("unexpected")),
+            HpiasBackendKind::Disabled
+        );
     }
 }

--- a/src-tauri/tests/generative_ui_executor_e2e.rs
+++ b/src-tauri/tests/generative_ui_executor_e2e.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::sync::{Arc, Mutex};
 
 use deep_student_lib::chat_v2::event_types;
@@ -8,6 +9,32 @@ use deep_student_lib::hpias::HPIAS_EVENT_CHANNEL;
 use deep_student_lib::tools::ToolRegistry;
 use serde_json::{json, Value};
 use tauri::Listener;
+
+static HPIAS_BACKEND_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct HpiasBackendEnvGuard {
+    previous: Option<OsString>,
+}
+
+impl HpiasBackendEnvGuard {
+    fn set(value: Option<&str>) -> Self {
+        let previous = std::env::var_os("DEEP_STUDENT_HPIAS_BACKEND");
+        match value {
+            Some(value) => std::env::set_var("DEEP_STUDENT_HPIAS_BACKEND", value),
+            None => std::env::remove_var("DEEP_STUDENT_HPIAS_BACKEND"),
+        }
+        Self { previous }
+    }
+}
+
+impl Drop for HpiasBackendEnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var("DEEP_STUDENT_HPIAS_BACKEND", value),
+            None => std::env::remove_var("DEEP_STUDENT_HPIAS_BACKEND"),
+        }
+    }
+}
 
 struct GenerativeUiHarness {
     _app: tauri::App,
@@ -93,8 +120,53 @@ fn hpias_event_channel_matches_frontend_contract() {
 }
 
 #[tokio::test]
+async fn execute_with_default_backend_keeps_research_blocks_static() {
+    let _env_lock = HPIAS_BACKEND_ENV_LOCK.lock().await;
+    let _env = HpiasBackendEnvGuard::set(None);
+    let harness = create_harness();
+    let hpias_events = capture_hpias_events(&harness.window);
+    let executor = GenerativeUiExecutor::new();
+    let intent = json!({
+        "version": "1",
+        "blocks": [{
+            "type": "research-report",
+            "props": {
+                "title": "Static report",
+                "body": "Closed-book content rendered without a fake retrieval timeline."
+            }
+        }]
+    });
+
+    let result = executor
+        .execute(
+            &ToolCall::new(
+                "call-generative-ui-hpias-default".to_string(),
+                "builtin-render_generative_ui".to_string(),
+                json!({
+                    "researchSessionId": "e2e-hpias-default",
+                    "intent": intent
+                }),
+            ),
+            &execution_context(&harness, "block-generative-ui-hpias-default"),
+        )
+        .await
+        .expect("executor returns ToolResultInfo");
+
+    assert!(result.success);
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    let captured = hpias_events
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(
+        captured.is_empty(),
+        "default backend must not emit a fake HPIAS timeline: {captured:?}"
+    );
+}
+
+#[tokio::test]
 async fn execute_with_research_session_emits_hpias_session_started() {
-    std::env::set_var("DEEP_STUDENT_HPIAS_BACKEND", "stub");
+    let _env_lock = HPIAS_BACKEND_ENV_LOCK.lock().await;
+    let _env = HpiasBackendEnvGuard::set(Some("stub"));
     let harness = create_harness();
     let hpias_events = capture_hpias_events(&harness.window);
     let executor = GenerativeUiExecutor::new();
@@ -161,7 +233,8 @@ async fn execute_with_research_session_emits_hpias_session_started() {
 
 #[tokio::test]
 async fn execute_hpias_stub_pipeline_emits_plan_generated() {
-    std::env::set_var("DEEP_STUDENT_HPIAS_BACKEND", "stub");
+    let _env_lock = HPIAS_BACKEND_ENV_LOCK.lock().await;
+    let _env = HpiasBackendEnvGuard::set(Some("stub"));
     let harness = create_harness();
     let hpias_events = capture_hpias_events(&harness.window);
     let executor = GenerativeUiExecutor::new();

--- a/src/features/chat/components/renderers/MarkdownRenderer.tsx
+++ b/src/features/chat/components/renderers/MarkdownRenderer.tsx
@@ -838,6 +838,24 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = React.memo(({
             return <p {...props}>{children}</p>;
           },
           span: ({ children, node: _node, ...props }: any) => {
+            // Generative UI research reports mark non-interactive source labels with their
+            // literal citation id. Re-apply note semantics after rehype-sanitize strips `role`.
+            const researchCitationLabel = props['data-citation'];
+            if (
+              typeof researchCitationLabel === 'string' &&
+              researchCitationLabel !== 'true'
+            ) {
+              return (
+                <span
+                  {...props}
+                  role="note"
+                  aria-label={researchCitationLabel}
+                >
+                  {children}
+                </span>
+              );
+            }
+
             // 处理思维导图引用 - 渲染完整的 ReactFlow 预览
             const isMindmapCitation = props['data-mindmap-citation'] === 'true';
             if (isMindmapCitation) {

--- a/src/features/generative-ui/components/ResearchReportBlock.tsx
+++ b/src/features/generative-ui/components/ResearchReportBlock.tsx
@@ -2,11 +2,12 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 import { cn } from '@/lib/utils';
-import { Badge } from '@/components/ui/shad/Badge';
+import { MarkdownRenderer } from '@/features/chat/components/renderers/MarkdownRenderer';
 import {
   parseResearchReportCitations,
   RESEARCH_REPORT_CITATION_PATTERN,
 } from '../utils/parseResearchReportCitations';
+import { sanitizeGenerativeMarkdown } from '../utils/sanitizeGenerativeMarkdown';
 
 export const researchReportPropsSchema = z.object({
   id: z.string().optional(),
@@ -17,51 +18,96 @@ export const researchReportPropsSchema = z.object({
 
 export type ResearchReportBlockProps = z.infer<typeof researchReportPropsSchema>;
 
-function renderBodyWithCitations(body: string, citationAriaLabel: (label: string) => string) {
-  const parts: React.ReactNode[] = [];
+interface MarkdownAstNode {
+  type?: string;
+  value?: string;
+  children?: MarkdownAstNode[];
+}
+
+const CITATION_CLASS =
+  'mx-0.5 inline-flex items-center rounded-md border border-transparent bg-secondary px-2.5 py-0.5 align-baseline text-xs font-normal text-secondary-foreground';
+
+function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/g,
+    (character) =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[character] ?? character,
+  );
+}
+
+function replaceResearchCitations(
+  value: string,
+  citationAriaLabel: (label: string) => string,
+): MarkdownAstNode[] {
+  const parts: MarkdownAstNode[] = [];
   let lastIndex = 0;
   const pattern = new RegExp(RESEARCH_REPORT_CITATION_PATTERN.source, 'g');
 
-  for (const match of body.matchAll(pattern)) {
+  for (const match of value.matchAll(pattern)) {
     const start = match.index ?? 0;
     if (start > lastIndex) {
-      parts.push(
-        <span key={`text-${lastIndex}`} className="whitespace-pre-wrap">
-          {body.slice(lastIndex, start)}
-        </span>,
-      );
+      parts.push({ type: 'text', value: value.slice(lastIndex, start) });
     }
     const fullMatch = match[0];
-    parts.push(
-      <Badge
-        key={`cite-${start}`}
-        variant="secondary"
-        className="mx-0.5 align-baseline text-xs font-normal"
-        role="note"
-        data-citation={fullMatch}
-        aria-label={citationAriaLabel(fullMatch)}
-      >
-        {fullMatch}
-      </Badge>,
-    );
+    parts.push({
+      type: 'html',
+      value: `<span class="${CITATION_CLASS}" role="note" data-citation="${escapeHtml(fullMatch)}" aria-label="${escapeHtml(citationAriaLabel(fullMatch))}">${escapeHtml(fullMatch)}</span>`,
+    });
     lastIndex = start + fullMatch.length;
   }
 
-  if (lastIndex < body.length) {
-    parts.push(
-      <span key={`text-${lastIndex}`} className="whitespace-pre-wrap">
-        {body.slice(lastIndex)}
-      </span>,
-    );
+  if (lastIndex < value.length) {
+    parts.push({ type: 'text', value: value.slice(lastIndex) });
   }
 
   return parts;
+}
+
+function createResearchCitationRemarkPlugin(citationAriaLabel: (label: string) => string) {
+  return function researchCitationAttacher() {
+    return function researchCitationTransformer(tree: MarkdownAstNode) {
+      function visit(node: MarkdownAstNode): void {
+        if (['code', 'inlineCode', 'math', 'inlineMath', 'html'].includes(node.type ?? '')) {
+          return;
+        }
+        if (!node.children) return;
+
+        const nextChildren: MarkdownAstNode[] = [];
+        for (const child of node.children) {
+          if (child.type === 'text' && child.value?.includes('[')) {
+            nextChildren.push(...replaceResearchCitations(child.value, citationAriaLabel));
+          } else {
+            visit(child);
+            nextChildren.push(child);
+          }
+        }
+        node.children = nextChildren;
+      }
+
+      visit(tree);
+    };
+  };
 }
 
 export function ResearchReportBlock({ title, body, density }: ResearchReportBlockProps) {
   const { t } = useTranslation('generativeUi');
   const titleId = React.useId();
   const citationCount = useMemo(() => parseResearchReportCitations(body).length, [body]);
+  const sanitizedBody = useMemo(() => sanitizeGenerativeMarkdown(body.trim()), [body]);
+  const citationRemarkPlugins = useMemo(
+    () => [
+      createResearchCitationRemarkPlugin((label) =>
+        t('research.report.citation_aria', { label }),
+      ),
+    ],
+    [t],
+  );
 
   return (
     <article
@@ -81,7 +127,12 @@ export function ResearchReportBlock({ title, body, density }: ResearchReportBloc
           density === 'compact' ? 'text-xs' : 'text-sm',
         )}
       >
-        {renderBodyWithCitations(body, (label) => t('research.report.citation_aria', { label }))}
+        <MarkdownRenderer
+          content={sanitizedBody}
+          isStreaming={false}
+          className={density === 'compact' ? 'text-xs' : 'text-sm'}
+          extraRemarkPlugins={citationRemarkPlugins}
+        />
       </div>
     </article>
   );

--- a/tests/vitest/generative-ui/researchBlocks.test.tsx
+++ b/tests/vitest/generative-ui/researchBlocks.test.tsx
@@ -91,4 +91,15 @@ describe('Research generative-ui blocks POC', () => {
     expect(badge).not.toHaveAttribute('tabIndex');
     expect(badge).toHaveAttribute('data-citation', '[paper-1]');
   });
+
+  it('renders research-report Markdown through the shared renderer', () => {
+    const { container } = render(
+      <ResearchReportBlock body={'## 综合结论\n\n证据支持 **多模态融合** [paper-1]。'} />,
+    );
+
+    expect(screen.getByRole('heading', { name: '综合结论' })).toBeInTheDocument();
+    expect(container.querySelector('strong')).toHaveTextContent('多模态融合');
+    expect(container.querySelector('.markdown-content')).toBeTruthy();
+    expect(container.querySelector('[data-citation="[paper-1]"]')).toHaveAttribute('role', 'note');
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

默认 HPIAS stub 不再把演戏检索当成真实文献调研。Chat 默认路径保持诚实；研究报告按 markdown 渲染；plan queries 封顶。

### Changes
- 默认 stub 不再伪造检索计数/入选引用语义
- 研究报告复用 markdown 渲染
- 相关 e2e / vitest 收口

### How to test
- 窄测：`generative_ui_executor_e2e`、`researchBlocks`
- 本 PR 未跑全量 `npm run build` / `cargo build`

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ffbe94-512c-4a8c-abad-f6378cada875?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ffbe94-512c-4a8c-abad-f6378cada875&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

