### PR TITLE
fix: isolate question-bank practice progress by view

### DIFF
--- a/src/components/QuestionBankEditor.tsx
+++ b/src/components/QuestionBankEditor.tsx
@@ -69,7 +69,11 @@ import type {
   SubmitResult,
 } from '@/api/questionBankApi';
 import { getNextQuestionIndex, parseNumericInput } from '@/api/questionBankApi';
-import { useQuestionBankStore } from '@/stores/questionBankStore';
+import {
+  getPracticeSessionKey,
+  useQuestionBankStore,
+  type PracticeSessionOwner,
+} from '@/stores/questionBankStore';
 import {
   type ExtendedQuestionType,
   type MatchingPair,
@@ -91,6 +95,8 @@ import {
 
 export interface QuestionBankEditorProps {
   sessionId: string;
+  /** 当前保活视图的显式会话归属；由 useQuestionBankSession 生成。 */
+  practiceSessionOwner: PracticeSessionOwner;
   questions: Question[];
   stats?: QuestionBankStats;
   currentIndex?: number;
@@ -470,6 +476,7 @@ OptionButton.displayName = 'OptionButton';
 
 export const QuestionBankEditor: React.FC<QuestionBankEditorProps> = ({
   sessionId,
+  practiceSessionOwner,
   questions,
   stats,
   currentIndex = 0,
@@ -600,16 +607,15 @@ export const QuestionBankEditor: React.FC<QuestionBankEditorProps> = ({
   
   // 连对计数 & 激励（里程碑提示走 showGlobalNotification 统一通知，不再用本地 z-50 toast）
   // 会话进度提到 questionBankStore：切到错题本 / 统计再回来不清零（仅内存，重启不恢复）
-  const streakCount = useQuestionBankStore((state) => state.practiceSession.streakCount);
-  const totalCorrectCount = useQuestionBankStore((state) => state.practiceSession.totalCorrectCount);
-  const ensurePracticeSession = useQuestionBankStore((state) => state.ensurePracticeSession);
+  const practiceSessionKey = getPracticeSessionKey(practiceSessionOwner);
+  const practiceSession = useQuestionBankStore((state) => (
+    practiceSessionKey ? state.practiceSessions[practiceSessionKey] : undefined
+  ));
+  const streakCount = practiceSession?.streakCount ?? 0;
+  const totalCorrectCount = practiceSession?.totalCorrectCount ?? 0;
   const recordPracticeSessionAnswer = useQuestionBankStore(
     (state) => state.recordPracticeSessionAnswer,
   );
-
-  useEffect(() => {
-    ensurePracticeSession(sessionId);
-  }, [sessionId, ensurePracticeSession]);
   
   // 完成庆祝
   const [showCompletionCelebration, setShowCompletionCelebration] = useState(false);
@@ -1133,7 +1139,16 @@ export const QuestionBankEditor: React.FC<QuestionBankEditorProps> = ({
       
       // 连对与已作答集合由 store 统一推进（null = 主观题待判定，不中断连对）；
       // 返回值是同帧快照，里程碑与完成判定都读它，避免 setState 异步导致的错位。
-      const progress = recordPracticeSessionAnswer(currentQuestion.id, result.isCorrect ?? null);
+      const progress = recordPracticeSessionAnswer(
+        practiceSessionOwner,
+        currentQuestion.id,
+        result.isCorrect ?? null,
+      );
+      if (!progress) {
+        // 后端提交已经成功，但归属或题目白名单不匹配时不得写入其他实例。
+        debugLog.warn('[QuestionBankEditor] practice session ownership rejected answer progress');
+        return;
+      }
 
       if (result.isCorrect) {
         // 检查里程碑 (3, 5, 10, 15, 20...)：走统一通知（替代原 z-50 本地 toast）
@@ -1164,7 +1179,7 @@ export const QuestionBankEditor: React.FC<QuestionBankEditorProps> = ({
       submitInFlightRef.current = false;
       setIsSubmitting(false);
     }
-  }, [currentQuestion, canSubmit, qType, selectedAnswer, selectedOptions, fillBlankAnswers, matchingData, matchingPairs, orderingData, orderingOrder, onSubmitAnswer, onRefreshQuestion, recordPracticeSessionAnswer, totalQuestions, resolvedElapsedTime, resetAiGrading, startAiGrading, t, isSubmitting]);
+  }, [currentQuestion, canSubmit, qType, selectedAnswer, selectedOptions, fillBlankAnswers, matchingData, matchingPairs, orderingData, orderingOrder, onSubmitAnswer, onRefreshQuestion, recordPracticeSessionAnswer, practiceSessionOwner, totalQuestions, resolvedElapsedTime, resetAiGrading, startAiGrading, t, isSubmitting]);
 
   // 重做当前题目
   const handleRetry = useCallback(() => {

--- a/src/features/learning-hub/apps/views/ExamContentView.tsx
+++ b/src/features/learning-hub/apps/views/ExamContentView.tsx
@@ -311,6 +311,7 @@ const ExamContentView: React.FC<ContentViewProps> = ({
 
   // 🆕 2026-01 改造：使用 useQuestionBankSession Hook 管理题目状态
   const {
+    practiceSessionOwner,
     questions,
     currentIndex,
     stats,
@@ -2453,9 +2454,10 @@ const ExamContentView: React.FC<ContentViewProps> = ({
               onBack={handleUploaderBack}
               onManualCreate={handleCreateQuestionEntry}
             />
-          ) : viewMode === 'practice' && hasQuestions ? (
+          ) : viewMode === 'practice' && hasQuestions && practiceSessionOwner ? (
             <QuestionBankEditor
               sessionId={sessionId}
+              practiceSessionOwner={practiceSessionOwner}
               questions={practiceQuestions}
               stats={stats}
               currentIndex={practiceCurrentIndex}

--- a/src/hooks/useQuestionBankSession.ts
+++ b/src/hooks/useQuestionBankSession.ts
@@ -13,6 +13,10 @@ import { invoke } from '@tauri-apps/api/core';
 import { type Question, type QuestionBankStats, type SubmitResult, type PracticeMode, type QuestionStructuredData } from '@/api/questionBankApi';
 import { debugLog } from '@/debug-panel/debugMasterSwitch';
 import { emitExamSheetDebug } from '@/debug-panel/plugins/ExamSheetProcessingDebugPlugin';
+import {
+  useQuestionBankStore,
+  type PracticeSessionOwner,
+} from '@/stores/questionBankStore';
 
 // Store 侧类型（snake_case，与 Rust 序列化一致）
 interface StoreQuestion {
@@ -129,6 +133,8 @@ interface UseQuestionBankSessionOptions {
 }
 
 interface UseQuestionBankSessionReturn {
+  /** 本 hook 实例的稳定归属键；同一 examId 的两个保活实例也不会共享进度。 */
+  practiceSessionOwner: PracticeSessionOwner | null;
   questions: Question[];
   currentQuestion: Question | null;
   currentIndex: number;
@@ -183,6 +189,17 @@ function writeLastQuestionId(examId: string, questionId: string | null): void {
 export function useQuestionBankSession({
   examId,
 }: UseQuestionBankSessionOptions): UseQuestionBankSessionReturn {
+  const practiceViewInstanceIdRef = useRef<string | null>(null);
+  if (practiceViewInstanceIdRef.current === null) {
+    practiceViewInstanceIdRef.current = `qbank_view_${generateClientRequestId()}`;
+  }
+  const practiceSessionOwner = useMemo<PracticeSessionOwner | null>(
+    () => examId
+      ? { examId, viewInstanceId: practiceViewInstanceIdRef.current! }
+      : null,
+    [examId],
+  );
+
   // ========== ★ 完全本地化状态 ==========
   const [localQuestions, setLocalQuestions] = useState<Map<string, StoreQuestion>>(new Map());
   const [localOrder, setLocalOrder] = useState<string[]>([]);
@@ -193,6 +210,21 @@ export function useQuestionBankSession({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pagination, setPagination] = useState({ page: 1, pageSize: PAGE_SIZE, total: 0, hasMore: false });
+  const ensurePracticeSession = useQuestionBankStore((state) => state.ensurePracticeSession);
+  const releasePracticeSession = useQuestionBankStore((state) => state.releasePracticeSession);
+
+  // 全局容器只负责跨「做题 / 错题本 / 统计」子视图保留即时进度。
+  // 归属由当前 hook 实例显式提供，题目白名单随本地题目集刷新。
+  useEffect(() => {
+    if (!practiceSessionOwner) return;
+    ensurePracticeSession(practiceSessionOwner, localOrder);
+  }, [practiceSessionOwner, localOrder, ensurePracticeSession]);
+
+  // 整个题库视图卸载（关闭标签）后释放分片；切换内部子视图不会卸载本 hook。
+  useEffect(() => {
+    if (!practiceSessionOwner) return;
+    return () => releasePracticeSession(practiceSessionOwner);
+  }, [practiceSessionOwner, releasePracticeSession]);
 
   // Refs for concurrent request protection
   const examIdRef = useRef(examId);
@@ -593,6 +625,7 @@ export function useQuestionBankSession({
   const isMigrated = questions.length > 0;
 
   return {
+    practiceSessionOwner,
     questions,
     currentQuestion,
     currentIndex,

--- a/src/stores/questionBankStore.ts
+++ b/src/stores/questionBankStore.ts
@@ -816,9 +816,16 @@ let checkInCalendarRequestSeq = 0;
 // Store 状态
 // ============================================================================
 
-/** 本轮做题进度（仅内存，跨视图切换保留，不跨进程） */
-export interface PracticeSessionProgress {
-  examId: string | null;
+/** 做题会话归属；同一题库的两个保活视图也必须使用不同的 viewInstanceId。 */
+export interface PracticeSessionOwner {
+  examId: string;
+  viewInstanceId: string;
+}
+
+/** 本轮做题进度（仅内存，跨子视图切换保留，不跨进程） */
+export interface PracticeSessionProgress extends PracticeSessionOwner {
+  /** 当前实例允许作答的题目，用于拒绝串入其他题库的题目。 */
+  questionIds: string[];
   /** 连续答对数（明确答错清零；主观题待判定不中断） */
   streakCount: number;
   totalCorrectCount: number;
@@ -826,12 +833,31 @@ export interface PracticeSessionProgress {
   answeredIds: string[];
 }
 
-const EMPTY_PRACTICE_SESSION: PracticeSessionProgress = {
-  examId: null,
-  streakCount: 0,
-  totalCorrectCount: 0,
-  answeredIds: [],
-};
+export function getPracticeSessionKey(owner: PracticeSessionOwner): string | null {
+  if (
+    typeof owner?.examId !== 'string'
+    || owner.examId.length === 0
+    || typeof owner?.viewInstanceId !== 'string'
+    || owner.viewInstanceId.length === 0
+  ) {
+    return null;
+  }
+  // JSON 元组避免 examId / viewInstanceId 中出现分隔符时产生键碰撞。
+  return JSON.stringify([owner.examId, owner.viewInstanceId]);
+}
+
+function createEmptyPracticeSession(
+  owner: PracticeSessionOwner,
+  questionIds: readonly string[],
+): PracticeSessionProgress {
+  return {
+    ...owner,
+    questionIds: Array.from(new Set(questionIds.filter((id) => typeof id === 'string' && id.length > 0))),
+    streakCount: 0,
+    totalCorrectCount: 0,
+    answeredIds: [],
+  };
+}
 
 interface QuestionBankState {
   // 数据
@@ -944,19 +970,27 @@ interface QuestionBankState {
   ) => void;
   
   /**
-   * 做题会话的即时进度（连对 / 已作答集合）。
+   * 做题会话的即时进度（连对 / 已作答集合），按 examId + viewInstanceId 分片。
    * 提到 store 是为了让「做题 → 错题本 → 回做题」不清零；
-   * 未持久化，所以进程重启后仍然从零开始。
+   * 未持久化，所以视图卸载或进程重启后仍然从零开始。
    */
-  practiceSession: PracticeSessionProgress;
-  /** 切换题集时重置本轮进度；examId 未变则原样保留。 */
-  ensurePracticeSession: (examId: string | null) => void;
-  /** 记录一次作答，返回更新后的快照（调用方需要同帧读到新连对数）。 */
+  practiceSessions: Record<string, PracticeSessionProgress>;
+  /** 注册或刷新实例可作答的题目；已有实例保留仍有效的进度。 */
+  ensurePracticeSession: (
+    owner: PracticeSessionOwner,
+    questionIds: readonly string[],
+  ) => PracticeSessionProgress | null;
+  /**
+   * 记录一次作答并返回更新后的快照。
+   * 归属无效、实例未注册或题目不属于实例时 fail-closed，不写入任何分片。
+   */
   recordPracticeSessionAnswer: (
+    owner: PracticeSessionOwner,
     questionId: string,
     isCorrect: boolean | null,
-  ) => PracticeSessionProgress;
-  resetPracticeSession: (examId?: string | null) => void;
+  ) => PracticeSessionProgress | null;
+  resetPracticeSession: (owner: PracticeSessionOwner) => PracticeSessionProgress | null;
+  releasePracticeSession: (owner: PracticeSessionOwner) => void;
 
   // 练习模式状态
   timedSession: TimedPracticeSession | null;
@@ -1025,7 +1059,7 @@ export const useQuestionBankStore = create<QuestionBankState>()(
       // 并发防护：请求 ID，确保只有最新请求的结果会被应用
       loadRequestId: 0,
       
-      practiceSession: EMPTY_PRACTICE_SESSION,
+      practiceSessions: {},
 
       // 练习模式状态（2026-01 新增）
       timedSession: null,
@@ -1050,15 +1084,56 @@ export const useQuestionBankStore = create<QuestionBankState>()(
       
       resetFilters: () => set({ filters: {} }),
 
-      ensurePracticeSession: (examId) => {
-        if (get().practiceSession.examId === examId) return;
-        set({ practiceSession: { ...EMPTY_PRACTICE_SESSION, examId } });
+      ensurePracticeSession: (owner, questionIds) => {
+        const key = getPracticeSessionKey(owner);
+        if (!key || !Array.isArray(questionIds)) return null;
+
+        const normalizedQuestionIds = Array.from(
+          new Set(questionIds.filter((id) => typeof id === 'string' && id.length > 0)),
+        );
+        const previous = get().practiceSessions[key];
+        if (!previous) {
+          const created = createEmptyPracticeSession(owner, normalizedQuestionIds);
+          set((state) => ({
+            practiceSessions: { ...state.practiceSessions, [key]: created },
+          }));
+          return created;
+        }
+
+        const allowedIds = new Set(normalizedQuestionIds);
+        const answeredIds = previous.answeredIds.filter((id) => allowedIds.has(id));
+        const unchanged = previous.questionIds.length === normalizedQuestionIds.length
+          && previous.questionIds.every((id, index) => id === normalizedQuestionIds[index])
+          && answeredIds.length === previous.answeredIds.length;
+        if (unchanged) return previous;
+
+        const next: PracticeSessionProgress = {
+          ...previous,
+          questionIds: normalizedQuestionIds,
+          answeredIds,
+        };
+        set((state) => ({
+          practiceSessions: { ...state.practiceSessions, [key]: next },
+        }));
+        return next;
       },
 
-      recordPracticeSessionAnswer: (questionId, isCorrect) => {
-        const previous = get().practiceSession;
+      recordPracticeSessionAnswer: (owner, questionId, isCorrect) => {
+        const key = getPracticeSessionKey(owner);
+        if (!key || typeof questionId !== 'string' || questionId.length === 0) return null;
+
+        const previous = get().practiceSessions[key];
+        if (
+          !previous
+          || previous.examId !== owner.examId
+          || previous.viewInstanceId !== owner.viewInstanceId
+          || !previous.questionIds.includes(questionId)
+        ) {
+          return null;
+        }
+
         const next: PracticeSessionProgress = {
-          examId: previous.examId,
+          ...previous,
           // null（主观题待判定）既不加连对也不中断
           streakCount: isCorrect === true
             ? previous.streakCount + 1
@@ -1068,12 +1143,33 @@ export const useQuestionBankStore = create<QuestionBankState>()(
             ? previous.answeredIds
             : [...previous.answeredIds, questionId],
         };
-        set({ practiceSession: next });
+        set((state) => ({
+          practiceSessions: { ...state.practiceSessions, [key]: next },
+        }));
         return next;
       },
 
-      resetPracticeSession: (examId = get().practiceSession.examId) => {
-        set({ practiceSession: { ...EMPTY_PRACTICE_SESSION, examId: examId ?? null } });
+      resetPracticeSession: (owner) => {
+        const key = getPracticeSessionKey(owner);
+        if (!key) return null;
+        const previous = get().practiceSessions[key];
+        if (!previous) return null;
+
+        const next = createEmptyPracticeSession(owner, previous.questionIds);
+        set((state) => ({
+          practiceSessions: { ...state.practiceSessions, [key]: next },
+        }));
+        return next;
+      },
+
+      releasePracticeSession: (owner) => {
+        const key = getPracticeSessionKey(owner);
+        if (!key || !get().practiceSessions[key]) return;
+        set((state) => {
+          const practiceSessions = { ...state.practiceSessions };
+          delete practiceSessions[key];
+          return { practiceSessions };
+        });
       },
 
       // API Actions

--- a/tests/vitest/learning-hub/exam-content-view-entries.test.tsx
+++ b/tests/vitest/learning-hub/exam-content-view-entries.test.tsx
@@ -19,6 +19,10 @@ const storeState = vi.hoisted(() => ({
 }));
 
 const hookState = vi.hoisted(() => ({
+  practiceSessionOwner: {
+    examId: 'exam-1',
+    viewInstanceId: 'entries-test-view',
+  },
   questions: [
     {
       id: 'q_1',

--- a/tests/vitest/learning-hub/exam-content-view-history-entry.test.tsx
+++ b/tests/vitest/learning-hub/exam-content-view-history-entry.test.tsx
@@ -19,6 +19,10 @@ const storeState = vi.hoisted(() => ({
 }));
 
 const hookState = vi.hoisted(() => ({
+  practiceSessionOwner: {
+    examId: 'exam-1',
+    viewInstanceId: 'history-test-view',
+  },
   questions: [
     {
       id: 'q_1',

--- a/tests/vitest/question-bank-editor-ai-markdown.test.tsx
+++ b/tests/vitest/question-bank-editor-ai-markdown.test.tsx
@@ -4,6 +4,10 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { QuestionBankEditor } from '@/components/QuestionBankEditor';
 import type { Question, SubmitResult } from '@/api/questionBankApi';
+import {
+  useQuestionBankStore,
+  type PracticeSessionOwner,
+} from '@/stores/questionBankStore';
 
 vi.mock('@/hooks/useBreakpoint', () => ({
   useBreakpoint: () => ({ isSmallScreen: false }),
@@ -63,10 +67,17 @@ describe('QuestionBankEditor AI markdown rendering', () => {
     };
 
     const onSubmitAnswer = vi.fn(async () => submitResult);
+    const practiceSessionOwner: PracticeSessionOwner = {
+      examId: 'session-1',
+      viewInstanceId: 'markdown-test-view',
+    };
+    useQuestionBankStore.setState({ practiceSessions: {} });
+    useQuestionBankStore.getState().ensurePracticeSession(practiceSessionOwner, ['q1']);
 
     render(
       <QuestionBankEditor
         sessionId="session-1"
+        practiceSessionOwner={practiceSessionOwner}
         questions={[question]}
         onSubmitAnswer={onSubmitAnswer}
       />

--- a/tests/vitest/question-bank-practice-progress.test.ts
+++ b/tests/vitest/question-bank-practice-progress.test.ts
@@ -9,7 +9,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 
-import { useQuestionBankStore } from '@/stores/questionBankStore';
+import {
+  getPracticeSessionKey,
+  useQuestionBankStore,
+  type PracticeSessionOwner,
+} from '@/stores/questionBankStore';
 import {
   normalizeDailyTarget,
   readStoredDailyTarget,
@@ -17,6 +21,59 @@ import {
 } from '@/components/practice/DailyPracticeMode';
 
 const startedAt = '2026-08-24T08:00:00.000Z';
+
+describe('questionBankStore practice-session ownership', () => {
+  const leftOwner: PracticeSessionOwner = {
+    examId: 'exam-shared',
+    viewInstanceId: 'view-left',
+  };
+  const rightOwner: PracticeSessionOwner = {
+    examId: 'exam-shared',
+    viewInstanceId: 'view-right',
+  };
+
+  beforeEach(() => {
+    useQuestionBankStore.setState({ practiceSessions: {} });
+  });
+
+  it('isolates answers between two kept-alive instances of the same exam', () => {
+    const store = useQuestionBankStore.getState();
+    store.ensurePracticeSession(leftOwner, ['q-1', 'q-2']);
+    store.ensurePracticeSession(rightOwner, ['q-1', 'q-2']);
+
+    expect(store.recordPracticeSessionAnswer(leftOwner, 'q-1', true)).toMatchObject({
+      streakCount: 1,
+      totalCorrectCount: 1,
+      answeredIds: ['q-1'],
+    });
+
+    const leftKey = getPracticeSessionKey(leftOwner)!;
+    const rightKey = getPracticeSessionKey(rightOwner)!;
+    expect(useQuestionBankStore.getState().practiceSessions[rightKey]).toMatchObject({
+      streakCount: 0,
+      totalCorrectCount: 0,
+      answeredIds: [],
+    });
+
+    store.recordPracticeSessionAnswer(rightOwner, 'q-2', false);
+    expect(useQuestionBankStore.getState().practiceSessions[leftKey]).toMatchObject({
+      streakCount: 1,
+      totalCorrectCount: 1,
+      answeredIds: ['q-1'],
+    });
+    expect(useQuestionBankStore.getState().practiceSessions[rightKey].answeredIds).toEqual(['q-2']);
+  });
+
+  it('fails closed for missing ownership and questions outside the owned exam', () => {
+    const store = useQuestionBankStore.getState();
+    store.ensurePracticeSession(leftOwner, ['q-left']);
+    const before = useQuestionBankStore.getState().practiceSessions;
+
+    expect(store.recordPracticeSessionAnswer(rightOwner, 'q-left', true)).toBeNull();
+    expect(store.recordPracticeSessionAnswer(leftOwner, 'q-right', true)).toBeNull();
+    expect(useQuestionBankStore.getState().practiceSessions).toBe(before);
+  });
+});
 
 function seedTimedSession(overrides: Record<string, unknown> = {}) {
   useQuestionBankStore.setState({

--- a/tests/vitest/question-bank-session-hook.test.tsx
+++ b/tests/vitest/question-bank-session-hook.test.tsx
@@ -24,6 +24,10 @@ vi.mock('@/debug-panel/plugins/ExamSheetProcessingDebugPlugin', () => ({
 }));
 
 import { useQuestionBankSession } from '@/hooks/useQuestionBankSession';
+import {
+  getPracticeSessionKey,
+  useQuestionBankStore,
+} from '@/stores/questionBankStore';
 
 function makeStoreQuestion(id: string, content: string) {
   return {
@@ -66,6 +70,50 @@ function makeStats(correctRate = 0) {
 describe('useQuestionBankSession', () => {
   beforeEach(() => {
     mockInvoke.mockReset();
+    useQuestionBankStore.setState({ practiceSessions: {} });
+  });
+
+  it('gives two kept-alive hook instances independent practice-session shards', async () => {
+    mockInvoke.mockImplementation(async (command: string) => {
+      if (command === 'qbank_get_stats') return makeStats();
+      if (command === 'qbank_list_questions') {
+        return {
+          questions: [makeStoreQuestion('q1', 'shared question')],
+          total: 1,
+          page: 1,
+          page_size: 50,
+          has_more: false,
+        };
+      }
+      throw new Error(`Unexpected invoke: ${command}`);
+    });
+
+    const { result } = renderHook(() => ({
+      left: useQuestionBankSession({ examId: 'exam_shared' }),
+      right: useQuestionBankSession({ examId: 'exam_shared' }),
+    }));
+
+    await waitFor(() => {
+      expect(result.current.left.questions).toHaveLength(1);
+      expect(result.current.right.questions).toHaveLength(1);
+    });
+
+    const leftOwner = result.current.left.practiceSessionOwner!;
+    const rightOwner = result.current.right.practiceSessionOwner!;
+    expect(leftOwner.examId).toBe('exam_shared');
+    expect(rightOwner.examId).toBe('exam_shared');
+    expect(leftOwner.viewInstanceId).not.toBe(rightOwner.viewInstanceId);
+
+    act(() => {
+      useQuestionBankStore.getState().recordPracticeSessionAnswer(leftOwner, 'q1', true);
+    });
+
+    const left = useQuestionBankStore.getState().practiceSessions[getPracticeSessionKey(leftOwner)!];
+    const right = useQuestionBankStore.getState().practiceSessions[getPracticeSessionKey(rightOwner)!];
+    expect(left.answeredIds).toEqual(['q1']);
+    expect(left.streakCount).toBe(1);
+    expect(right.answeredIds).toEqual([]);
+    expect(right.streakCount).toBe(0);
   });
 
   it('initial load fetches all pages instead of only the first page', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

题库练习进度不再用全局单槽。按 view/session 分片，答题记录带归属并 fail-closed，两个保活题库并行不得串台。

### Changes
- `questionBankStore.practiceSession` 改为按视图分片
- `recordPracticeSessionAnswer` 校验归属
- 双实例并行测试

### How to test
- 窄测：`question-bank-practice-progress`、`question-bank-session-hook`
- 本 PR 未跑全量 `npm run build` / `cargo build`

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ffbe94-512c-4a8c-abad-f6378cada875?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ffbe94-512c-4a8c-abad-f6378cada875&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

