### PR TITLE
style(anki): 制卡模板及附属页面设计一致性收敛

### DIFF
--- a/src/components/anki/AnkiCardPreviewPanel.tsx
+++ b/src/components/anki/AnkiCardPreviewPanel.tsx
@@ -59,7 +59,7 @@ export const AnkiCardPreviewPanel: React.FC<AnkiCardPreviewPanelProps> = ({
           role="tab"
           aria-selected={showFront}
           onClick={() => setShowFront(true)}
-          className="min-h-11 gap-1.5 text-sm sm:min-h-8 [@media(pointer:coarse)]:!min-h-11"
+          className="min-h-11 gap-1.5 text-sm sm:min-h-8"
         >
           <Eye size={14} />
           {t('anki:card_front')}
@@ -71,7 +71,7 @@ export const AnkiCardPreviewPanel: React.FC<AnkiCardPreviewPanelProps> = ({
           role="tab"
           aria-selected={!showFront}
           onClick={() => setShowFront(false)}
-          className="min-h-11 gap-1.5 text-sm sm:min-h-8 [@media(pointer:coarse)]:!min-h-11"
+          className="min-h-11 gap-1.5 text-sm sm:min-h-8"
         >
           <Eye size={14} />
           {t('anki:card_back')}
@@ -80,7 +80,7 @@ export const AnkiCardPreviewPanel: React.FC<AnkiCardPreviewPanelProps> = ({
 
       {/* 卡面渲染 */}
       <div className="min-w-0 rounded-md border border-border/70 bg-card">
-        <div className="px-3 pt-2 text-[11px] uppercase tracking-wide text-muted-foreground/70">
+        <div className="px-3 pt-2 text-xs uppercase tracking-wide text-muted-foreground/70">
           {showFront ? t('anki:preview_front') : t('anki:preview_back')}
         </div>
         <div className="p-3">
@@ -100,7 +100,7 @@ export const AnkiCardPreviewPanel: React.FC<AnkiCardPreviewPanelProps> = ({
             {card.tags.map((tag, index) => (
               <span
                 key={`${tag}-${index}`}
-                className="rounded-sm bg-emerald-500/10 px-1.5 py-0.5 text-xs text-emerald-700 dark:text-emerald-400"
+                className="rounded-sm bg-success/10 px-1.5 py-0.5 text-xs text-success"
               >
                 {tag}
               </span>

--- a/src/components/anki/AnkiTemplateCardFace.tsx
+++ b/src/components/anki/AnkiTemplateCardFace.tsx
@@ -71,7 +71,7 @@ const RenderIssueNotice: React.FC<{ issues: TemplateRenderIssue[] }> = ({ issues
   return (
     <div
       data-anki-render-issues={issues.length}
-      className="mt-1 rounded border border-warning/50 bg-warning/10 px-2 py-1 text-[11px] leading-snug text-warning"
+      className="mt-1 rounded border border-warning/50 bg-warning/10 px-2 py-1 text-xs leading-snug text-warning"
     >
       {t('card.renderIssue', { message: primary.message })}
       {extra > 0 ? t('card.renderIssueMore', { count: extra }) : ''}

--- a/src/features/anki-tasks/AnkiTasksApp.tsx
+++ b/src/features/anki-tasks/AnkiTasksApp.tsx
@@ -527,17 +527,17 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
               <p className="wb-at-subtitle">{t('taskDashboard.subtitle')}</p>
             </div>
             <div className="wb-at-toolbar">
-              <DsButton size="sm" variant="utility" onClick={cycleSort} className="h-7 [@media(pointer:coarse)]:!h-11">
+              <DsButton size="sm" variant="utility" onClick={cycleSort} className="h-7">
                 <ArrowsDownUp size={14} />
-                <span className="text-[11px]">{sortLabel}</span>
+                <span className="text-xs">{sortLabel}</span>
               </DsButton>
               <CommonTooltip content={t('taskDashboard.refresh')}>
-                <DsButton size="sm" variant="utility" onClick={load} className="h-7 w-7 p-0 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11" aria-label={t('taskDashboard.refresh')}>
+                <DsButton size="sm" variant="utility" onClick={load} className="h-7 w-7 p-0" aria-label={t('taskDashboard.refresh')}>
                   <ArrowsClockwise size={14} />
                 </DsButton>
               </CommonTooltip>
               <CommonTooltip content={t('taskDashboard.recoverStuckHint')}>
-                <DsButton size="sm" variant="utility" onClick={handleRecover} disabled={recovering} className="h-7 [@media(pointer:coarse)]:!h-11" aria-label={t('taskDashboard.recoverStuck')}>
+                <DsButton size="sm" variant="utility" onClick={handleRecover} disabled={recovering} className="h-7" aria-label={t('taskDashboard.recoverStuck')}>
                   {recovering
                     ? <CircleNotch size={14} className="animate-spin" />
                     : <ArrowCounterClockwise size={14} />}
@@ -555,7 +555,7 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
             <PropRow icon={<Hash size={14} />} label={t('taskDashboard.propTotalCards')}>
               <AnimatedNumber value={metrics.totalCards} className="font-semibold" />
               {metrics.avgCards > 0 && (
-                <span className="text-muted-foreground/50 ml-1 text-[12px]">
+                <span className="text-muted-foreground/50 ml-1 text-sm">
                   ({t('taskDashboard.avgCardsPerDoc')} {metrics.avgCards})
                 </span>
               )}
@@ -566,29 +566,29 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
             <PropRow icon={<TrendUp size={14} />} label={t('taskDashboard.propActiveJobs')}>
               {groups.active.length > 0 ? (
                 <span className="inline-flex items-center gap-1.5">
-                  <CircleNotch size={12} className="text-[color:hsl(var(--info))] animate-spin" />
-                  <span className="text-[color:hsl(var(--info))] font-medium">{groups.active.length}</span>
+                  <CircleNotch size={12} className="text-info animate-spin" />
+                  <span className="text-info font-medium">{groups.active.length}</span>
                   <CommonTooltip content={preventSleep ? t('taskDashboard.preventSleepOn') : t('taskDashboard.preventSleepOff')}>
                     <DsButton
                       size="sm"
                       variant={preventSleep ? 'secondary' : 'ghost'}
                       onClick={togglePreventSleep}
-                      className="ml-1 h-6 text-[12px] [@media(pointer:coarse)]:!h-11"
+                      className="ml-1 h-6 text-sm"
                     >
-                      <Coffee size={12} className={preventSleep ? 'text-[color:hsl(var(--warning))]' : ''} />
+                      <Coffee size={12} className={preventSleep ? 'text-warning' : ''} />
                       {t('taskDashboard.preventSleep')}
                     </DsButton>
                   </CommonTooltip>
                 </span>
               ) : (
                 <span className="inline-flex items-center gap-1.5">
-                  <CheckCircle size={12} className="text-[color:hsl(var(--success))]" />
-                  <span className="text-[color:hsl(var(--success))]">{t('taskDashboard.allDone')}</span>
+                  <CheckCircle size={12} className="text-success" />
+                  <span className="text-success">{t('taskDashboard.allDone')}</span>
                 </span>
               )}
             </PropRow>
             <PropRow icon={<Warning size={14} />} label={t('taskDashboard.propErrorRate')}>
-              <span className={`tabular-nums ${Number(metrics.errorRate) > 0 ? 'text-[color:hsl(var(--warning))]' : ''}`}>
+              <span className={`tabular-nums ${Number(metrics.errorRate) > 0 ? 'text-warning' : ''}`}>
                 {metrics.errorRate}%
               </span>
               {metrics.failedTasks > 0 && (
@@ -607,7 +607,7 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
               </CommonTooltip>
               {/* 移动端已有整行"打开模板库"入口，避免重复渲染小号链接 */}
               {!isSmallScreen && (
-                <DsButton size="sm" variant="ghost" onClick={onOpenTemplateManagement} className="ml-2 h-6 text-[12px] [@media(pointer:coarse)]:!min-h-11">
+                <DsButton size="sm" variant="ghost" onClick={onOpenTemplateManagement} className="ml-2 h-6 text-sm">
                   {t('taskDashboard.openTemplateLib')}
                 </DsButton>
               )}
@@ -649,8 +649,8 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
                     {donutData.map((d, i) => (
                       <div key={i} className="flex items-center gap-2">
                         <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: d.color }} />
-                        <span className="text-[12px] text-muted-foreground">{d.label}</span>
-                        <span className="text-[12px] text-foreground/70 tabular-nums ml-auto">{d.value}</span>
+                        <span className="text-sm text-muted-foreground">{d.label}</span>
+                        <span className="text-sm text-foreground/70 tabular-nums ml-auto">{d.value}</span>
                       </div>
                     ))}
                   </div>
@@ -685,9 +685,9 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
           <div
             role="status"
             data-testid="anki-tasks-stats-error"
-            className="flex flex-wrap items-center gap-2 rounded-md border border-[color:hsl(var(--warning))]/30 bg-[color:hsl(var(--warning))]/10 px-3 py-2 text-xs"
+            className="flex flex-wrap items-center gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs"
           >
-            <Warning size={14} className="text-[color:hsl(var(--warning))]" />
+            <Warning size={14} className="text-warning" />
             <span className="min-w-0 break-words text-muted-foreground">
               {t('taskDashboard.statsLoadFailed', {
                 defaultValue: '统计数据加载失败，任务列表不受影响',
@@ -706,9 +706,9 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
           <div
             role="status"
             data-testid="anki-tasks-stale-banner"
-            className="flex flex-wrap items-center gap-2 rounded-md border border-[color:hsl(var(--warning))]/30 bg-[color:hsl(var(--warning))]/10 px-3 py-2 text-xs"
+            className="flex flex-wrap items-center gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs"
           >
-            <Warning size={14} className="text-[color:hsl(var(--warning))]" />
+            <Warning size={14} className="text-warning" />
             <span className="min-w-0 break-words text-muted-foreground">
               {t('taskDashboard.refreshFailedStale')}
             </span>
@@ -735,8 +735,8 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
                 // 不能只靠 isSmallScreen）。!min-h-11 带 important：app.css 的
                 // .study-shell-segmented-button { min-height: 0 } 会盖掉基元里
                 // 非 important 的 coarse min-h-11
-                ? '!h-auto !px-3 !py-2 text-[12px] whitespace-nowrap [@media(pointer:coarse)]:!min-h-11'
-                : '!h-auto !px-2.5 !py-1 text-[12px] whitespace-nowrap [@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!px-3'}
+                ? '!h-auto !px-3 !py-2 text-sm whitespace-nowrap'
+                : '!h-auto !px-2.5 !py-1 text-sm whitespace-nowrap [@media(pointer:coarse)]:!px-3'}
               options={(['all', 'active', 'attention', 'completed'] as FilterTab[]).map((tab) => {
                 const labelText =
                   tab === 'all'
@@ -752,7 +752,7 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
                     <>
                       <span>{labelText}</span>
                       {tabCounts[tab] > 0 && (
-                        <span className="ml-1 text-[10px] text-muted-foreground/40 tabular-nums">
+                        <span className="ml-1 text-2xs text-muted-foreground/40 tabular-nums">
                           {tabCounts[tab]}
                         </span>
                       )}
@@ -772,10 +772,10 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
                 value={search}
                 onChange={e => setSearch(e.target.value)}
                 placeholder={t('taskDashboard.searchPlaceholder')}
-                className="h-7 border-transparent bg-transparent pl-7 pr-7 text-[12px] [@media(pointer:coarse)]:!h-11"
+                className="h-7 border-transparent bg-transparent pl-7 pr-7 text-sm [@media(pointer:coarse)]:h-[var(--touch-target-size)]"
               />
               {search && (
-                <DsButton variant="ghost" size="icon" iconOnly onClick={() => setSearch('')} className="absolute right-1.5 top-1/2 -translate-y-1/2 !h-auto !w-auto !p-0 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11 text-muted-foreground/40 hover:text-muted-foreground" aria-label={t('common:clear', { defaultValue: 'Clear' })}>
+                <DsButton variant="ghost" size="icon" iconOnly onClick={() => setSearch('')} className="absolute right-1.5 top-1/2 -translate-y-1/2 !h-auto !w-auto !p-0 text-muted-foreground/40 hover:text-muted-foreground" aria-label={t('common:clear', { defaultValue: 'Clear' })}>
                   <X size={12} />
                 </DsButton>
               )}
@@ -784,19 +784,19 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
             {/* 移动端：排序 / 刷新 / 恢复卡住任务（桌面在页头工具条） */}
             {isSmallScreen && (
               <div className="flex items-center gap-1">
-                <DsButton size="sm" variant="utility" onClick={cycleSort} className="[@media(pointer:coarse)]:!min-h-11" aria-label={sortLabel} title={sortLabel}>
+                <DsButton size="sm" variant="utility" onClick={cycleSort} aria-label={sortLabel} title={sortLabel}>
                   <ArrowsDownUp size={14} />
-                  <span className="text-[11px]">{sortLabel}</span>
+                  <span className="text-xs">{sortLabel}</span>
                 </DsButton>
-                <DsButton size="sm" variant="utility" onClick={load} className="w-11 p-0 [@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11" aria-label={t('taskDashboard.refresh')}>
+                <DsButton size="sm" variant="utility" onClick={load} className="w-11 p-0" aria-label={t('taskDashboard.refresh')}>
                   <ArrowsClockwise size={14} />
                 </DsButton>
                 {/* 触屏无 hover tooltip，纯图标无从得知含义——补文案（工具条 flex-wrap 可换行不溢出） */}
-                <DsButton size="sm" variant="utility" onClick={handleRecover} disabled={recovering} className="[@media(pointer:coarse)]:!min-h-11" aria-label={t('taskDashboard.recoverStuck')} title={t('taskDashboard.recoverStuckHint')}>
+                <DsButton size="sm" variant="utility" onClick={handleRecover} disabled={recovering} aria-label={t('taskDashboard.recoverStuck')} title={t('taskDashboard.recoverStuckHint')}>
                   {recovering
                     ? <CircleNotch size={14} className="animate-spin" />
                     : <ArrowCounterClockwise size={14} />}
-                  <span className="text-[11px]">{t('taskDashboard.recoverStuck')}</span>
+                  <span className="text-xs">{t('taskDashboard.recoverStuck')}</span>
                 </DsButton>
               </div>
             )}
@@ -805,8 +805,8 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
           {loadError && sessions.length === 0 ? (
             /* 加载失败 ≠ 没有任务：显式错误态 + 重试 */
             <div className="wb-at-empty" role="alert" data-testid="anki-tasks-load-error">
-              <Warning size={28} className="text-[color:hsl(var(--warning))]" />
-              <p className="font-medium text-foreground text-[13px]">
+              <Warning size={28} className="text-warning" />
+              <p className="font-medium text-foreground text-ui">
                 {t('taskDashboard.loadFailed')}
               </p>
               <p className="max-w-md break-words text-xs text-muted-foreground/70">
@@ -821,7 +821,7 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
             /* 空状态 + 双引导：去聊天发起制卡（主）/ 打开模板库先备好模板（次） */
             <div className="wb-at-empty">
               <FileText size={28} className="text-muted-foreground/30" />
-              <p className="font-medium text-foreground text-[13px]">
+              <p className="font-medium text-foreground text-ui">
                 {t('taskDashboard.empty')}
               </p>
               <p className="text-xs text-muted-foreground/70">
@@ -831,7 +831,7 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
                 <DsButton
                   size="sm"
                   variant="primary"
-                  className="[@media(pointer:coarse)]:!min-h-11"
+                 
                   onClick={() => {
                     // onNavigateToChat 在 legacy 壳中会 setCurrentView('chat-v2')
                     // 并 dispatch navigate-to-session。传特殊标记表示仅切换视图
@@ -846,7 +846,7 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
                   <DsButton
                     size="sm"
                     variant="default"
-                    className="[@media(pointer:coarse)]:!min-h-11"
+                   
                     onClick={onOpenTemplateManagement}
                   >
                     <Palette size={14} />
@@ -857,7 +857,7 @@ export const AnkiTasksApp: React.FC<AnkiTasksAppProps> = ({
             </div>
           ) : sortedAndFiltered.length === 0 ? (
             <div className="wb-at-empty">
-              <p className="text-[13px] text-muted-foreground/50">
+              <p className="text-ui text-muted-foreground/50">
                 {t('taskDashboard.noMatchFilter')}
               </p>
             </div>

--- a/src/features/anki-tasks/anki-tasks.css
+++ b/src/features/anki-tasks/anki-tasks.css
@@ -40,7 +40,7 @@
 
 .wb-at-title {
   margin: 0;
-  font-size: 15px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   line-height: 1.3;
   color: hsl(var(--foreground));
@@ -48,7 +48,7 @@
 
 .wb-at-subtitle {
   margin: 2px 0 0;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   line-height: 1.35;
   color: hsl(var(--muted-foreground));
 }
@@ -71,7 +71,7 @@
 
 .wb-at-panel-title {
   margin: 0 0 8px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: hsl(var(--muted-foreground));
 }
@@ -104,7 +104,7 @@
   gap: 12px;
   padding: 6px 12px;
   border-bottom: 1px solid color-mix(in hsl, hsl(var(--border)) 45%, transparent 55%);
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   font-weight: 500;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -143,7 +143,7 @@
   justify-content: space-between;
   padding: 6px 12px;
   border-top: 1px solid color-mix(in hsl, hsl(var(--border)) 40%, transparent 60%);
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: hsl(var(--muted-foreground) / 0.6);
 }
 
@@ -281,7 +281,7 @@ svg:hover .wb-at-donut-seg:not(:hover) {
   gap: 8px;
   min-width: 0;
   padding: 2px 0;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   line-height: 1.4;
 }
 
@@ -295,7 +295,7 @@ svg:hover .wb-at-donut-seg:not(:hover) {
   flex-shrink: 0;
   padding: 0 5px;
   border-radius: 4px;
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   font-weight: 500;
   line-height: 16px;
   color: hsl(var(--warning));
@@ -338,6 +338,6 @@ svg:hover .wb-at-donut-seg:not(:hover) {
   min-height: 10rem;
   padding: 24px 16px;
   text-align: center;
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   color: hsl(var(--muted-foreground));
 }

--- a/src/features/anki-tasks/components/FailedTasksPanel.tsx
+++ b/src/features/anki-tasks/components/FailedTasksPanel.tsx
@@ -119,8 +119,8 @@ export const FailedTasksPanel: React.FC<{
   return (
     <div className="wb-at-failed-panel" role="alert">
       <div className="flex items-center gap-2">
-        <WarningCircle size={15} weight="fill" className="text-[color:hsl(var(--warning))] flex-shrink-0" />
-        <span className="text-xs font-medium text-[color:hsl(var(--warning))] flex-1 min-w-0">
+        <WarningCircle size={15} weight="fill" className="text-warning flex-shrink-0" />
+        <span className="text-xs font-medium text-warning flex-1 min-w-0">
           {t('tasks.failedPanelTitle', { count: tasks.length })}
         </span>
         <DsButton
@@ -128,7 +128,7 @@ export const FailedTasksPanel: React.FC<{
           variant="ghost"
           onClick={retryAll}
           disabled={retryingAll || !!retryingId}
-          className="h-6 text-[11px] flex-shrink-0 [@media(pointer:coarse)]:!h-11"
+          className="h-6 text-xs flex-shrink-0"
         >
           {retryingAll
             ? <CircleNotch size={12} className="animate-spin" />
@@ -152,7 +152,7 @@ export const FailedTasksPanel: React.FC<{
               variant="ghost"
               onClick={() => retryOne(task.id)}
               disabled={retryingAll || !!retryingId}
-              className="h-5 w-5 p-0 flex-shrink-0 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11"
+              className="h-5 w-5 p-0 flex-shrink-0"
               aria-label={t('taskDashboard.retryFailed')}
             >
               {retryingId === task.id
@@ -168,7 +168,7 @@ export const FailedTasksPanel: React.FC<{
           size="sm"
           variant="ghost"
           onClick={() => setShowAll(true)}
-          className="mt-1 h-6 w-full justify-center text-[11px] text-muted-foreground/60 hover:text-muted-foreground [@media(pointer:coarse)]:!h-11"
+          className="mt-1 h-6 w-full justify-center text-xs text-muted-foreground/60 hover:text-muted-foreground"
         >
           {t('tasks.showMoreFailures', { count: hiddenCount })}
         </DsButton>

--- a/src/features/anki-tasks/components/SessionRow.tsx
+++ b/src/features/anki-tasks/components/SessionRow.tsx
@@ -265,7 +265,7 @@ export const SessionRow: React.FC<{
     >
       {/* ---- 主行 ---- */}
       <div
-        className={`wb-at-row-main [@media(pointer:coarse)]:min-h-[44px]${isSmallScreen ? ' min-h-[44px]' : ''}`}
+        className={`wb-at-row-main [@media(pointer:coarse)]:min-h-[var(--touch-target-size)]${isSmallScreen ? ' min-h-[44px]' : ''}`}
         onClick={onToggle}
       >
         {/* 展开箭头 */}
@@ -277,7 +277,7 @@ export const SessionRow: React.FC<{
 
         {/* 文档名 */}
         <FileText className="h-[15px] w-[15px] text-muted-foreground/50 flex-shrink-0" />
-        <span className="text-[13px] text-foreground truncate min-w-0 flex-1">
+        <span className="text-ui text-foreground truncate min-w-0 flex-1">
           {session.documentName || session.documentId.slice(0, 12)}
         </span>
 
@@ -289,7 +289,7 @@ export const SessionRow: React.FC<{
             title={t('taskDashboard.sessionWarningsHint', {
               defaultValue: '存在失败或警告分段（不阻断运行与完成）',
             })}
-            className="inline-flex flex-shrink-0 items-center gap-0.5 rounded-sm px-1 py-0.5 text-[10px] font-medium text-[color:hsl(var(--warning))] bg-[color:hsl(var(--warning)/0.12)]"
+            className="inline-flex flex-shrink-0 items-center gap-0.5 rounded-sm px-1 py-0.5 text-2xs font-medium text-warning bg-warning/10"
           >
             <Warning size={11} />
             {warningCount > 0 && <span className="tabular-nums">{warningCount}</span>}
@@ -335,21 +335,21 @@ export const SessionRow: React.FC<{
               （且仅悬停可见时），不构成可访问名称——读屏用户会听到空按钮 */}
           {group === 'active' && session.activeTasks > 0 && (
             <CommonTooltip content={t('pause')}>
-              <DsButton size="sm" variant="ghost" onClick={() => act('pause')} disabled={!!busy} className="w-6 h-6 p-0 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11" aria-label={t('pause')}>
+              <DsButton size="sm" variant="ghost" onClick={() => act('pause')} disabled={!!busy} className="w-6 h-6 p-0" aria-label={t('pause')}>
                 <Pause size={12} />
               </DsButton>
             </CommonTooltip>
           )}
           {session.pausedTasks > 0 && (
             <CommonTooltip content={t('resume')}>
-              <DsButton size="sm" variant="ghost" onClick={() => act('resume')} disabled={!!busy} className="w-6 h-6 p-0 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11" aria-label={t('resume')}>
+              <DsButton size="sm" variant="ghost" onClick={() => act('resume')} disabled={!!busy} className="w-6 h-6 p-0" aria-label={t('resume')}>
                 <Play size={12} />
               </DsButton>
             </CommonTooltip>
           )}
           {group === 'active' && (
             <CommonTooltip content={t('tasks.cancelTask')}>
-              <DsButton size="sm" variant="ghost" onClick={() => act('cancel')} disabled={!!busy} className="w-6 h-6 p-0 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11" aria-label={t('tasks.cancelTask')}>
+              <DsButton size="sm" variant="ghost" onClick={() => act('cancel')} disabled={!!busy} className="w-6 h-6 p-0" aria-label={t('tasks.cancelTask')}>
                 <XCircle size={12} />
               </DsButton>
             </CommonTooltip>
@@ -358,21 +358,21 @@ export const SessionRow: React.FC<{
               条件：失败 + 暂停并存的会话在行内找不到重试，只能展开后再找） */}
           {session.failedTasks > 0 && (
             <CommonTooltip content={t('taskDashboard.retryFailed')}>
-              <DsButton size="sm" variant="ghost" onClick={() => act('retryFailed')} disabled={!!busy} className="w-6 h-6 p-0 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11" aria-label={t('taskDashboard.retryFailed')}>
+              <DsButton size="sm" variant="ghost" onClick={() => act('retryFailed')} disabled={!!busy} className="w-6 h-6 p-0" aria-label={t('taskDashboard.retryFailed')}>
                 <ArrowCounterClockwise size={12} />
               </DsButton>
             </CommonTooltip>
           )}
           {session.totalCards > 0 && (
             <CommonTooltip content={t('taskDashboard.quickExport')}>
-              <DsButton size="sm" variant="ghost" onClick={handleQuickExport} disabled={!!busy || loadingCards} className="w-6 h-6 p-0 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11" aria-label={t('taskDashboard.quickExport')}>
+              <DsButton size="sm" variant="ghost" onClick={handleQuickExport} disabled={!!busy || loadingCards} className="w-6 h-6 p-0" aria-label={t('taskDashboard.quickExport')}>
                 <DownloadSimple size={12} />
               </DsButton>
             </CommonTooltip>
           )}
           {session.sourceSessionId && (
             <CommonTooltip content={t('taskDashboard.jumpToChat')}>
-              <DsButton size="sm" variant="ghost" onClick={onJump} className="w-6 h-6 p-0 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11" aria-label={t('taskDashboard.jumpToChat')}>
+              <DsButton size="sm" variant="ghost" onClick={onJump} className="w-6 h-6 p-0" aria-label={t('taskDashboard.jumpToChat')}>
                 <ArrowSquareOut size={12} />
               </DsButton>
             </CommonTooltip>
@@ -384,12 +384,12 @@ export const SessionRow: React.FC<{
               variant={deleteConfirm ? 'danger' : 'ghost'}
               onClick={handleDelete}
               disabled={!!busy}
-              className={`h-6 p-0 [@media(pointer:coarse)]:!h-11 ${deleteConfirm ? 'px-2 gap-1' : 'w-6 [@media(pointer:coarse)]:!w-11'}`}
+              className={`h-6 p-0 ${deleteConfirm ? 'px-2 gap-1' : 'w-6'}`}
               aria-label={deleteConfirm ? t('taskDashboard.confirmDeleteHint') : t('taskDashboard.deleteSession')}
             >
               <Trash size={12} />
               {deleteConfirm && (
-                <span className="text-[10px]">{t('taskDashboard.confirmDeleteHint')}</span>
+                <span className="text-2xs">{t('taskDashboard.confirmDeleteHint')}</span>
               )}
             </DsButton>
           </CommonTooltip>
@@ -409,7 +409,7 @@ export const SessionRow: React.FC<{
                   {session.activeTasks} {t('taskDashboard.statusActive')} / {session.pausedTasks} {t('taskDashboard.statusPaused')}
                   {/* 混合态：运行组里失败分段不静默，明示计数（重试入口在下方常显） */}
                   {session.failedTasks > 0 && (
-                    <span className="ml-1 text-[color:hsl(var(--warning))]">
+                    <span className="ml-1 text-warning">
                       / {session.failedTasks} {t('taskDashboard.statusFailed')}
                     </span>
                   )}
@@ -433,32 +433,32 @@ export const SessionRow: React.FC<{
           {/* 操作按钮（移动端为唯一操作入口，补齐暂停/恢复/跳转聊天） */}
           <div className="flex flex-wrap gap-1.5 pt-1">
             {session.totalCards > 0 && (
-              <DsButton size="sm" variant="default" onClick={handleQuickExport} disabled={!!busy || loadingCards} className="[@media(pointer:coarse)]:!min-h-11">
+              <DsButton size="sm" variant="default" onClick={handleQuickExport} disabled={!!busy || loadingCards}>
                 <DownloadSimple size={14} />{t('taskDashboard.exportApkg')}
               </DsButton>
             )}
             {session.failedTasks > 0 && (
-              <DsButton size="sm" variant="primary" onClick={() => act('retryFailed')} disabled={!!busy} className="[@media(pointer:coarse)]:!min-h-11">
+              <DsButton size="sm" variant="primary" onClick={() => act('retryFailed')} disabled={!!busy}>
                 <ArrowCounterClockwise size={14} />{t('taskDashboard.retryFailed')}
               </DsButton>
             )}
             {isSmallScreen && group === 'active' && session.activeTasks > 0 && (
-              <DsButton size="sm" variant="default" onClick={() => act('pause')} disabled={!!busy} className="[@media(pointer:coarse)]:!min-h-11">
+              <DsButton size="sm" variant="default" onClick={() => act('pause')} disabled={!!busy}>
                 <Pause size={14} />{t('pause')}
               </DsButton>
             )}
             {isSmallScreen && session.pausedTasks > 0 && (
-              <DsButton size="sm" variant="default" onClick={() => act('resume')} disabled={!!busy} className="[@media(pointer:coarse)]:!min-h-11">
+              <DsButton size="sm" variant="default" onClick={() => act('resume')} disabled={!!busy}>
                 <Play size={14} />{t('resume')}
               </DsButton>
             )}
             {isSmallScreen && group === 'active' && (
-              <DsButton size="sm" variant="default" onClick={() => act('cancel')} disabled={!!busy} className="[@media(pointer:coarse)]:!min-h-11">
+              <DsButton size="sm" variant="default" onClick={() => act('cancel')} disabled={!!busy}>
                 <XCircle size={14} />{t('tasks.cancelTask')}
               </DsButton>
             )}
             {isSmallScreen && session.sourceSessionId && (
-              <DsButton size="sm" variant="default" onClick={onJump} className="[@media(pointer:coarse)]:!min-h-11">
+              <DsButton size="sm" variant="default" onClick={onJump}>
                 <ArrowSquareOut size={14} />{t('taskDashboard.jumpToChat')}
               </DsButton>
             )}
@@ -467,7 +467,7 @@ export const SessionRow: React.FC<{
               variant={deleteConfirm ? 'danger' : 'default'}
               onClick={handleDelete}
               disabled={!!busy}
-              className="[@media(pointer:coarse)]:!min-h-11"
+             
             >
               <Trash size={14} />
               {deleteConfirm ? t('taskDashboard.confirmDeleteHint') : t('taskDashboard.deleteSession')}
@@ -486,7 +486,7 @@ export const SessionRow: React.FC<{
           {/* 错误卡片详情（从已加载卡片中提取） */}
           {errorCards.length > 0 && (
             <div className="py-1 space-y-1">
-              <div className="text-xs font-medium text-[color:hsl(var(--warning))]">
+              <div className="text-xs font-medium text-warning">
                 {t('taskDashboard.errorCardsFound', { count: errorCards.length })}
               </div>
               {errorCards.slice(0, 3).map((c, i) => (
@@ -495,14 +495,14 @@ export const SessionRow: React.FC<{
                     {c.front || '—'}
                   </span>
                   {c.error_content && (
-                    <span className="text-[color:hsl(var(--warning)/0.7)] ml-2">
+                    <span className="text-warning/70 ml-2">
                       {t('taskDashboard.errorReason')}: {c.error_content}
                     </span>
                   )}
                 </div>
               ))}
               {errorCards.length > 3 && (
-                <div className="text-[11px] text-muted-foreground/30 pl-4">
+                <div className="text-xs text-muted-foreground/30 pl-4">
                   +{errorCards.length - 3} ...
                 </div>
               )}
@@ -518,7 +518,7 @@ export const SessionRow: React.FC<{
             <div>
               {/* 模板标签 */}
               {templateName && (
-                <div className="flex items-center gap-1.5 px-2 py-1.5 text-[11px]">
+                <div className="flex items-center gap-1.5 px-2 py-1.5 text-xs">
                   <span className="text-muted-foreground/50">{t('taskDashboard.templateLabel')}</span>
                   <span className="text-foreground/70 font-medium">{templateName}</span>
                 </div>
@@ -527,7 +527,7 @@ export const SessionRow: React.FC<{
               <CustomScrollArea className="min-w-0" orientation="horizontal" fullHeight={false}>
                 <div style={!isFallback && columns.length > 2 ? { minWidth: `${columns.length * 120 + 36}px` } : undefined}>
                   {/* 表头 — 根据模板字段动态生成列 */}
-                  <div className="flex items-center gap-3 px-2 py-1.5 text-[11px] font-medium text-muted-foreground/50 uppercase tracking-wider">
+                  <div className="flex items-center gap-3 px-2 py-1.5 text-xs font-medium text-muted-foreground/50 uppercase tracking-wider">
                     <span className="w-6 text-right flex-shrink-0">#</span>
                     {isFallback ? (
                       <>
@@ -547,15 +547,15 @@ export const SessionRow: React.FC<{
                   >
                     {visibleCards.map((c, i) => (
                       <div key={c.id || i} className="flex items-start gap-3 px-2 py-2 hover:bg-[var(--interactive-hover)] transition-colors">
-                        <span className="text-[10px] text-muted-foreground/30 mt-0.5 w-6 text-right flex-shrink-0 tabular-nums">
+                        <span className="text-2xs text-muted-foreground/30 mt-0.5 w-6 text-right flex-shrink-0 tabular-nums">
                           {i + 1}
                         </span>
                         {isFallback ? (
                           <>
-                            <div className="flex-1 min-w-[100px] text-[13px] text-foreground/90 truncate">
+                            <div className="flex-1 min-w-[100px] text-ui text-foreground/90 truncate">
                               {c.front || '—'}
                             </div>
-                            <div className="flex-1 min-w-[100px] text-[13px] text-muted-foreground truncate">
+                            <div className="flex-1 min-w-[100px] text-ui text-muted-foreground truncate">
                               {c.back || '—'}
                             </div>
                           </>
@@ -563,7 +563,7 @@ export const SessionRow: React.FC<{
                           columns.map((col, ci) => (
                             <div
                               key={col}
-                              className={`flex-1 min-w-[100px] text-[13px] truncate ${ci === 0 ? 'text-foreground/90' : 'text-muted-foreground'}`}
+                              className={`flex-1 min-w-[100px] text-ui truncate ${ci === 0 ? 'text-foreground/90' : 'text-muted-foreground'}`}
                             >
                               {getCardFieldValue(c, col)}
                             </div>
@@ -575,7 +575,7 @@ export const SessionRow: React.FC<{
                 </div>
               </CustomScrollArea>
               {hasMoreCards && (
-                <DsButton variant="ghost" size="sm" onClick={() => setShowAllCards(v => !v)} className="w-full !py-1.5 text-[12px] text-muted-foreground/50 hover:text-muted-foreground [@media(pointer:coarse)]:!min-h-11">
+                <DsButton variant="ghost" size="sm" onClick={() => setShowAllCards(v => !v)} className="w-full !py-1.5 text-sm text-muted-foreground/50 hover:text-muted-foreground">
                   {showAllCards
                     ? t('taskDashboard.showLessCards')
                     : t('taskDashboard.showMoreCards', { remaining: normalCards.length - CARDS_PAGE_SIZE })}
@@ -583,7 +583,7 @@ export const SessionRow: React.FC<{
               )}
             </div>
           ) : session.totalCards === 0 ? (
-            <p className="text-[13px] text-muted-foreground/40 py-3">{t('taskDashboard.noCards')}</p>
+            <p className="text-ui text-muted-foreground/40 py-3">{t('taskDashboard.noCards')}</p>
           ) : null}
         </div>
       )}

--- a/src/features/anki-tasks/components/bits.tsx
+++ b/src/features/anki-tasks/components/bits.tsx
@@ -16,11 +16,11 @@ export const PropRow: React.FC<{
       <span className="text-muted-foreground/40 group-hover:text-muted-foreground/60 transition-colors flex-shrink-0">
         {icon}
       </span>
-      <span className="text-[13px] text-muted-foreground truncate">
+      <span className="text-ui text-muted-foreground truncate">
         {label}
       </span>
     </div>
-    <div className="flex items-center gap-1 text-[13px] text-foreground min-w-0 flex-wrap">
+    <div className="flex items-center gap-1 text-ui text-foreground min-w-0 flex-wrap">
       {children}
     </div>
   </div>
@@ -31,14 +31,14 @@ export const StatusTag: React.FC<{ group: SessionGroup; paused?: boolean }> = ({
   const config = {
     active: {
       text: paused ? t('taskDashboard.statusPaused') : t('taskDashboard.statusActive'),
-      cls: 'text-[color:hsl(var(--info))] bg-[color:hsl(var(--info)/0.12)]',
+      cls: 'text-info bg-info/10',
     },
-    attention: { text: t('taskDashboard.statusFailed'), cls: 'text-[color:hsl(var(--warning))] bg-[color:hsl(var(--warning)/0.14)]' },
-    completed: { text: t('taskDashboard.statusDone'), cls: 'text-[color:hsl(var(--success))] bg-[color:hsl(var(--success)/0.14)]' },
+    attention: { text: t('taskDashboard.statusFailed'), cls: 'text-warning bg-warning/15' },
+    completed: { text: t('taskDashboard.statusDone'), cls: 'text-success bg-success/15' },
   }[group];
 
   return (
-    <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 text-[11px] font-medium rounded-sm ${config.cls}`}>
+    <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-sm ${config.cls}`}>
       {group === 'active' && !paused && <span aria-hidden className="wb-at-pulse-dot" />}
       {config.text}
     </span>
@@ -60,11 +60,11 @@ export const InlineProgress: React.FC<{
     <div className="flex items-center gap-2.5">
       <div className={`wb-at-progress-track w-[80px] h-1.5 bg-muted/30 rounded-full overflow-hidden flex flex-shrink-0${active ? ' wb-at-progress-active' : ''}`}>
         <div
-          className={`h-full ${active ? 'bg-[color:hsl(var(--info)/0.75)]' : 'bg-[color:hsl(var(--success)/0.6)]'} wb-at-progress-fill`}
+          className={`h-full ${active ? 'bg-info/75' : 'bg-success/60'} wb-at-progress-fill`}
           style={{ width: `${pctDone}%` }}
         />
         {pctFail > 0 && (
-          <div className="h-full bg-[color:hsl(var(--warning)/0.6)] wb-at-progress-fill" style={{ width: `${pctFail}%` }} />
+          <div className="h-full bg-warning/60 wb-at-progress-fill" style={{ width: `${pctFail}%` }} />
         )}
       </div>
       <span className="text-xs text-muted-foreground tabular-nums flex-shrink-0">

--- a/src/features/anki-tasks/components/charts.tsx
+++ b/src/features/anki-tasks/components/charts.tsx
@@ -81,10 +81,10 @@ export const HBarChart: React.FC<{
         <div key={i} className="group">
           <div className="flex items-center justify-between mb-1 gap-2">
             <span className="flex items-baseline gap-1.5 min-w-0">
-              <span className="text-[10px] text-muted-foreground/40 tabular-nums flex-shrink-0 w-3">
+              <span className="text-2xs text-muted-foreground/40 tabular-nums flex-shrink-0 w-3">
                 {i + 1}
               </span>
-              <span className="text-[13px] text-foreground/80 truncate">
+              <span className="text-ui text-foreground/80 truncate">
                 {item.label}
               </span>
             </span>

--- a/src/features/template-management/TemplateManagementApp.tsx
+++ b/src/features/template-management/TemplateManagementApp.tsx
@@ -162,7 +162,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
             if (!leaveEditorGuardRef.current()) return;
             onBackToAnki?.();
           }}
-          className="hover:text-primary !p-0 !h-auto truncate max-w-[100px] text-muted-foreground [@media(pointer:coarse)]:text-primary [@media(pointer:coarse)]:!min-h-11"
+          className="hover:text-primary !p-0 !h-auto truncate max-w-[100px] text-muted-foreground [@media(pointer:coarse)]:text-primary"
         >
           {tAnki('page_title')}
         </DsButton>
@@ -770,7 +770,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
             title={t('template_code')}
             aria-pressed={screenPosition === 'right'}
             onClick={() => setScreenPosition(prev => (prev === 'right' ? 'center' : 'right'))}
-            className="[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11"
+           
           >
             <Code size={18} />
           </DsButton>
@@ -782,7 +782,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
           aria-label={t('manager_title')}
           title={t('manager_title')}
           onClick={() => setScreenPosition(prev => prev === 'left' ? 'center' : 'left')}
-          className="[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11"
+         
         >
           <Gear size={18} />
         </DsButton>
@@ -966,7 +966,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
             onClick={() => {
               onCancel();
             }}
-            className="w-full justify-start gap-2 [@media(pointer:coarse)]:!min-h-11"
+            className="w-full justify-start gap-2"
           >
             <ArrowLeft size={16} />
             {t('back_button')}
@@ -1008,7 +1008,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
         >
           <BookOpen size={16} weight="duotone" />
           {isSelectingMode ? t('page_title_select') : t('tab_browse')}
-          <span className="text-[11px] text-muted-foreground/60 tabular-nums">
+          <span className="text-xs text-muted-foreground/60 tabular-nums">
             {filteredTemplates.length}
           </span>
         </button>
@@ -1018,17 +1018,17 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
         {!isSelectingMode && activeTab === 'browse' && (
           <>
             <CommonTooltip content={t('tab_create')}>
-              <DsButton variant="utility" size="icon" iconOnly onClick={startCreateTemplate} aria-label={t('tab_create')} className="h-7 w-7 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11">
+              <DsButton variant="utility" size="icon" iconOnly onClick={startCreateTemplate} aria-label={t('tab_create')} className="h-7 w-7">
                 <Plus size={14} />
               </DsButton>
             </CommonTooltip>
             <CommonTooltip content={t('refresh')}>
-              <DsButton variant="utility" size="icon" iconOnly onClick={loadTemplates} disabled={isLoading} aria-label={t('refresh')} className="h-7 w-7 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11">
+              <DsButton variant="utility" size="icon" iconOnly onClick={loadTemplates} disabled={isLoading} aria-label={t('refresh')} className="h-7 w-7">
                 <ArrowClockwise size={14} className={cn(isLoading && 'animate-spin')} />
               </DsButton>
             </CommonTooltip>
             <CommonTooltip content={isImporting ? t('importing') : t('import_builtin_templates')}>
-              <DsButton variant="utility" size="icon" iconOnly onClick={handleImportBuiltinTemplates} disabled={isImporting} aria-label={t('import_builtin_templates')} className="h-7 w-7 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11">
+              <DsButton variant="utility" size="icon" iconOnly onClick={handleImportBuiltinTemplates} disabled={isImporting} aria-label={t('import_builtin_templates')} className="h-7 w-7">
                 <Download size={14} />
               </DsButton>
             </CommonTooltip>
@@ -1041,7 +1041,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
                 aria-label={t('import_external_templates')}
                 aria-pressed={activePanel === 'import'}
                 data-active={activePanel === 'import' ? 'true' : undefined}
-                className="h-7 w-7 wb-tm-nav-toggle [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11"
+                className="h-7 w-7 wb-tm-nav-toggle"
               >
                 <Upload size={14} />
               </DsButton>
@@ -1055,7 +1055,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
                 aria-label={t('export_templates_sidebar')}
                 aria-pressed={activePanel === 'export'}
                 data-active={activePanel === 'export' ? 'true' : undefined}
-                className="h-7 w-7 wb-tm-nav-toggle [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11"
+                className="h-7 w-7 wb-tm-nav-toggle"
               >
                 <Download size={14} weight="bold" />
               </DsButton>
@@ -1068,7 +1068,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
                   iconOnly
                   onClick={onOpenJsonPreview}
                   aria-label={t('json_preview.open_button')}
-                  className="h-7 w-7 [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11"
+                  className="h-7 w-7"
                 >
                   <Code size={14} />
                 </DsButton>
@@ -1081,7 +1081,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
             variant="default"
             size="sm"
             onClick={onCancel}
-            className="h-7 [@media(pointer:coarse)]:!min-h-11"
+            className="h-7"
           >
             <ArrowLeft size={14} />
             {t('back_button')}
@@ -1169,7 +1169,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
             <Warning size={16} className="flex-shrink-0" />
             <span className="truncate">{error}</span>
           </span>
-          <DsButton variant="ghost" size="icon" iconOnly onClick={() => setError(null)} className="text-current hover:text-current [@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11" aria-label={t('common:a11y.close')}>
+          <DsButton variant="ghost" size="icon" iconOnly onClick={() => setError(null)} className="text-current hover:text-current" aria-label={t('common:a11y.close')}>
             <X size={14} />
           </DsButton>
         </div>
@@ -1277,7 +1277,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
           iconOnly
           onClick={loadTemplates}
           disabled={isLoading}
-          className="shrink-0 [@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11"
+          className="shrink-0"
           title={t('refresh')}
           aria-label={t('refresh')}
         >
@@ -1290,7 +1290,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             placeholder={t('search_placeholder')}
-            className="sidebar-shell-search h-9 w-full pl-9 text-sm [@media(pointer:coarse)]:!h-11"
+            className="sidebar-shell-search h-9 w-full pl-9 text-sm [@media(pointer:coarse)]:h-[var(--touch-target-size)]"
           />
         </div>
         {!isSelectingMode && (
@@ -1302,7 +1302,7 @@ export const TemplateManagementApp: React.FC<TemplateManagementAppProps> = ({
               startCreateTemplate();
               closeMobileDrawer();
             }}
-            className="shrink-0 [@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11"
+            className="shrink-0"
             title={t('tab_create')}
             aria-label={t('tab_create')}
           >

--- a/src/features/template-management/components/TemplateBrowser.tsx
+++ b/src/features/template-management/components/TemplateBrowser.tsx
@@ -111,10 +111,10 @@ const InlineDeleteConfirm: React.FC<InlineDeleteConfirmProps> = ({ template, onC
         </span>
       </div>
       <div className="wb-tm-delete-confirm-actions">
-        <DsButton variant="ghost" size="sm" onClick={onCancel} autoFocus className="[@media(pointer:coarse)]:!min-h-11">
+        <DsButton variant="ghost" size="sm" onClick={onCancel} autoFocus>
           {t('cancel_button')}
         </DsButton>
-        <DsButton variant="danger" size="sm" onClick={onConfirm} className="[@media(pointer:coarse)]:!min-h-11">
+        <DsButton variant="danger" size="sm" onClick={onConfirm}>
           {t('templateMgmt.delete_confirm_button')}
         </DsButton>
       </div>
@@ -171,7 +171,7 @@ const CardActions: React.FC<CardActionsProps> = ({
   if (isSelectingMode) {
     return (
       <div className="wb-tm-card-actions" onClick={(e) => e.stopPropagation()}>
-        <DsButton variant="primary" size="sm" className="w-full [@media(pointer:coarse)]:!min-h-11" onClick={() => onTemplateSelected?.(template)}>
+        <DsButton variant="primary" size="sm" className="w-full" onClick={() => onTemplateSelected?.(template)}>
           {t('use_template')}
         </DsButton>
       </div>
@@ -188,20 +188,20 @@ const CardActions: React.FC<CardActionsProps> = ({
         disabled={isDefault}
         aria-label={isDefault ? t('default_template') : t('set_default')}
         title={isDefault ? t('default_template') : t('set_default')}
-        className={cn('[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11', isDefault && 'wb-tm-star--active')}
+        className={cn(isDefault && 'wb-tm-star--active')}
       >
         <Star size={16} weight={isDefault ? 'fill' : 'regular'} />
       </DsButton>
-      <DsButton variant="utility" size="icon" iconOnly onClick={onEdit} aria-label={t('edit_tooltip')} title={t('edit_tooltip')} className="[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11">
+      <DsButton variant="utility" size="icon" iconOnly onClick={onEdit} aria-label={t('edit_tooltip')} title={t('edit_tooltip')}>
         <PencilSimple size={16} />
       </DsButton>
-      <DsButton variant="utility" size="icon" iconOnly onClick={onDuplicate} aria-label={t('duplicate_tooltip')} title={t('duplicate_tooltip')} className="[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11">
+      <DsButton variant="utility" size="icon" iconOnly onClick={onDuplicate} aria-label={t('duplicate_tooltip')} title={t('duplicate_tooltip')}>
         <Copy size={16} />
       </DsButton>
-      <DsButton variant="utility" size="icon" iconOnly onClick={onExport} aria-label={t('export_tooltip')} title={t('export_tooltip')} className="[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11">
+      <DsButton variant="utility" size="icon" iconOnly onClick={onExport} aria-label={t('export_tooltip')} title={t('export_tooltip')}>
         <Download size={16} />
       </DsButton>
-      <DsButton variant="danger" size="icon" iconOnly onClick={onRequestDelete} aria-label={t('delete_tooltip')} title={t('delete_tooltip')} className="[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11">
+      <DsButton variant="danger" size="icon" iconOnly onClick={onRequestDelete} aria-label={t('delete_tooltip')} title={t('delete_tooltip')}>
         <Trash size={16} />
       </DsButton>
     </div>
@@ -658,7 +658,7 @@ export const TemplateBrowser: React.FC<TemplateBrowserProps> = ({
           <h3 className="wb-tm-empty-title">{t('empty_title')}</h3>
           <p>{t('empty_description')}</p>
           {!isSelectingMode && onCreateTemplate && (
-            <DsButton variant="primary" size="sm" onClick={onCreateTemplate} className="mt-1 [@media(pointer:coarse)]:!min-h-11">
+            <DsButton variant="primary" size="sm" onClick={onCreateTemplate} className="mt-1">
               <Plus size={14} />
               {t('tab_create')}
             </DsButton>
@@ -670,7 +670,7 @@ export const TemplateBrowser: React.FC<TemplateBrowserProps> = ({
           <h3 className="wb-tm-empty-title">{t('templateMgmt.no_results_title')}</h3>
           <p>{t('templateMgmt.no_results_desc')}</p>
           {onResetFilters && hasFilters && (
-            <DsButton variant="default" size="sm" onClick={onResetFilters} className="mt-1 [@media(pointer:coarse)]:!min-h-11">
+            <DsButton variant="default" size="sm" onClick={onResetFilters} className="mt-1">
               {t('templateMgmt.clear_filters')}
             </DsButton>
           )}

--- a/src/features/template-management/components/TemplateInlinePanels.tsx
+++ b/src/features/template-management/components/TemplateInlinePanels.tsx
@@ -65,7 +65,7 @@ export const TemplateImportPanel: React.FC<TemplateImportPanelProps> = ({
           disabled={isImporting}
           aria-label={t('templateMgmt.panel_close')}
           title={t('templateMgmt.panel_close')}
-          className="[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11"
+         
         >
           <X size={14} />
         </DsButton>
@@ -103,7 +103,7 @@ export const TemplateImportPanel: React.FC<TemplateImportPanelProps> = ({
             size="sm"
             onClick={() => fileInputRef.current?.click()}
             disabled={isImporting}
-            className="[@media(pointer:coarse)]:!min-h-11"
+           
           >
             <FileArrowUp size={14} />
             {selectedFile ? t('templateMgmt.import_change_file') : t('templateMgmt.import_choose_file')}
@@ -156,7 +156,7 @@ export const TemplateImportPanel: React.FC<TemplateImportPanelProps> = ({
           size="sm"
           onClick={onClose}
           disabled={isImporting}
-          className="[@media(pointer:coarse)]:!min-h-11"
+         
         >
           {t('cancel_button')}
         </DsButton>
@@ -165,7 +165,7 @@ export const TemplateImportPanel: React.FC<TemplateImportPanelProps> = ({
           size="sm"
           onClick={onConfirm}
           disabled={!selectedFile || isImporting}
-          className="[@media(pointer:coarse)]:!min-h-11"
+         
         >
           {isImporting ? t('importing') : t('start_import_button')}
         </DsButton>
@@ -214,7 +214,7 @@ export const TemplateExportPanel: React.FC<TemplateExportPanelProps> = ({
             size="sm"
             onClick={onSelectAll}
             disabled={isExporting || templates.length === 0}
-            className="[@media(pointer:coarse)]:!min-h-11"
+           
           >
             {t('select_all_button')}
           </DsButton>
@@ -223,7 +223,7 @@ export const TemplateExportPanel: React.FC<TemplateExportPanelProps> = ({
             size="sm"
             onClick={onClearSelection}
             disabled={isExporting || selection.size === 0}
-            className="[@media(pointer:coarse)]:!min-h-11"
+           
           >
             {t('clear_selection_button')}
           </DsButton>
@@ -235,7 +235,7 @@ export const TemplateExportPanel: React.FC<TemplateExportPanelProps> = ({
             disabled={isExporting}
             aria-label={t('templateMgmt.panel_close')}
             title={t('templateMgmt.panel_close')}
-            className="[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11"
+           
           >
             <X size={14} />
           </DsButton>
@@ -291,7 +291,7 @@ export const TemplateExportPanel: React.FC<TemplateExportPanelProps> = ({
             size="sm"
             onClick={onClose}
             disabled={isExporting}
-            className="[@media(pointer:coarse)]:!min-h-11"
+           
           >
             {t('cancel_button')}
           </DsButton>
@@ -300,7 +300,7 @@ export const TemplateExportPanel: React.FC<TemplateExportPanelProps> = ({
             size="sm"
             onClick={onConfirm}
             disabled={isExporting || selection.size === 0}
-            className="[@media(pointer:coarse)]:!min-h-11"
+           
           >
             {isExporting ? t('exporting') : t('export_count_button', { count: selection.size })}
           </DsButton>

--- a/src/features/template-management/template-management.css
+++ b/src/features/template-management/template-management.css
@@ -28,7 +28,7 @@
   padding: 2px 2px 4px;
   overflow: hidden;
   color: var(--shell-navigation-section-label);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 400;
   line-height: 18px;
   text-overflow: ellipsis;
@@ -59,7 +59,7 @@
 
 .wb-tm-sidebar .sidebar-shell-item.desktop-shell-nav-row p {
   margin-top: 2px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   line-height: 16px;
 }
 
@@ -85,7 +85,7 @@
   border-radius: 6px 6px 0 0;
   background: transparent;
   color: hsl(var(--muted-foreground));
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   line-height: 1.25;
   white-space: nowrap;
   cursor: pointer;
@@ -155,7 +155,7 @@
   padding: 1px 6px;
   border-radius: 3px;
   background: color-mix(in hsl, hsl(var(--muted)) 55%, transparent 45%);
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   font-weight: 500;
   line-height: 1.5;
   color: hsl(var(--muted-foreground));
@@ -199,7 +199,7 @@
   border: 1px solid hsl(var(--destructive) / 0.3);
   border-radius: 6px;
   background: hsl(var(--destructive) / 0.08);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   color: hsl(var(--destructive));
 }
 
@@ -231,7 +231,7 @@
   border-radius: 6px;
   background: color-mix(in hsl, hsl(var(--warning)) 8%, transparent 92%);
   color: hsl(var(--warning));
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   line-height: 1.4;
 }
 
@@ -287,7 +287,7 @@
   border: none;
   background: transparent;
   outline: none;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: hsl(var(--foreground));
 }
 
@@ -318,7 +318,7 @@
 }
 
 .wb-tm-toolbar-count {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: hsl(var(--muted-foreground));
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
@@ -332,7 +332,7 @@
 }
 
 .wb-tm-sort-label {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: hsl(var(--muted-foreground));
   white-space: nowrap;
 }
@@ -351,7 +351,7 @@
   border-radius: var(--radius-shell-control, 8px);
   background: color-mix(in hsl, hsl(var(--foreground)) 4%, transparent 96%);
   color: hsl(var(--foreground));
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
 }
 
@@ -427,7 +427,7 @@
   border-radius: 999px;
   background: transparent;
   color: hsl(var(--muted-foreground));
-  font-size: 11.5px;
+  font-size: var(--font-size-xs);
   line-height: 1;
   white-space: nowrap;
   cursor: pointer;
@@ -548,7 +548,7 @@
   margin: 0;
   flex: 1;
   min-width: 0;
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   line-height: 1.4;
   color: hsl(var(--foreground));
@@ -590,7 +590,7 @@
 }
 
 .wb-tm-preview-meta {
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   font-weight: 500;
   color: hsl(var(--muted-foreground) / 0.8);
   font-variant-numeric: tabular-nums;
@@ -608,7 +608,7 @@
   padding: 2px 8px;
   border-radius: 999px;
   background: transparent;
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   font-weight: 600;
   letter-spacing: 0.04em;
   color: hsl(var(--muted-foreground));
@@ -663,7 +663,7 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   margin: 0 0 6px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   color: hsl(var(--muted-foreground));
 }
@@ -672,7 +672,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: hsl(var(--muted-foreground));
 }
 
@@ -693,7 +693,7 @@
   padding: 1px 6px;
   border-radius: 3px;
   background: color-mix(in hsl, hsl(var(--muted)) 55%, transparent 45%);
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   line-height: 1.4;
   color: hsl(var(--muted-foreground));
 }
@@ -758,7 +758,7 @@
   display: flex;
   align-items: flex-start;
   gap: 6px;
-  font-size: 11.5px;
+  font-size: var(--font-size-xs);
   line-height: 1.5;
   color: hsl(var(--destructive));
 }
@@ -835,7 +835,7 @@
 }
 
 .wb-tm-row-name {
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   color: hsl(var(--foreground));
   overflow: hidden;
@@ -846,7 +846,7 @@
 
 .wb-tm-row-description {
   margin: 3px 0 0;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   line-height: 1.45;
   color: hsl(var(--muted-foreground));
   display: -webkit-box;
@@ -859,7 +859,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   white-space: nowrap;
   color: hsl(var(--muted-foreground));
   font-variant-numeric: tabular-nums;
@@ -905,7 +905,7 @@
   align-items: center;
   gap: 6px;
   margin: 0;
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   color: hsl(var(--foreground));
 }
@@ -919,20 +919,20 @@
 .wb-tm-panel-desc {
   margin: 6px 0 0;
   padding: 0 12px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   color: hsl(var(--muted-foreground));
 }
 
 .wb-tm-panel-details {
   margin: 8px 12px 0;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: hsl(var(--muted-foreground));
 }
 
 .wb-tm-panel-details summary {
   cursor: pointer;
-  font-size: 11.5px;
+  font-size: var(--font-size-xs);
   color: hsl(var(--primary));
   user-select: none;
 }
@@ -976,7 +976,7 @@
   padding: 3px 8px;
   border-radius: 5px;
   background: color-mix(in hsl, hsl(var(--muted)) 45%, transparent 55%);
-  font-size: 11.5px;
+  font-size: var(--font-size-xs);
   color: hsl(var(--foreground));
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1010,7 +1010,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 12.5px;
+  font-size: var(--font-size-ui);
   color: hsl(var(--foreground));
   user-select: none;
   cursor: pointer;
@@ -1025,7 +1025,7 @@
   margin: 0 12px;
   padding: 8px 10px;
   border-radius: 6px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
 }
 
@@ -1064,7 +1064,7 @@
 
 .wb-tm-panel-count {
   margin-right: auto;
-  font-size: 11.5px;
+  font-size: var(--font-size-xs);
   color: hsl(var(--muted-foreground));
   font-variant-numeric: tabular-nums;
 }
@@ -1111,7 +1111,7 @@
 }
 
 .wb-tm-export-item-name {
-  font-size: 12.5px;
+  font-size: var(--font-size-ui);
   font-weight: 500;
   color: hsl(var(--foreground));
   overflow: hidden;
@@ -1120,7 +1120,7 @@
 }
 
 .wb-tm-export-item-meta {
-  font-size: 10.5px;
+  font-size: var(--font-size-xs);
   color: hsl(var(--muted-foreground));
 }
 
@@ -1136,13 +1136,13 @@
   min-height: 12rem;
   padding: 32px 16px;
   text-align: center;
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   color: hsl(var(--muted-foreground));
 }
 
 .wb-tm-empty-title {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: hsl(var(--foreground));
 }
@@ -1282,13 +1282,13 @@
   .wb-tm-chip {
     min-height: 44px;
     padding: 0 14px;
-    font-size: 12.5px;
+    font-size: var(--font-size-ui);
   }
 
   .wb-tm-sort-select {
     height: 44px;
     /* iOS 聚焦 <16px 的 select 会触发页面自动放大 */
-    font-size: 16px;
+    font-size: var(--font-size-lg);
   }
 
   .wb-tm-view-toggle-btn {
@@ -1299,7 +1299,7 @@
   .wb-tm-side-toggle-btn {
     min-height: 44px;
     padding: 7px 12px;
-    font-size: 11px;
+    font-size: var(--font-size-xs);
   }
 
   .wb-tm-toolbar-search {
@@ -1308,7 +1308,7 @@
 
   .wb-tm-toolbar-search-input {
     /* iOS 聚焦 <16px 的输入框会触发页面自动放大 */
-    font-size: 16px;
+    font-size: var(--font-size-lg);
   }
 
   .wb-tm-toolbar-search-clear {
@@ -1335,7 +1335,7 @@
   .wb-tm-badge,
   .wb-tm-preview-meta,
   .wb-tm-side-toggle-btn {
-    font-size: 11px;
+    font-size: var(--font-size-xs);
   }
 
   .wb-tm-card-badges {


### PR DESCRIPTION
## 背景

对 Anki 制卡主流程（anki-tasks）、卡片模板管理（template-management）、卡片预览组件（components/anki）做设计系统一致性深审。结论：该区域已经过 Workbench 原生范式重构，颜色/圆角/阴影均为 token 驱动，无美术级冲突；实际漂移集中在字号、触控覆盖层与语义色写法。

## 改动

- **字号 token 化**：TSX text-[10/11/12/13px] → text-2xs/xs/sm/ui（37 处）；CSS 固定 px → var(--font-size-*)（37 处）。半像素异端就近归并：11.5px→xs、12.5px→ui、10.5px→xs；15px 恰为 --font-size-md 精确值。scale=1 时像素不变，恢复设置里的界面字号缩放能力。
- **移除 DsButton 冗余 coarse 覆盖**（69 处）：[@media(pointer:coarse)]:!h-11/!min-h-11/!min-w-11 与按钮原语契约内建的 44px 触控命中同值冗余，且 !important 制造特异性抽奖。两个搜索框 input 无契约兜底，其 coarse 高度保留并改为 token 写法。
- **语义色写法收敛**：[color:hsl(var(--warning))] 等 24 处冗长任意值 → text-warning / bg-warning/10 等注册色形式（tailwind config 已带 <alpha-value>）；AnkiCardPreviewPanel 的 emerald 硬编码 badge → success token。
- **维持现状项**：chips/分段开关/标签页等原生 button 为定制控件、样式自洽（token 驱动），no-native-button 警告属预期；radii 6-8px 为密集管理界面的密度折衷，DS 约定存量渐进迁移。

## 验证

- 该区域 eslint warning 129 → 23（余 14 定制控件按钮 + 9 存量非视觉项），0 error
- tsc --noEmit 干净
- vitest：learning-hub + settings + 三域共 29 文件 178 用例全绿；三域单跑 72 用例全绿
- dev app 已用本分支代码启动验证