### PR TITLE
reviewfix: journal crypto key publication for crash-safe restore

### DIFF
--- a/src-tauri/src/crypto_publication.rs
+++ b/src-tauri/src/crypto_publication.rs
@@ -1,0 +1,386 @@
+//! 恢复流程全局密钥发布的持久化 journal 与启动侧恢复。
+//!
+//! 恢复切槽把备份中的 `.master_key`/`.secure` 发布到应用根目录，并在同一
+//! 事务内登记 restore cutover lease。发布涉及多次 rename 与一次 state 落盘，
+//! 进程若在中间崩溃，磁盘上会留下「活跃槽仍旧库 + 全局密钥已换」或
+//! 「根目录暂时无密钥」的撕裂状态。本模块在发布前写入 fsync 的 journal
+//! （记录旧密钥是否存在、将安装哪些文件、对应的 backup/target slot），
+//! 使下次启动可以确定性地收敛：
+//!
+//! - lease 已持久化且与 journal 匹配 → 发布视为已提交，前滚清理回滚目录；
+//! - lease 缺失 → 发布未提交，把旧密钥从固定回滚目录还原回根目录；
+//! - lease 存在但与 journal 不匹配 → 状态不可判定，fail-close 拒绝启动。
+//!
+//! journal 与回滚目录都放在应用根目录下的固定路径，与密钥同一文件系统，
+//! rename 保持原子。
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tracing::{info, warn};
+
+pub const CRYPTO_PUBLICATION_JOURNAL_FILE: &str = ".crypto_restore_journal.json";
+pub const CRYPTO_PUBLICATION_ROLLBACK_DIR: &str = ".crypto_restore_rollback";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CryptoPublicationJournal {
+    pub version: u32,
+    /// 切槽恢复流程填写；启动侧据此与 restore cutover lease 匹配判定前滚。
+    /// 非切槽调用方（如 pre-restore 密钥回滚）为 `None`，崩溃后一律回滚。
+    pub backup_id: Option<String>,
+    pub target_slot: Option<String>,
+    /// 发布前应用根目录是否已有旧 `.master_key` / `.secure`。
+    pub had_old_master: bool,
+    pub had_old_secure: bool,
+    /// 本次发布计划安装的内容。
+    pub installs_master: bool,
+    pub installs_secure: bool,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CryptoPublicationRecovery {
+    /// 没有未决的密钥发布事务。
+    Clean,
+    /// lease 已持久化，发布视为已提交，仅清理回滚目录与 journal。
+    RolledForward,
+    /// 发布未提交，已把全局密钥还原到发布前状态。
+    RolledBack,
+}
+
+pub fn journal_path(app_data_root: &Path) -> PathBuf {
+    app_data_root.join(CRYPTO_PUBLICATION_JOURNAL_FILE)
+}
+
+pub fn rollback_dir(app_data_root: &Path) -> PathBuf {
+    app_data_root.join(CRYPTO_PUBLICATION_ROLLBACK_DIR)
+}
+
+pub(crate) fn sync_directory(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        fs::File::open(path)?.sync_all()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+fn remove_path_if_exists(path: &Path) -> std::io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_dir() {
+                fs::remove_dir_all(path)
+            } else {
+                fs::remove_file(path)
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// 原子写入 journal：同目录临时文件 fsync 后 persist，再 fsync 目录。
+pub fn write_journal(
+    app_data_root: &Path,
+    journal: &CryptoPublicationJournal,
+) -> std::io::Result<()> {
+    use std::io::Write;
+
+    fs::create_dir_all(app_data_root)?;
+    let bytes = serde_json::to_vec_pretty(journal).map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("序列化密钥发布 journal 失败: {error}"),
+        )
+    })?;
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".crypto-journal-")
+        .suffix(".tmp")
+        .tempfile_in(app_data_root)?;
+    temporary.write_all(&bytes)?;
+    temporary.as_file().sync_all()?;
+    temporary
+        .into_temp_path()
+        .persist(journal_path(app_data_root))
+        .map_err(|error| error.error)?;
+    sync_directory(app_data_root)
+}
+
+pub fn remove_journal(app_data_root: &Path) -> std::io::Result<()> {
+    match fs::remove_file(journal_path(app_data_root)) {
+        Ok(()) => sync_directory(app_data_root),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// 启动时收敛未决的密钥发布事务。
+///
+/// `active_lease` 是当前持久化的 restore cutover lease `(backup_id, target_slot)`；
+/// 调用方需已确认 lease 与活跃槽一致（不一致时应在调用前 fail-close）。
+pub fn recover_crypto_publication(
+    app_data_root: &Path,
+    active_lease: Option<(&str, &str)>,
+) -> std::io::Result<CryptoPublicationRecovery> {
+    let journal_file = journal_path(app_data_root);
+    let rollback = rollback_dir(app_data_root);
+    let journal_bytes = match fs::read(&journal_file) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            // 没有未决事务；无 journal 的回滚目录来自已解决的发布，仅作清理。
+            remove_path_if_exists(&rollback)?;
+            return Ok(CryptoPublicationRecovery::Clean);
+        }
+        Err(error) => return Err(error),
+    };
+    let journal: CryptoPublicationJournal =
+        serde_json::from_slice(&journal_bytes).map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("密钥发布 journal 损坏，拒绝在不确定密钥状态上启动: {error}"),
+            )
+        })?;
+
+    let journal_cutover = journal
+        .backup_id
+        .as_deref()
+        .zip(journal.target_slot.as_deref());
+    match (journal_cutover, active_lease) {
+        (Some((journal_backup, journal_slot)), Some((lease_backup, lease_slot)))
+            if journal_backup == lease_backup && journal_slot == lease_slot =>
+        {
+            // 切槽 lease 已持久化：密钥发布视为已提交，前滚清理。
+            remove_path_if_exists(&rollback)?;
+            remove_journal(app_data_root)?;
+            info!("[CryptoPublication] 检测到已提交的密钥发布 journal，已前滚清理");
+            return Ok(CryptoPublicationRecovery::RolledForward);
+        }
+        (_, Some((lease_backup, lease_slot))) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "密钥发布 journal 与恢复维护租约不匹配（lease backup={lease_backup}, target={lease_slot}），拒绝自动修复"
+                ),
+            ));
+        }
+        _ => {}
+    }
+
+    rollback_entry(
+        app_data_root,
+        &rollback,
+        ".master_key",
+        journal.had_old_master,
+        journal.installs_master,
+        false,
+    )?;
+    rollback_entry(
+        app_data_root,
+        &rollback,
+        ".secure",
+        journal.had_old_secure,
+        journal.installs_secure,
+        true,
+    )?;
+    remove_path_if_exists(&rollback)?;
+    sync_directory(app_data_root)?;
+    remove_journal(app_data_root)?;
+    warn!("[CryptoPublication] 检测到未提交的密钥发布 journal，已回滚到发布前的全局密钥");
+    Ok(CryptoPublicationRecovery::RolledBack)
+}
+
+fn rollback_entry(
+    app_data_root: &Path,
+    rollback: &Path,
+    name: &str,
+    had_old: bool,
+    installs: bool,
+    is_dir: bool,
+) -> std::io::Result<()> {
+    let target = app_data_root.join(name);
+    let saved = rollback.join(name);
+    if fs::symlink_metadata(&saved).is_ok() {
+        // 旧文件已被移入回滚目录：目标上无论是新密钥还是空缺都还原为旧文件。
+        remove_path_if_exists(&target)?;
+        fs::rename(&saved, &target)?;
+        restore_permissions(&target, is_dir);
+        return Ok(());
+    }
+    if !had_old && installs {
+        // 发布前目标不存在：目前存在的只可能是未提交的新文件。
+        remove_path_if_exists(&target)?;
+    }
+    // had_old 且回滚目录中缺失：旧文件从未被移出，目标保持原样。
+    Ok(())
+}
+
+fn restore_permissions(path: &Path, is_dir: bool) {
+    crate::secure_store::SecureStore::restrict_permissions(path, is_dir);
+    if is_dir {
+        if let Ok(entries) = fs::read_dir(path) {
+            for entry in entries.flatten() {
+                if entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                    crate::secure_store::SecureStore::restrict_permissions(&entry.path(), false);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn cutover_journal(had_old: bool) -> CryptoPublicationJournal {
+        CryptoPublicationJournal {
+            version: 1,
+            backup_id: Some("backup-1".to_string()),
+            target_slot: Some("slotB".to_string()),
+            had_old_master: had_old,
+            had_old_secure: had_old,
+            installs_master: true,
+            installs_secure: true,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+
+    fn seed_torn_publication(root: &Path, had_old: bool) {
+        let rollback = rollback_dir(root);
+        fs::create_dir_all(&rollback).unwrap();
+        if had_old {
+            fs::write(rollback.join(".master_key"), b"old-master").unwrap();
+            let old_secure = rollback.join(".secure");
+            fs::create_dir_all(&old_secure).unwrap();
+            fs::write(old_secure.join(".key_seed"), b"old-seed").unwrap();
+            fs::write(old_secure.join("old.enc"), b"old-credential").unwrap();
+        }
+        fs::write(root.join(".master_key"), b"new-master").unwrap();
+        let new_secure = root.join(".secure");
+        fs::create_dir_all(&new_secure).unwrap();
+        fs::write(new_secure.join(".key_seed"), b"new-seed").unwrap();
+        write_journal(root, &cutover_journal(had_old)).unwrap();
+    }
+
+    #[test]
+    fn recover_without_journal_is_clean_and_sweeps_stale_rollback() {
+        let root = TempDir::new().unwrap();
+        fs::create_dir_all(rollback_dir(root.path())).unwrap();
+        fs::write(rollback_dir(root.path()).join(".master_key"), b"stale").unwrap();
+
+        let outcome = recover_crypto_publication(root.path(), None).unwrap();
+
+        assert_eq!(outcome, CryptoPublicationRecovery::Clean);
+        assert!(!rollback_dir(root.path()).exists());
+    }
+
+    #[test]
+    fn uncommitted_publication_rolls_back_previous_keys() {
+        let root = TempDir::new().unwrap();
+        seed_torn_publication(root.path(), true);
+
+        let outcome = recover_crypto_publication(root.path(), None).unwrap();
+
+        assert_eq!(outcome, CryptoPublicationRecovery::RolledBack);
+        assert_eq!(
+            fs::read(root.path().join(".master_key")).unwrap(),
+            b"old-master"
+        );
+        assert_eq!(
+            fs::read(root.path().join(".secure/.key_seed")).unwrap(),
+            b"old-seed"
+        );
+        assert_eq!(
+            fs::read(root.path().join(".secure/old.enc")).unwrap(),
+            b"old-credential"
+        );
+        assert!(!journal_path(root.path()).exists());
+        assert!(!rollback_dir(root.path()).exists());
+    }
+
+    #[test]
+    fn uncommitted_publication_removes_new_keys_when_no_previous_generation() {
+        let root = TempDir::new().unwrap();
+        seed_torn_publication(root.path(), false);
+
+        let outcome = recover_crypto_publication(root.path(), None).unwrap();
+
+        assert_eq!(outcome, CryptoPublicationRecovery::RolledBack);
+        assert!(!root.path().join(".master_key").exists());
+        assert!(!root.path().join(".secure").exists());
+        assert!(!journal_path(root.path()).exists());
+        assert!(!rollback_dir(root.path()).exists());
+    }
+
+    #[test]
+    fn crash_before_moving_old_keys_leaves_target_untouched() {
+        let root = TempDir::new().unwrap();
+        // journal 已写入但 rename 尚未开始：目标仍是旧密钥，回滚目录为空。
+        fs::write(root.path().join(".master_key"), b"old-master").unwrap();
+        let old_secure = root.path().join(".secure");
+        fs::create_dir_all(&old_secure).unwrap();
+        fs::write(old_secure.join(".key_seed"), b"old-seed").unwrap();
+        fs::create_dir_all(rollback_dir(root.path())).unwrap();
+        write_journal(root.path(), &cutover_journal(true)).unwrap();
+
+        let outcome = recover_crypto_publication(root.path(), None).unwrap();
+
+        assert_eq!(outcome, CryptoPublicationRecovery::RolledBack);
+        assert_eq!(
+            fs::read(root.path().join(".master_key")).unwrap(),
+            b"old-master"
+        );
+        assert_eq!(
+            fs::read(root.path().join(".secure/.key_seed")).unwrap(),
+            b"old-seed"
+        );
+        assert!(!journal_path(root.path()).exists());
+    }
+
+    #[test]
+    fn committed_publication_rolls_forward_and_keeps_new_keys() {
+        let root = TempDir::new().unwrap();
+        seed_torn_publication(root.path(), true);
+
+        let outcome =
+            recover_crypto_publication(root.path(), Some(("backup-1", "slotB"))).unwrap();
+
+        assert_eq!(outcome, CryptoPublicationRecovery::RolledForward);
+        assert_eq!(
+            fs::read(root.path().join(".master_key")).unwrap(),
+            b"new-master"
+        );
+        assert_eq!(
+            fs::read(root.path().join(".secure/.key_seed")).unwrap(),
+            b"new-seed"
+        );
+        assert!(!journal_path(root.path()).exists());
+        assert!(!rollback_dir(root.path()).exists());
+    }
+
+    #[test]
+    fn mismatched_lease_fails_closed() {
+        let root = TempDir::new().unwrap();
+        seed_torn_publication(root.path(), true);
+
+        let error = recover_crypto_publication(root.path(), Some(("other-backup", "slotA")))
+            .expect_err("mismatched lease must not be auto-repaired");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(journal_path(root.path()).exists());
+    }
+
+    #[test]
+    fn corrupted_journal_fails_closed() {
+        let root = TempDir::new().unwrap();
+        fs::write(journal_path(root.path()), b"not-json").unwrap();
+
+        let error = recover_crypto_publication(root.path(), None)
+            .expect_err("corrupted journal must not be auto-repaired");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    }
+}

--- a/src-tauri/src/data_governance/backup/mod.rs
+++ b/src-tauri/src/data_governance/backup/mod.rs
@@ -3552,17 +3552,23 @@ impl BackupManager {
         manifest: &BackupManifest,
         backup_subdir: &Path,
     ) -> Result<usize, BackupError> {
-        self.restore_crypto_keys_from_manifest_transactional(manifest, backup_subdir, |_| Ok(()))
+        self.restore_crypto_keys_from_manifest_transactional(manifest, backup_subdir, None, |_| {
+            Ok(())
+        })
     }
 
     /// Publish manifest-verified crypto material and keep the previous global
     /// generation available until `after_publish` durably commits the matching
     /// restore cutover. If that commit fails, both `.master_key` and `.secure`
     /// are restored to their exact pre-publication state.
+    ///
+    /// `cutover` 为 `(backup_id, target_slot)`，写入持久化 journal；进程在发布
+    /// 中途崩溃时，启动侧据其与 restore cutover lease 的匹配结果前滚或回滚。
     pub(crate) fn restore_crypto_keys_from_manifest_transactional<F>(
         &self,
         manifest: &BackupManifest,
         backup_subdir: &Path,
+        cutover: Option<(&str, &str)>,
         after_publish: F,
     ) -> Result<usize, BackupError>
     where
@@ -3607,7 +3613,7 @@ impl BackupManager {
             }
         }
         Self::verify_crypto_material(manifest, backup_subdir)?;
-        self.restore_crypto_keys_transactional(backup_subdir, after_publish)
+        self.restore_crypto_keys_transactional(backup_subdir, cutover, after_publish)
     }
 
     /// 从备份目录恢复加密密钥文件到应用数据目录
@@ -3615,12 +3621,13 @@ impl BackupManager {
     /// 恢复 `.master_key` 和 `.secure/` 目录，使跨设备恢复后 API 密钥可正常解密。
     /// 仅在备份中包含 crypto/ 子目录时执行。
     pub fn restore_crypto_keys(&self, backup_subdir: &Path) -> Result<usize, BackupError> {
-        self.restore_crypto_keys_transactional(backup_subdir, |_| Ok(()))
+        self.restore_crypto_keys_transactional(backup_subdir, None, |_| Ok(()))
     }
 
     fn restore_crypto_keys_transactional<F>(
         &self,
         backup_subdir: &Path,
+        cutover: Option<(&str, &str)>,
         after_publish: F,
     ) -> Result<usize, BackupError>
     where
@@ -3811,25 +3818,57 @@ impl BackupManager {
         }
 
         let app_data_root = self.application_data_root();
-        let rollback = tempfile::Builder::new()
-            .prefix("crypto-restore-rollback-")
-            .tempdir_in(&app_data_root)
-            .map_err(|e| BackupError::RestoreFailed(format!("创建密钥回滚目录失败: {}", e)))?;
+        if crate::crypto_publication::journal_path(&app_data_root).exists() {
+            return Err(BackupError::RestoreFailed(
+                "检测到未决的密钥发布 journal，请先重启应用完成恢复后重试".to_string(),
+            ));
+        }
+        let rollback_dir = crate::crypto_publication::rollback_dir(&app_data_root);
+        // 无 journal 的残留回滚目录来自已解决的发布，重建为本次发布的空回滚点。
+        remove_crypto_path(&rollback_dir).map_err(|e| {
+            BackupError::RestoreFailed(format!("清理残留密钥回滚目录失败，目标密钥保持不变: {}", e))
+        })?;
+        fs::create_dir(&rollback_dir)?;
+        crate::secure_store::SecureStore::restrict_permissions(&rollback_dir, true);
         let target_master = app_data_root.join(".master_key");
         let target_secure = app_data_root.join(".secure");
-        let rollback_master = rollback.path().join(".master_key");
-        let rollback_secure = rollback.path().join(".secure");
+        let rollback_master = rollback_dir.join(".master_key");
+        let rollback_secure = rollback_dir.join(".secure");
+        let had_old_master = fs::symlink_metadata(&target_master).is_ok();
+        let had_old_secure = fs::symlink_metadata(&target_secure).is_ok();
+
+        // 发布是「旧密钥移出 → 新密钥装入 → cutover lease 落盘」的多步过程，
+        // 任一步之间崩溃都可能留下密钥/槽位代际错位。journal 先于任何 rename
+        // 落盘，使启动侧能确定性地前滚（lease 已持久化）或回滚（lease 缺失）。
+        let journal = crate::crypto_publication::CryptoPublicationJournal {
+            version: 1,
+            backup_id: cutover.map(|(backup_id, _)| backup_id.to_string()),
+            target_slot: cutover.map(|(_, slot)| slot.to_string()),
+            had_old_master,
+            had_old_secure,
+            installs_master: has_master,
+            installs_secure: has_secure,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        };
+        if let Err(e) = crate::crypto_publication::write_journal(&app_data_root, &journal) {
+            let _ = remove_crypto_path(&rollback_dir);
+            return Err(BackupError::RestoreFailed(format!(
+                "写入密钥发布 journal 失败，目标密钥保持不变: {}",
+                e
+            )));
+        }
+
         let mut moved_master = false;
         let mut moved_secure = false;
         let mut installed_master = false;
         let mut installed_secure = false;
 
         let commit_result: Result<(), BackupError> = (|| {
-            if has_master && fs::symlink_metadata(&target_master).is_ok() {
+            if has_master && had_old_master {
                 fs::rename(&target_master, &rollback_master)?;
                 moved_master = true;
             }
-            if has_secure && fs::symlink_metadata(&target_secure).is_ok() {
+            if has_secure && had_old_secure {
                 fs::rename(&target_secure, &rollback_secure)?;
                 moved_secure = true;
             }
@@ -3855,11 +3894,18 @@ impl BackupManager {
                 moved_master,
                 moved_secure,
             );
+            // 回滚干净时事务已就地解决；否则保留 journal 供下次启动继续修复。
+            if rollback_errors.is_empty() {
+                if let Err(e) = crate::crypto_publication::remove_journal(&app_data_root) {
+                    warn!("[Restore] 清理密钥发布 journal 失败（启动侧回滚为幂等空操作）: {}", e);
+                }
+                let _ = remove_crypto_path(&rollback_dir);
+            }
             return Err(BackupError::RestoreFailed(if rollback_errors.is_empty() {
                 format!("密钥原子提交失败，已恢复原目标: {}", commit_error)
             } else {
                 format!(
-                    "密钥原子提交失败且回滚不完整: {}; {}",
+                    "密钥原子提交失败且回滚不完整（journal 已保留，重启后自动修复）: {}; {}",
                     commit_error,
                     rollback_errors.join("; ")
                 )
@@ -3868,6 +3914,11 @@ impl BackupManager {
 
         let restored = usize::from(has_master) + secure_file_count;
         let publish_result = (|| -> Result<(), BackupError> {
+            // 在登记 cutover lease 之前把密钥 rename 落盘：崩溃后不允许出现
+            // 「lease 已持久化但密钥安装未持久化」的组合。
+            crate::crypto_publication::sync_directory(&app_data_root).map_err(|e| {
+                BackupError::RestoreFailed(format!("密钥发布落盘失败: {}", e))
+            })?;
             if has_master {
                 crate::secure_store::SecureStore::restrict_permissions(&target_master, false);
             }
@@ -3897,6 +3948,12 @@ impl BackupManager {
                 moved_master,
                 moved_secure,
             );
+            if rollback_errors.is_empty() {
+                if let Err(e) = crate::crypto_publication::remove_journal(&app_data_root) {
+                    warn!("[Restore] 清理密钥发布 journal 失败（启动侧回滚为幂等空操作）: {}", e);
+                }
+                let _ = remove_crypto_path(&rollback_dir);
+            }
             return Err(BackupError::RestoreFailed(if rollback_errors.is_empty() {
                 format!(
                     "密钥发布后的恢复切槽提交失败，已恢复旧密钥: {}",
@@ -3904,11 +3961,55 @@ impl BackupManager {
                 )
             } else {
                 format!(
-                    "密钥发布后的恢复切槽提交失败且旧密钥回滚不完整: {}; {}",
+                    "密钥发布后的恢复切槽提交失败且旧密钥回滚不完整（journal 已保留，重启后自动修复）: {}; {}",
                     cutover_error,
                     rollback_errors.join("; ")
                 )
             }));
+        }
+
+        match crate::crypto_publication::remove_journal(&app_data_root) {
+            Ok(()) => {
+                if let Err(e) = remove_crypto_path(&rollback_dir) {
+                    warn!(
+                        "[Restore] 清理密钥回滚目录失败（残留将在下次启动清理）: {}",
+                        e
+                    );
+                }
+            }
+            Err(journal_error) if cutover.is_some() => {
+                // lease 已持久化，启动侧会按前滚清理残留的 journal 与回滚目录。
+                warn!(
+                    "[Restore] 清理密钥发布 journal 失败，下次启动将按已登记切槽前滚清理: {}",
+                    journal_error
+                );
+            }
+            Err(journal_error) => {
+                // 非切槽调用没有 lease 供前滚判定，残留 journal 会在下次启动
+                // 回滚本次发布；就地撤销并如实报告失败。
+                let rollback_errors = rollback_published_crypto(
+                    &target_master,
+                    &target_secure,
+                    &rollback_master,
+                    &rollback_secure,
+                    installed_master,
+                    installed_secure,
+                    moved_master,
+                    moved_secure,
+                );
+                return Err(BackupError::RestoreFailed(if rollback_errors.is_empty() {
+                    format!(
+                        "密钥发布 journal 清理失败，已恢复旧密钥: {}",
+                        journal_error
+                    )
+                } else {
+                    format!(
+                        "密钥发布 journal 清理失败且旧密钥回滚不完整（journal 已保留，重启后自动修复）: {}; {}",
+                        journal_error,
+                        rollback_errors.join("; ")
+                    )
+                }));
+            }
         }
         info!("[Restore] 加密密钥原子恢复完成: {} 个文件", restored);
         Ok(restored)

--- a/src-tauri/src/data_governance/backup/mod.rs
+++ b/src-tauri/src/data_governance/backup/mod.rs
@@ -344,6 +344,40 @@ fn remove_crypto_path(path: &Path) -> std::io::Result<()> {
     }
 }
 
+fn rollback_published_crypto(
+    target_master: &Path,
+    target_secure: &Path,
+    rollback_master: &Path,
+    rollback_secure: &Path,
+    installed_master: bool,
+    installed_secure: bool,
+    moved_master: bool,
+    moved_secure: bool,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+    if installed_master {
+        if let Err(error) = remove_crypto_path(target_master) {
+            errors.push(format!("删除新主密钥失败: {}", error));
+        }
+    }
+    if installed_secure {
+        if let Err(error) = remove_crypto_path(target_secure) {
+            errors.push(format!("删除新安全目录失败: {}", error));
+        }
+    }
+    if moved_master {
+        if let Err(error) = fs::rename(rollback_master, target_master) {
+            errors.push(format!("恢复旧主密钥失败: {}", error));
+        }
+    }
+    if moved_secure {
+        if let Err(error) = fs::rename(rollback_secure, target_secure) {
+            errors.push(format!("恢复旧安全目录失败: {}", error));
+        }
+    }
+    errors
+}
+
 /// 生成安全且高概率唯一的备份 ID（目录名）
 ///
 /// 约束：
@@ -3518,12 +3552,29 @@ impl BackupManager {
         manifest: &BackupManifest,
         backup_subdir: &Path,
     ) -> Result<usize, BackupError> {
+        self.restore_crypto_keys_from_manifest_transactional(manifest, backup_subdir, |_| Ok(()))
+    }
+
+    /// Publish manifest-verified crypto material and keep the previous global
+    /// generation available until `after_publish` durably commits the matching
+    /// restore cutover. If that commit fails, both `.master_key` and `.secure`
+    /// are restored to their exact pre-publication state.
+    pub(crate) fn restore_crypto_keys_from_manifest_transactional<F>(
+        &self,
+        manifest: &BackupManifest,
+        backup_subdir: &Path,
+        after_publish: F,
+    ) -> Result<usize, BackupError>
+    where
+        F: FnOnce(usize) -> Result<(), BackupError>,
+    {
         let plan = manifest
             .crypto_restore_plan()
             .ok_or_else(|| BackupError::Manifest("备份缺少 crypto restore plan".to_string()))?;
         let actual_files = Self::collect_backup_files_under(backup_subdir, "crypto")?;
         if matches!(plan.status, CoverageStatus::Absent | CoverageStatus::Empty) {
             if actual_files.is_empty() {
+                after_publish(0)?;
                 return Ok(0);
             }
             return Err(BackupError::Manifest(
@@ -3556,7 +3607,7 @@ impl BackupManager {
             }
         }
         Self::verify_crypto_material(manifest, backup_subdir)?;
-        self.restore_crypto_keys(backup_subdir)
+        self.restore_crypto_keys_transactional(backup_subdir, after_publish)
     }
 
     /// 从备份目录恢复加密密钥文件到应用数据目录
@@ -3564,6 +3615,17 @@ impl BackupManager {
     /// 恢复 `.master_key` 和 `.secure/` 目录，使跨设备恢复后 API 密钥可正常解密。
     /// 仅在备份中包含 crypto/ 子目录时执行。
     pub fn restore_crypto_keys(&self, backup_subdir: &Path) -> Result<usize, BackupError> {
+        self.restore_crypto_keys_transactional(backup_subdir, |_| Ok(()))
+    }
+
+    fn restore_crypto_keys_transactional<F>(
+        &self,
+        backup_subdir: &Path,
+        after_publish: F,
+    ) -> Result<usize, BackupError>
+    where
+        F: FnOnce(usize) -> Result<(), BackupError>,
+    {
         let backup_metadata = fs::symlink_metadata(backup_subdir).map_err(|e| {
             BackupError::RestoreFailed(format!("无法检查备份目录，目标密钥保持不变: {}", e))
         })?;
@@ -3575,7 +3637,10 @@ impl BackupManager {
 
         let crypto_src = backup_subdir.join("crypto");
         match fs::symlink_metadata(&crypto_src) {
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                after_publish(0)?;
+                return Ok(0);
+            }
             Ok(metadata) if !metadata.file_type().is_symlink() && metadata.is_dir() => {}
             Ok(_) => {
                 return Err(BackupError::RestoreFailed(
@@ -3726,6 +3791,7 @@ impl BackupManager {
             })?;
         }
         if !has_master && !has_secure {
+            after_publish(0)?;
             return Ok(0);
         }
 
@@ -3779,27 +3845,16 @@ impl BackupManager {
         })();
 
         if let Err(commit_error) = commit_result {
-            let mut rollback_errors = Vec::new();
-            if installed_master {
-                if let Err(e) = remove_crypto_path(&target_master) {
-                    rollback_errors.push(format!("删除新主密钥失败: {}", e));
-                }
-            }
-            if installed_secure {
-                if let Err(e) = remove_crypto_path(&target_secure) {
-                    rollback_errors.push(format!("删除新安全目录失败: {}", e));
-                }
-            }
-            if moved_master {
-                if let Err(e) = fs::rename(&rollback_master, &target_master) {
-                    rollback_errors.push(format!("恢复旧主密钥失败: {}", e));
-                }
-            }
-            if moved_secure {
-                if let Err(e) = fs::rename(&rollback_secure, &target_secure) {
-                    rollback_errors.push(format!("恢复旧安全目录失败: {}", e));
-                }
-            }
+            let rollback_errors = rollback_published_crypto(
+                &target_master,
+                &target_secure,
+                &rollback_master,
+                &rollback_secure,
+                installed_master,
+                installed_secure,
+                moved_master,
+                moved_secure,
+            );
             return Err(BackupError::RestoreFailed(if rollback_errors.is_empty() {
                 format!("密钥原子提交失败，已恢复原目标: {}", commit_error)
             } else {
@@ -3811,20 +3866,50 @@ impl BackupManager {
             }));
         }
 
-        if has_master {
-            crate::secure_store::SecureStore::restrict_permissions(&target_master, false);
-        }
-        if has_secure {
-            crate::secure_store::SecureStore::restrict_permissions(&target_secure, true);
-            for entry in fs::read_dir(&target_secure)? {
-                let entry = entry?;
-                if entry.file_type()?.is_file() {
-                    crate::secure_store::SecureStore::restrict_permissions(&entry.path(), false);
+        let restored = usize::from(has_master) + secure_file_count;
+        let publish_result = (|| -> Result<(), BackupError> {
+            if has_master {
+                crate::secure_store::SecureStore::restrict_permissions(&target_master, false);
+            }
+            if has_secure {
+                crate::secure_store::SecureStore::restrict_permissions(&target_secure, true);
+                for entry in fs::read_dir(&target_secure)? {
+                    let entry = entry?;
+                    if entry.file_type()?.is_file() {
+                        crate::secure_store::SecureStore::restrict_permissions(
+                            &entry.path(),
+                            false,
+                        );
+                    }
                 }
             }
-        }
+            after_publish(restored)
+        })();
 
-        let restored = usize::from(has_master) + secure_file_count;
+        if let Err(cutover_error) = publish_result {
+            let rollback_errors = rollback_published_crypto(
+                &target_master,
+                &target_secure,
+                &rollback_master,
+                &rollback_secure,
+                installed_master,
+                installed_secure,
+                moved_master,
+                moved_secure,
+            );
+            return Err(BackupError::RestoreFailed(if rollback_errors.is_empty() {
+                format!(
+                    "密钥发布后的恢复切槽提交失败，已恢复旧密钥: {}",
+                    cutover_error
+                )
+            } else {
+                format!(
+                    "密钥发布后的恢复切槽提交失败且旧密钥回滚不完整: {}; {}",
+                    cutover_error,
+                    rollback_errors.join("; ")
+                )
+            }));
+        }
         info!("[Restore] 加密密钥原子恢复完成: {} 个文件", restored);
         Ok(restored)
     }

--- a/src-tauri/src/data_governance/commands_restore.rs
+++ b/src-tauri/src/data_governance/commands_restore.rs
@@ -85,6 +85,7 @@ fn publish_restore_keys_and_commit_cutover<F>(
     manager: &super::backup::BackupManager,
     manifest: &super::backup::BackupManifest,
     backup_subdir: &Path,
+    target_slot: &str,
     commit_cutover: F,
 ) -> Result<usize, String>
 where
@@ -92,16 +93,24 @@ where
 {
     let keys_required = manifest.key_policy == super::backup::BackupKeyPolicy::IncludedLocal;
     manager
-        .restore_crypto_keys_from_manifest_transactional(manifest, backup_subdir, move |restored| {
-            if keys_required && restored == 0 {
-                return Err(super::backup::BackupError::RestoreFailed(
-                    "备份声明包含加密密钥，但未恢复任何密钥文件".to_string(),
-                ));
-            }
-            commit_cutover().map_err(|error| {
-                super::backup::BackupError::RestoreFailed(format!("登记恢复切槽失败: {}", error))
-            })
-        })
+        .restore_crypto_keys_from_manifest_transactional(
+            manifest,
+            backup_subdir,
+            Some((manifest.backup_id.as_str(), target_slot)),
+            move |restored| {
+                if keys_required && restored == 0 {
+                    return Err(super::backup::BackupError::RestoreFailed(
+                        "备份声明包含加密密钥，但未恢复任何密钥文件".to_string(),
+                    ));
+                }
+                commit_cutover().map_err(|error| {
+                    super::backup::BackupError::RestoreFailed(format!(
+                        "登记恢复切槽失败: {}",
+                        error
+                    ))
+                })
+            },
+        )
         .map_err(|error| error.to_string())
 }
 
@@ -1086,23 +1095,30 @@ async fn execute_restore_with_progress(
     }
 
     // The candidate is fully restored, migrated, baselined and protected by
-    // the maintenance barrier. Keep the previous global crypto generation in
-    // the publication rollback directory until pending-slot registration is
-    // durable; a registration failure restores the old keys before returning.
-    let restored_crypto_keys =
-        match publish_restore_keys_and_commit_cutover(&manager, &manifest, &backup_subdir, || {
+    // the maintenance barrier. Key publication writes a durable journal first,
+    // keeps the previous global crypto generation in the fixed rollback
+    // directory until pending-slot registration is durable, and a registration
+    // failure restores the old keys before returning. A crash mid-publication
+    // is reconciled at next startup by matching the journal against the lease.
+    let restored_crypto_keys = match publish_restore_keys_and_commit_cutover(
+        &manager,
+        &manifest,
+        &backup_subdir,
+        inactive_slot.name(),
+        || {
             data_space_manager
                 .mark_restore_cutover_pending(inactive_slot, &backup_id)
                 .map_err(|error| error.to_string())
-        }) {
-            Ok(count) => count,
-            Err(error) => {
-                let _ = set_restore_cutover_maintenance(&app, false);
-                let _ = std::fs::remove_file(inactive_dir.join(RESTORE_ACTIVATION_MARKER));
-                job_ctx.fail(format!("提交恢复密钥与切槽失败: {}", error));
-                return;
-            }
-        };
+        },
+    ) {
+        Ok(count) => count,
+        Err(error) => {
+            let _ = set_restore_cutover_maintenance(&app, false);
+            let _ = std::fs::remove_file(inactive_dir.join(RESTORE_ACTIVATION_MARKER));
+            job_ctx.fail(format!("提交恢复密钥与切槽失败: {}", error));
+            return;
+        }
+    };
     if restored_crypto_keys > 0 {
         info!(
             "[data_governance] 加密密钥与恢复切槽原子提交完成: {} 个文件",
@@ -1287,6 +1303,7 @@ mod tests {
                 &manager,
                 &manifest,
                 &backup_subdir,
+                Slot::B.name(),
                 || {
                     failure_injected_after_publication = true;
                     assert_eq!(
@@ -1298,6 +1315,10 @@ mod tests {
                         new_seed
                     );
                     assert_eq!(data_space.active_slot(), Slot::A);
+                    // 密钥发布期间 journal 必须已持久化，供崩溃后的启动侧收敛。
+                    assert!(
+                        crate::crypto_publication::journal_path(app_data.path()).exists()
+                    );
                     Err("injected post-key-publication failure".to_string())
                 },
             )
@@ -1307,6 +1328,9 @@ mod tests {
             assert!(error.contains("已恢复旧密钥"), "{error}");
             assert_eq!(data_space.active_slot(), Slot::A);
             assert!(data_space.restore_cutover_pending().unwrap().is_none());
+            // 就地回滚成功后事务已解决：journal 与回滚目录不得残留。
+            assert!(!crate::crypto_publication::journal_path(app_data.path()).exists());
+            assert!(!crate::crypto_publication::rollback_dir(app_data.path()).exists());
             if old_keys_exist {
                 assert_eq!(
                     fs::read(app_data.path().join(".master_key")).unwrap(),

--- a/src-tauri/src/data_governance/commands_restore.rs
+++ b/src-tauri/src/data_governance/commands_restore.rs
@@ -81,6 +81,30 @@ fn write_restore_activation_marker(
     )
 }
 
+fn publish_restore_keys_and_commit_cutover<F>(
+    manager: &super::backup::BackupManager,
+    manifest: &super::backup::BackupManifest,
+    backup_subdir: &Path,
+    commit_cutover: F,
+) -> Result<usize, String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    let keys_required = manifest.key_policy == super::backup::BackupKeyPolicy::IncludedLocal;
+    manager
+        .restore_crypto_keys_from_manifest_transactional(manifest, backup_subdir, move |restored| {
+            if keys_required && restored == 0 {
+                return Err(super::backup::BackupError::RestoreFailed(
+                    "备份声明包含加密密钥，但未恢复任何密钥文件".to_string(),
+                ));
+            }
+            commit_cutover().map_err(|error| {
+                super::backup::BackupError::RestoreFailed(format!("登记恢复切槽失败: {}", error))
+            })
+        })
+        .map_err(|error| error.to_string())
+}
+
 /// Commit device/cursor generation only after the restored slot has become
 /// active and its migrations have succeeded during startup.
 pub(crate) fn finalize_restore_activation(active_dir: &Path) -> Result<bool, String> {
@@ -857,27 +881,6 @@ async fn execute_restore_with_progress(
         return;
     }
 
-    // ============ 阶段 3a: 恢复加密密钥（跨设备恢复支持） ============
-    manager.set_app_data_dir(inactive_dir.clone());
-    match manager.restore_crypto_keys(&backup_subdir) {
-        Ok(count) => {
-            if manifest.key_policy == super::backup::BackupKeyPolicy::IncludedLocal && count == 0 {
-                job_ctx.fail("备份声明包含加密密钥，但未恢复任何密钥文件".to_string());
-                return;
-            }
-            if count > 0 {
-                info!(
-                    "[data_governance] 加密密钥恢复完成: {} 个文件（API 密钥可跨设备解密）",
-                    count
-                );
-            }
-        }
-        Err(e) => {
-            job_ctx.fail(format!("加密密钥恢复失败: {}", e));
-            return;
-        }
-    }
-
     // ============ 阶段 3b: Replace/Assets (80-92%) - 恢复资产文件 ============
     if restore_assets == Some(false) {
         job_ctx.fail("完整快照恢复不能跳过资产；请使用完整恢复".to_string());
@@ -1082,11 +1085,29 @@ async fn execute_restore_with_progress(
         return;
     }
 
-    if let Err(e) = data_space_manager.mark_restore_cutover_pending(inactive_slot, &backup_id) {
-        let _ = set_restore_cutover_maintenance(&app, false);
-        let _ = std::fs::remove_file(inactive_dir.join(RESTORE_ACTIVATION_MARKER));
-        job_ctx.fail(format!("登记恢复切槽失败: {}", e));
-        return;
+    // The candidate is fully restored, migrated, baselined and protected by
+    // the maintenance barrier. Keep the previous global crypto generation in
+    // the publication rollback directory until pending-slot registration is
+    // durable; a registration failure restores the old keys before returning.
+    let restored_crypto_keys =
+        match publish_restore_keys_and_commit_cutover(&manager, &manifest, &backup_subdir, || {
+            data_space_manager
+                .mark_restore_cutover_pending(inactive_slot, &backup_id)
+                .map_err(|error| error.to_string())
+        }) {
+            Ok(count) => count,
+            Err(error) => {
+                let _ = set_restore_cutover_maintenance(&app, false);
+                let _ = std::fs::remove_file(inactive_dir.join(RESTORE_ACTIVATION_MARKER));
+                job_ctx.fail(format!("提交恢复密钥与切槽失败: {}", error));
+                return;
+            }
+        };
+    if restored_crypto_keys > 0 {
+        info!(
+            "[data_governance] 加密密钥与恢复切槽原子提交完成: {} 个文件",
+            restored_crypto_keys
+        );
     }
     info!(
         "[data_governance] 已原子登记下次启动切换到 {}",
@@ -1174,7 +1195,46 @@ async fn execute_restore_with_progress(
 
 #[cfg(test)]
 mod tests {
-    use super::atomic_restore_unavailable_error;
+    use super::{atomic_restore_unavailable_error, publish_restore_keys_and_commit_cutover};
+    use crate::data_governance::backup::{
+        calculate_file_sha256, BackupFile, BackupKeyPolicy, BackupManager, BackupManifest,
+        CoverageStatus,
+    };
+    use crate::data_space::{DataSpaceManager, Slot};
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn crypto_restore_manifest(backup_subdir: &Path) -> BackupManifest {
+        let paths = ["crypto/.master_key", "crypto/.secure/.key_seed"];
+        let files = paths
+            .iter()
+            .map(|relative| {
+                let path = backup_subdir.join(relative);
+                BackupFile {
+                    path: (*relative).to_string(),
+                    size: fs::metadata(&path).unwrap().len(),
+                    sha256: calculate_file_sha256(&path).unwrap(),
+                    database_id: None,
+                }
+            })
+            .collect::<Vec<_>>();
+        let mut manifest = BackupManifest::new("test");
+        manifest.key_policy = BackupKeyPolicy::IncludedLocal;
+        manifest.files = files;
+        let crypto = manifest
+            .coverage
+            .as_mut()
+            .unwrap()
+            .domains
+            .get_mut("crypto")
+            .unwrap();
+        crypto.status = CoverageStatus::Complete;
+        crypto.paths = paths.iter().map(|path| (*path).to_string()).collect();
+        crypto.file_count = crypto.paths.len();
+        crypto.total_size = manifest.files.iter().map(|file| file.size).sum();
+        manifest
+    }
 
     #[test]
     fn atomic_restore_unavailable_refusal_has_stable_code() {
@@ -1184,6 +1244,87 @@ mod tests {
             "atomic-restore refusal must carry a stable code: {error}"
         );
         assert!(error.contains("写入任何恢复数据前中止"));
+    }
+
+    #[test]
+    fn post_key_publication_failure_restores_old_global_keys_and_active_slot() {
+        for old_keys_exist in [true, false] {
+            let app_data = TempDir::new().unwrap();
+            let data_space = DataSpaceManager::new(app_data.path().to_path_buf());
+            data_space.ensure_layout().unwrap();
+            fs::write(data_space.slot_dir(Slot::A).join("active.db"), b"old-slot").unwrap();
+            fs::write(
+                data_space.slot_dir(Slot::B).join("candidate.db"),
+                b"new-slot",
+            )
+            .unwrap();
+
+            if old_keys_exist {
+                fs::write(app_data.path().join(".master_key"), b"old-master").unwrap();
+                let old_secure = app_data.path().join(".secure");
+                fs::create_dir_all(&old_secure).unwrap();
+                fs::write(old_secure.join(".key_seed"), b"old-seed").unwrap();
+                fs::write(old_secure.join("old.enc"), b"old-credential").unwrap();
+            }
+
+            let backup_root = TempDir::new().unwrap();
+            let backup_subdir = backup_root.path().join("snapshot");
+            let backup_secure = backup_subdir.join("crypto/.secure");
+            fs::create_dir_all(&backup_secure).unwrap();
+            fs::write(
+                backup_subdir.join("crypto/.master_key"),
+                b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            )
+            .unwrap();
+            let new_seed = "aa".repeat(32);
+            fs::write(backup_secure.join(".key_seed"), &new_seed).unwrap();
+            let manifest = crypto_restore_manifest(&backup_subdir);
+
+            let mut manager = BackupManager::new(backup_root.path().join("manager"));
+            manager.set_app_data_dir(app_data.path().to_path_buf());
+            let mut failure_injected_after_publication = false;
+            let error = publish_restore_keys_and_commit_cutover(
+                &manager,
+                &manifest,
+                &backup_subdir,
+                || {
+                    failure_injected_after_publication = true;
+                    assert_eq!(
+                        fs::read(app_data.path().join(".master_key")).unwrap(),
+                        b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                    );
+                    assert_eq!(
+                        fs::read_to_string(app_data.path().join(".secure/.key_seed")).unwrap(),
+                        new_seed
+                    );
+                    assert_eq!(data_space.active_slot(), Slot::A);
+                    Err("injected post-key-publication failure".to_string())
+                },
+            )
+            .expect_err("cutover failure after key publication must abort");
+
+            assert!(failure_injected_after_publication);
+            assert!(error.contains("已恢复旧密钥"), "{error}");
+            assert_eq!(data_space.active_slot(), Slot::A);
+            assert!(data_space.restore_cutover_pending().unwrap().is_none());
+            if old_keys_exist {
+                assert_eq!(
+                    fs::read(app_data.path().join(".master_key")).unwrap(),
+                    b"old-master"
+                );
+                assert_eq!(
+                    fs::read(app_data.path().join(".secure/.key_seed")).unwrap(),
+                    b"old-seed"
+                );
+                assert_eq!(
+                    fs::read(app_data.path().join(".secure/old.enc")).unwrap(),
+                    b"old-credential"
+                );
+            } else {
+                assert!(!app_data.path().join(".master_key").exists());
+                assert!(!app_data.path().join(".secure").exists());
+            }
+        }
     }
 }
 

--- a/src-tauri/src/data_space.rs
+++ b/src-tauri/src/data_space.rs
@@ -1620,6 +1620,14 @@ impl DataSpaceManager {
                 ));
             }
         }
+        // 收敛被中断的全局密钥发布：cutover lease 已持久化则前滚清理，
+        // 否则把旧密钥从回滚目录还原，避免「活跃槽仍旧库 + 全局密钥已换」
+        // 的静默代际错位。必须先于任何 SecureStore/业务库访问执行。
+        let lease_ref = st
+            .restore_cutover_pending
+            .as_ref()
+            .map(|lease| (lease.backup_id.as_str(), lease.target_slot.as_str()));
+        crate::crypto_publication::recover_crypto_publication(&self.base_dir, lease_ref)?;
         // pending 已原子提交后，匹配当前活动槽的 rollback 才失去恢复价值。
         // 失败恢复只会在非活动槽留下 trash，因此这里不会误删尚未提交的回滚点。
         if let Some(active_slot) = Slot::from_name(&st.active) {
@@ -2733,6 +2741,83 @@ mod tests {
         let after = mgr.read_state().unwrap();
         assert_eq!(after.active, "slotA", "无效 pending 时应保持原 active");
         assert!(after.pending.is_none(), "pending 应已清除");
+    }
+
+    // -----------------------------------------------------------------------
+    // 8a-1. initialize_on_start — 未提交的密钥发布在启动时回滚
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_initialize_on_start_rolls_back_uncommitted_crypto_publication() {
+        let (tmp, mgr) = make_manager();
+        mgr.ensure_layout().unwrap();
+        let root = tmp.path();
+
+        // 模拟发布中途崩溃：旧密钥已移入回滚目录、新密钥已装入根目录，
+        // 但 cutover lease 尚未落盘。
+        let rollback = crate::crypto_publication::rollback_dir(root);
+        fs::create_dir_all(&rollback).unwrap();
+        fs::write(rollback.join(".master_key"), b"old-master").unwrap();
+        fs::write(root.join(".master_key"), b"new-master").unwrap();
+        crate::crypto_publication::write_journal(
+            root,
+            &crate::crypto_publication::CryptoPublicationJournal {
+                version: 1,
+                backup_id: Some("backup-1".to_string()),
+                target_slot: Some("slotB".to_string()),
+                had_old_master: true,
+                had_old_secure: false,
+                installs_master: true,
+                installs_secure: false,
+                created_at: chrono::Utc::now().to_rfc3339(),
+            },
+        )
+        .unwrap();
+
+        mgr.initialize_on_start().unwrap();
+
+        assert_eq!(fs::read(root.join(".master_key")).unwrap(), b"old-master");
+        assert!(!crate::crypto_publication::journal_path(root).exists());
+        assert!(!crate::crypto_publication::rollback_dir(root).exists());
+    }
+
+    // -----------------------------------------------------------------------
+    // 8a-2. initialize_on_start — lease 已持久化的密钥发布在启动时前滚
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_initialize_on_start_rolls_forward_committed_crypto_publication() {
+        let (tmp, mgr) = make_manager();
+        mgr.ensure_layout().unwrap();
+        let root = tmp.path();
+        populate_slot(&mgr, Slot::B);
+        mgr.mark_restore_cutover_pending(Slot::B, "backup-1").unwrap();
+
+        let rollback = crate::crypto_publication::rollback_dir(root);
+        fs::create_dir_all(&rollback).unwrap();
+        fs::write(rollback.join(".master_key"), b"old-master").unwrap();
+        fs::write(root.join(".master_key"), b"new-master").unwrap();
+        crate::crypto_publication::write_journal(
+            root,
+            &crate::crypto_publication::CryptoPublicationJournal {
+                version: 1,
+                backup_id: Some("backup-1".to_string()),
+                target_slot: Some("slotB".to_string()),
+                had_old_master: true,
+                had_old_secure: false,
+                installs_master: true,
+                installs_secure: false,
+                created_at: chrono::Utc::now().to_rfc3339(),
+            },
+        )
+        .unwrap();
+
+        mgr.initialize_on_start().unwrap();
+
+        // lease 已持久化：新密钥保留，journal 与回滚目录被前滚清理。
+        assert_eq!(fs::read(root.join(".master_key")).unwrap(), b"new-master");
+        assert!(!crate::crypto_publication::journal_path(root).exists());
+        assert!(!crate::crypto_publication::rollback_dir(root).exists());
+        let after = mgr.read_state().unwrap();
+        assert_eq!(after.active, "slotB");
     }
 
     // -----------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ pub mod config_recovery;
 pub mod crash_logger;
 #[allow(dead_code)]
 pub mod crypto;
+pub mod crypto_publication; // 恢复密钥发布 journal 与启动侧前滚/回滚
 #[allow(dead_code)]
 pub mod database;
 pub mod debug_commands;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

#330 二检补漏：密钥发布需要可恢复 journal，避免恢复失败后全局密钥已切、活跃槽仍是旧库。本枝在 #330 之上补 crash-safe cutover journal。打进 `cursor/0824-cde6`，不要整支 merge 进 official 0824 或 main。不要改 #330 正文。

### Changes
- 新增 `crypto_publication` journal：密钥先 staging，与槽切over 同一状态机发布/回滚。
- 接线 `commands_restore.rs` / `backup/mod.rs` / `data_space.rs`。

### How to test
- 对照 #330 + `35b71885`。未跑全量编译 / Tauri。
- 恢复中途失败时，全局 `.master_key`/`.secure` 不应只换成备份密钥而活跃槽仍是旧库。

### Screenshots / Logs

### Third-party content
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ffbe94-512c-4a8c-abad-f6378cada875?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ffbe94-512c-4a8c-abad-f6378cada875&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

