### PR TITLE
test: align post-Wave2 migration fixtures

### DIFF
--- a/src-tauri/src/chat_v2/tools/llm_usage_executor.rs
+++ b/src-tauri/src/chat_v2/tools/llm_usage_executor.rs
@@ -793,6 +793,10 @@ mod tests {
             "../../../migrations/llm_usage/V20260824__add_cache_write_tokens.sql"
         ))
         .expect("apply cache_write_tokens migration");
+        conn.execute_batch(include_str!(
+            "../../../migrations/llm_usage/V20260826__add_stream_identity.sql"
+        ))
+        .expect("apply stream identity migration");
         conn
     }
 

--- a/src-tauri/src/data_governance/migration/coordinator.rs
+++ b/src-tauri/src/data_governance/migration/coordinator.rs
@@ -9108,7 +9108,10 @@ mod tests {
             .migrate_single(DatabaseId::LlmUsage)
             .expect("dedicated V20260824 repair must avoid duplicate column");
         assert!(report.success);
-        assert_eq!(report.to_version, 20260824);
+        assert_eq!(
+            report.to_version,
+            LLM_USAGE_MIGRATION_SET.latest_version() as u32
+        );
 
         let conn = rusqlite::Connection::open(&db_path).unwrap();
         let history_count: i64 = conn


### PR DESCRIPTION
二次复核后修复两个稳定 Rust 测试失败：

- LLM usage recent fixture 应用 V20260826 stream identity migration
- migration 断言跟随当前 LLM usage latest version

并发 E2EE claim 测试已独立串行复跑通过，确认此前失败为共享 target 并行构建污染。