### PR TITLE
reviewfix: gate critic QA flags on enable_qa_pass

### DIFF
--- a/src-tauri/src/anki_critic.rs
+++ b/src-tauri/src/anki_critic.rs
@@ -21,6 +21,11 @@
 //! - `flag`：仅在 `extra_fields["_qa_flags"]` 追加 `llm_critic` 条目留痕，
 //!   卡片内容不动（与 `anki_qa_lint` 的 Flag 语义一致，绝不丢卡）。
 //!
+//! `enable_qa_pass=false`（"不要 QA 留痕"公开契约）时裁决与统计照常执行，
+//! 但所有 `_qa_flags` 写入（flag 留痕 / revise 审计 / relint）一律不落盘，
+//! 与 `parse_and_save_card` 的入库收口保持同一语义；revise 的内容修订
+//! 仍写回（critic 由 `enable_critic_pass` 单独显式开启）。
+//!
 //! ## 设计硬约束
 //!
 //! - **默认关闭**：`CriticOptions::from_options_json` 解析同一份
@@ -674,6 +679,35 @@ pub fn plan_updates(cards: &[AnkiCard], verdicts: &[CardVerdict]) -> CriticPlan 
     plan
 }
 
+/// `enable_qa_pass=false` 时的落盘收口（纯函数，与 `parse_and_save_card`
+/// 在入库前移除 `_qa_flags` 的行为对齐）：
+///
+/// - 所有待写回卡片先剥离 `_qa_flags`（flag 留痕、`llm_critic_revised`
+///   审计条目、revise 后 relint 条目一律不落盘）；
+/// - 剥离后与原卡无内容差异的更新（典型为 flag 裁决）整体丢弃，
+///   避免空写回触发 CAS、递增 local_version 并进入同步链路。
+///
+/// 裁决统计（kept/revised/flagged）不在此改动——critic 观测照常，
+/// 只是不产生持久化 QA 留痕。
+pub fn sanitize_plan_for_disabled_qa_pass(plan: &mut CriticPlan, originals: &[AnkiCard]) {
+    plan.updates.retain_mut(|card| {
+        card.extra_fields.remove(anki_qa_lint::QA_FLAGS_FIELD);
+        let Some(orig) = originals.iter().find(|orig| orig.id == card.id) else {
+            // 原卡不在送审快照中理论上不可达；防御性保留写回交给 CAS 判定
+            return true;
+        };
+        // 对照原卡时同样忽略 _qa_flags：flag-only 更新必须判定为无差异，
+        // 不能因原卡带历史留痕而落盘一次"纯留痕删除"写回。
+        let mut orig_extra = orig.extra_fields.clone();
+        orig_extra.remove(anki_qa_lint::QA_FLAGS_FIELD);
+        card.front != orig.front
+            || card.back != orig.back
+            || card.text != orig.text
+            || card.tags != orig.tags
+            || card.extra_fields != orig_extra
+    });
+}
+
 fn join_reasons(reasons: &[String]) -> String {
     let joined = reasons
         .iter()
@@ -896,13 +930,25 @@ pub async fn run_critic_pass(
         Err(_) => Err(format!("超过 {} 秒未返回", CRITIC_MODEL_TIMEOUT_SECS)),
     };
 
-    let (plan, rejected_unknown_ids, degraded) =
+    let (mut plan, rejected_unknown_ids, degraded) =
         plan_from_model_output(model_output, &examined, &allowed_ids);
     summary.kept = plan.kept;
     summary.revised = plan.revised;
     summary.flagged = plan.flagged;
     summary.rejected_unknown_ids = rejected_unknown_ids;
     summary.degraded = degraded;
+
+    // enable_qa_pass=false（公开契约"不要 QA 留痕"）：裁决与统计照常，
+    // 但 flag 留痕 / revise 审计 / relint 的 _qa_flags 一律不落盘，
+    // 与 parse_and_save_card 的入库收口同语义。开关与 CriticOptions/
+    // 路由模式一样从同一份 options JSON 二次解析。
+    let qa_pass_enabled = crate::anki_protocol::StructuredOutputOptions::from_options_json(
+        &task.anki_generation_options_json,
+    )
+    .qa_pass_enabled();
+    if !qa_pass_enabled {
+        sanitize_plan_for_disabled_qa_pass(&mut plan, &examined);
+    }
 
     // 持久化：模型调用最长可达 180 秒，送审后用户可能已经编辑同一卡片。
     // 必须用送审快照的 updated_at 做 CAS，绝不能用无版本 UPDATE 覆盖用户新内容。
@@ -1237,6 +1283,82 @@ mod tests {
             "修订内容必须重跑确定性 lint: {:?}",
             flags
         );
+    }
+
+    // -------- enable_qa_pass=false 落盘收口 --------
+
+    #[test]
+    fn disabled_qa_pass_drops_flag_only_updates() {
+        let cards = vec![make_card("c1", "Q", "A")];
+        let verdicts = vec![CardVerdict {
+            card_id: "c1".to_string(),
+            verdict: Verdict::Flag,
+            reasons: vec!["答案疑似泄漏".to_string()],
+            revised: None,
+        }];
+        let mut plan = plan_updates(&cards, &verdicts);
+        assert_eq!(plan.updates.len(), 1, "前置：flag 裁决本身会产生留痕写回");
+
+        sanitize_plan_for_disabled_qa_pass(&mut plan, &cards);
+        assert!(
+            plan.updates.is_empty(),
+            "关 QA 留痕后 flag-only 更新必须整体丢弃，不得空写回"
+        );
+        assert_eq!(plan.flagged, 1, "裁决统计（观测）不受留痕收口影响");
+    }
+
+    #[test]
+    fn disabled_qa_pass_keeps_revision_content_without_qa_flags() {
+        // revise 引入占位符 → relint 命中 placeholder_residue；
+        // 关 QA 留痕时内容修订仍写回，但 _qa_flags（审计 + relint）不落盘。
+        let cards = vec![make_card("c1", "问题", "答案")];
+        let verdicts = vec![CardVerdict {
+            card_id: "c1".to_string(),
+            verdict: Verdict::Revise,
+            reasons: vec![],
+            revised: Some(RevisedFields {
+                back: Some("请参考 {{DOCUMENT_CONTENT}}".to_string()),
+                ..Default::default()
+            }),
+        }];
+        let mut plan = plan_updates(&cards, &verdicts);
+        assert!(
+            !qa_flags(&plan.updates[0]).is_empty(),
+            "前置：revise 会写入审计与 relint 条目"
+        );
+
+        sanitize_plan_for_disabled_qa_pass(&mut plan, &cards);
+        assert_eq!(plan.updates.len(), 1, "内容修订必须保留写回");
+        let updated = &plan.updates[0];
+        assert_eq!(updated.back, "请参考 {{DOCUMENT_CONTENT}}");
+        assert!(
+            !updated
+                .extra_fields
+                .contains_key(anki_qa_lint::QA_FLAGS_FIELD),
+            "关 QA 留痕后 llm_critic_revised 审计与 relint 条目均不得落盘"
+        );
+    }
+
+    #[test]
+    fn disabled_qa_pass_ignores_legacy_flags_when_diffing() {
+        // 原卡带历史 _qa_flags 时，flag-only 更新仍视为无差异：
+        // 不能借留痕收口落盘一次"纯留痕删除"写回。
+        let mut card = make_card("c1", "Q", "A");
+        card.extra_fields.insert(
+            anki_qa_lint::QA_FLAGS_FIELD.to_string(),
+            r#"[{"code":"answer_leak","field":"front","message":"旧留痕","severity":"warn"}]"#
+                .to_string(),
+        );
+        let cards = vec![card];
+        let verdicts = vec![CardVerdict {
+            card_id: "c1".to_string(),
+            verdict: Verdict::Flag,
+            reasons: vec![],
+            revised: None,
+        }];
+        let mut plan = plan_updates(&cards, &verdicts);
+        sanitize_plan_for_disabled_qa_pass(&mut plan, &cards);
+        assert!(plan.updates.is_empty(), "flag-only 更新不得因历史留痕落盘");
     }
 
     // -------- 降级路径 --------

--- a/src-tauri/src/streaming_anki_service.rs
+++ b/src-tauri/src/streaming_anki_service.rs
@@ -4476,7 +4476,10 @@ mod tests {
     async fn parse_and_save_card_honors_qa_pass_flag_persistence_contract() {
         let (svc, _dir) = make_persisted_test_service();
         let default_enabled = StructuredOutputOptions::from_options_json("{}").qa_pass_enabled();
-        assert!(default_enabled, "QA flag persistence must remain enabled by default");
+        assert!(
+            default_enabled,
+            "QA flag persistence must remain enabled by default"
+        );
 
         for (label, qa_pass_enabled, expect_flags) in [
             ("disabled", false, false),

--- a/src-tauri/src/streaming_anki_service.rs
+++ b/src-tauri/src/streaming_anki_service.rs
@@ -1901,11 +1901,6 @@ impl StreamingAnkiService {
             .map(|(k, v)| (k.clone(), self.clean_template_placeholders(v)))
             .collect();
 
-        // enable_qa_pass=false 时不携带字段 QA 违规留痕（校验本身照跑，仅不落盘）
-        if !qa_pass_enabled {
-            cleaned_extra_fields.remove(QA_FLAGS_FIELD);
-        }
-
         // Cloze 模板兼容：若模板声明 Text 字段但当前缺失，则尝试补齐
         let needs_text_field = resolved_template_fields
             .as_ref()
@@ -1966,6 +1961,12 @@ impl StreamingAnkiService {
             crate::anki_qa_lint::duplicate_key_source(&lint_input),
         ));
         crate::anki_qa_lint::merge_flags(&mut cleaned_extra_fields, &lint_issues);
+
+        // enable_qa_pass=false 时校验仍照常执行，但字段规则与 lint 的 QA 留痕均不落盘。
+        // 必须在 merge_flags 之后移除，避免 lint 将 _qa_flags 写回。
+        if !qa_pass_enabled {
+            cleaned_extra_fields.remove(QA_FLAGS_FIELD);
+        }
 
         // 首次入库时固化生成原文，供后续用户编辑后挖掘 grounded critic 修正对。
         // entry-once helper 不覆盖模板/用户已有值；超限或序列化失败仅少一份快照，
@@ -4469,6 +4470,63 @@ mod tests {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn parse_and_save_card_honors_qa_pass_flag_persistence_contract() {
+        let (svc, _dir) = make_persisted_test_service();
+        let default_enabled = StructuredOutputOptions::from_options_json("{}").qa_pass_enabled();
+        assert!(default_enabled, "QA flag persistence must remain enabled by default");
+
+        for (label, qa_pass_enabled, expect_flags) in [
+            ("disabled", false, false),
+            ("enabled", true, true),
+            ("default", default_enabled, true),
+        ] {
+            let document_id = format!("doc-qa-pass-{label}-{}", uuid::Uuid::new_v4());
+            let task_id = format!("qa-pass-{label}-task");
+            crate::anki_qa_lint::release_document_tracker(&document_id);
+            seed_task(&svc.db, &task_id, &document_id, 0);
+
+            // front == back is a deterministic lint violation produced after field extraction.
+            let identical = format!("{label} identical content");
+            let payload = json!({ "front": identical, "back": identical }).to_string();
+            let card = svc
+                .parse_and_save_card(
+                    &payload,
+                    &task_id,
+                    &document_id,
+                    &fingerprint_options(),
+                    qa_pass_enabled,
+                    None,
+                )
+                .await
+                .expect("invalid card must still parse")
+                .expect("invalid card must still be saved");
+
+            assert_eq!(
+                card.extra_fields.contains_key(QA_FLAGS_FIELD),
+                expect_flags,
+                "{label} QA mode returned unexpected _qa_flags"
+            );
+            if expect_flags {
+                assert!(
+                    qa_flag_codes(&card)
+                        .iter()
+                        .any(|code| code == "front_back_identical"),
+                    "{label} QA mode must preserve lint flags"
+                );
+            }
+
+            let persisted = svc.db.get_cards_for_task(&task_id).expect("stored card");
+            assert_eq!(persisted.len(), 1);
+            assert_eq!(
+                persisted[0].extra_fields.contains_key(QA_FLAGS_FIELD),
+                expect_flags,
+                "{label} QA mode persisted unexpected _qa_flags"
+            );
+            crate::anki_qa_lint::release_document_tracker(&document_id);
+        }
     }
 
     // -------------------- 收尾 #4：首次入库原文快照 --------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

#328 二检补漏：`enable_qa_pass=false` 时，critic relint 仍可能落盘 `_qa_flags`。本枝在 #328 之上把 critic 持久化也闸到同一开关。打进 `cursor/0824-cde6`，不要整支 merge 进 official 0824 或 main。不要改 #328 正文。

### Changes
- 保留 #328 的 streaming 入库闸门。
- `anki_critic.rs`：关闭 QA 时不再因 critic relint 写入 `_qa_flags`。

### How to test
- 对照 #328 + `b36b8356`。未跑全量编译 / Tauri。
- `enable_qa_pass=false` 且 critic 会命中 lint 的路径不应再落盘 `_qa_flags`。

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ffbe94-512c-4a8c-abad-f6378cada875?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ffbe94-512c-4a8c-abad-f6378cada875&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

