### PR TITLE
fix(mobile): 移动端手势/输入/安全区/断点一致性修复（第三轮 UI 统一）

### DIFF
--- a/src/components/crepe/CrepeEditor.css
+++ b/src/components/crepe/CrepeEditor.css
@@ -917,7 +917,9 @@
   /* 消费全局层级 token（fallback 保持旧值）；z-index 全局统一待全局代理处理 */
   z-index: var(--z-popover, 1200);
   width: 216px;
+  /* dvh 优先 + vh 兜底：iOS 地址栏显示时 100vh 大于可视高，菜单底部会被遮挡 */
   max-height: min(380px, calc(100vh - 16px));
+  max-height: min(380px, calc(100dvh - 16px));
   overflow-y: auto;
   padding: 5px;
   border: 1px solid hsl(var(--border));

--- a/src/components/layout/MobileSlidingLayout.tsx
+++ b/src/components/layout/MobileSlidingLayout.tsx
@@ -45,7 +45,7 @@ const GESTURE_OPT_OUT_SELECTOR =
  * 优先布局手势,保证"随时可滑回"。调用方可通过 gestureIgnoreSelector 覆盖。
  */
 export const DEFAULT_GESTURE_IGNORE_SELECTOR =
-  '[data-no-screen-swipe], .ds-pdf-viewer, .react-pdf__Page, .mindmap-container, .react-flow, .ProseMirror';
+  '[data-no-screen-swipe], [role="slider"], .ds-pdf-viewer, .react-pdf__Page, .mindmap-container, .react-flow, .ProseMirror';
 
 const isGestureOptOutTarget = (target: EventTarget | null): boolean => {
   if (!(target instanceof Element)) return false;

--- a/src/components/skills-management/EmbeddedToolsEditor.tsx
+++ b/src/components/skills-management/EmbeddedToolsEditor.tsx
@@ -376,7 +376,7 @@ export const EmbeddedToolsEditor: React.FC<EmbeddedToolsEditorProps> = ({
                                   size="sm"
                                   onClick={() => toggleRequired(toolIndex, propName)}
                                   disabled={disabled}
-                                  className="max-lg:!h-11 [@media(pointer:coarse)]:!min-h-11 h-7 text-[10px] px-2"
+                                  className="max-lg:!h-11 [@media(pointer:coarse)]:!min-h-11 h-7 text-2xs px-2"
                                   title={isRequired ? t('skills:editor.required') : t('skills:editor.optional')}
                                 >
                                   {isRequired ? '*' : '?'}
@@ -405,7 +405,7 @@ export const EmbeddedToolsEditor: React.FC<EmbeddedToolsEditorProps> = ({
         </div>
       )}
 
-      <p className="text-[10px] text-muted-foreground/60">
+      <p className="text-2xs text-muted-foreground/60">
         {t('skills:editor.embedded_tools_hint')}
       </p>
     </div>

--- a/src/components/skills-management/SkillEditorModal.tsx
+++ b/src/components/skills-management/SkillEditorModal.tsx
@@ -428,7 +428,7 @@ export const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
               <Wrench size={14} className="mr-1.5" />
               {t('skills:editor.tab_tools')}
               {formData.embeddedTools && formData.embeddedTools.length > 0 && (
-                <span className="ml-1.5 text-[10px] bg-primary/20 text-primary px-1.5 py-0.5 rounded-full">
+                <span className="ml-1.5 text-2xs bg-primary/20 text-primary px-1.5 py-0.5 rounded-full">
                   {formData.embeddedTools.length}
                 </span>
               )}
@@ -461,7 +461,7 @@ export const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
                   {errors.id && (
                     <p className="text-xs text-destructive">{errors.id}</p>
                   )}
-                  <p className="text-[10px] text-muted-foreground/60">
+                  <p className="text-2xs text-muted-foreground/60">
                     {t('skills:editor.id_hint')}
                   </p>
                 </div>
@@ -513,7 +513,7 @@ export const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
                 {errors.description && (
                   <p className="text-xs text-destructive">{errors.description}</p>
                 )}
-                <p className="text-[10px] text-muted-foreground/60 text-right">
+                <p className="text-2xs text-muted-foreground/60 text-right">
                   {formData.description.length}/1024
                 </p>
               </div>
@@ -562,7 +562,7 @@ export const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
                   }}
                   className="bg-muted/30 border-transparent hover:border-border/50 focus:border-primary/30 focus:bg-background transition-colors h-10 w-24"
 />
-                <p className="text-[10px] text-muted-foreground/60">
+                <p className="text-2xs text-muted-foreground/60">
                   {t('skills:editor.priority_hint')}
                 </p>
               </div>
@@ -591,7 +591,7 @@ export const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
                       {t('skills:editor.skill_type_composite')}
                     </DsButton>
                   </div>
-                  <p className="text-[10px] text-muted-foreground/60">
+                  <p className="text-2xs text-muted-foreground/60">
                     {t('skills:editor.skill_type_hint')}
                   </p>
                 </div>
@@ -604,7 +604,7 @@ export const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
                     onChange={(next) => updateField('dependencies', next)}
                     placeholder={t('skills:editor.skill_list_placeholder')}
 />
-                  <p className="text-[10px] text-muted-foreground/60">
+                  <p className="text-2xs text-muted-foreground/60">
                     {t('skills:editor.dependencies_hint')}
                   </p>
                 </div>
@@ -619,7 +619,7 @@ export const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
                   onChange={(next) => updateField('relatedSkills', next)}
                   placeholder={t('skills:editor.skill_list_placeholder')}
 />
-                <p className="text-[10px] text-muted-foreground/60">
+                <p className="text-2xs text-muted-foreground/60">
                   {t('skills:editor.related_skills_hint')}
                 </p>
               </div>
@@ -665,7 +665,7 @@ export const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
                     embeddedMode ? 'overflow-hidden resize-none min-h-[200px]' : 'resize-none flex-1 min-h-[300px]'
                   )}
 />
-                <p className="text-[10px] text-muted-foreground/60 flex-none">
+                <p className="text-2xs text-muted-foreground/60 flex-none">
                   {t('skills:editor.content_hint')}
                 </p>
               </div>

--- a/src/components/skills-management/SkillFullscreenEditor.tsx
+++ b/src/components/skills-management/SkillFullscreenEditor.tsx
@@ -407,7 +407,7 @@ export const SkillFullscreenEditor: React.FC<SkillFullscreenEditorProps> = ({
                         {errors.id && (
                           <p className="text-xs text-destructive">{errors.id}</p>
                         )}
-                        <p className="text-[10px] text-muted-foreground/60">
+                        <p className="text-2xs text-muted-foreground/60">
                           {t('skills:editor.id_hint')}
                         </p>
                       </div>
@@ -454,7 +454,7 @@ export const SkillFullscreenEditor: React.FC<SkillFullscreenEditorProps> = ({
                       {errors.description && (
                         <p className="text-xs text-destructive">{errors.description}</p>
                       )}
-                      <p className="text-[10px] text-muted-foreground/60 text-right">
+                      <p className="text-2xs text-muted-foreground/60 text-right">
                         {formData.description.length}/1024
                       </p>
                     </div>
@@ -504,7 +504,7 @@ export const SkillFullscreenEditor: React.FC<SkillFullscreenEditorProps> = ({
                           }}
                           className="bg-muted/30 border-transparent hover:border-border/50 focus:border-primary/30 focus:bg-background transition-colors h-10 w-24"
 />
-                        <p className="text-[10px] text-muted-foreground/60">
+                        <p className="text-2xs text-muted-foreground/60">
                           {t('skills:editor.priority_hint')}
                         </p>
                       </div>
@@ -530,7 +530,7 @@ export const SkillFullscreenEditor: React.FC<SkillFullscreenEditorProps> = ({
                             {t('skills:editor.skill_type_composite')}
                           </DsButton>
                         </div>
-                        <p className="text-[10px] text-muted-foreground/60">
+                        <p className="text-2xs text-muted-foreground/60">
                           {t('skills:editor.skill_type_hint')}
                         </p>
                       </div>
@@ -546,7 +546,7 @@ export const SkillFullscreenEditor: React.FC<SkillFullscreenEditorProps> = ({
                         onChange={(next) => updateField('dependencies', next)}
                         placeholder={t('skills:editor.skill_list_placeholder')}
 />
-                      <p className="text-[10px] text-muted-foreground/60">
+                      <p className="text-2xs text-muted-foreground/60">
                         {t('skills:editor.dependencies_hint')}
                       </p>
                     </div>
@@ -560,7 +560,7 @@ export const SkillFullscreenEditor: React.FC<SkillFullscreenEditorProps> = ({
                         onChange={(next) => updateField('relatedSkills', next)}
                         placeholder={t('skills:editor.skill_list_placeholder')}
 />
-                      <p className="text-[10px] text-muted-foreground/60">
+                      <p className="text-2xs text-muted-foreground/60">
                         {t('skills:editor.related_skills_hint')}
                       </p>
                     </div>

--- a/src/components/skills-management/SkillPackageSummary.tsx
+++ b/src/components/skills-management/SkillPackageSummary.tsx
@@ -85,7 +85,7 @@ function Chip({
     <span
       title={title}
       className={cn(
-        'study-shell-badge study-shell-badge--borderless inline-flex min-w-0 items-center gap-1 px-1.5 py-0.5 text-[10px]',
+        'study-shell-badge study-shell-badge--borderless inline-flex min-w-0 items-center gap-1 px-1.5 py-0.5 text-2xs',
         tone === 'primary' && 'study-shell-badge--primary',
         tone === 'warning' && 'study-shell-badge--warning',
       )}
@@ -199,7 +199,7 @@ export const SkillPackageSummary: React.FC<SkillPackageSummaryProps> = ({
             size="sm"
             onClick={handleTrustToggle}
             title={t('skills:package.trust_effect_trusted')}
-            className="!h-auto !px-1.5 !py-0.5 max-lg:!h-9 max-lg:!px-2 [@media(pointer:coarse)]:!min-h-11 text-[10px] text-primary hover:underline"
+            className="!h-auto !px-1.5 !py-0.5 max-lg:!h-9 max-lg:!px-2 [@media(pointer:coarse)]:!min-h-11 text-2xs text-primary hover:underline"
           >
             {t('skills:package.trust_enable')}
           </DsButton>
@@ -210,7 +210,7 @@ export const SkillPackageSummary: React.FC<SkillPackageSummaryProps> = ({
             size="sm"
             onClick={handleTrustToggle}
             title={t('skills:package.trust_effect_untrusted')}
-            className="!h-auto !px-1.5 !py-0.5 max-lg:!h-9 max-lg:!px-2 [@media(pointer:coarse)]:!min-h-11 text-[10px] text-muted-foreground hover:underline"
+            className="!h-auto !px-1.5 !py-0.5 max-lg:!h-9 max-lg:!px-2 [@media(pointer:coarse)]:!min-h-11 text-2xs text-muted-foreground hover:underline"
           >
             {t('skills:package.trust_revoke')}
           </DsButton>
@@ -253,14 +253,14 @@ export const SkillPackageSummary: React.FC<SkillPackageSummaryProps> = ({
 
       {toolLabels.length > 0 && (
         <div className="space-y-1">
-          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+          <div className="text-2xs font-semibold uppercase tracking-wider text-muted-foreground/70">
             {t('skills:package.tools_heading')}
           </div>
           <div className="flex flex-wrap gap-1">
             {toolLabels.map((label) => (
               <span
                 key={label}
-                className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                className="rounded bg-muted px-1.5 py-0.5 font-mono text-2xs text-muted-foreground"
               >
                 {label}
               </span>
@@ -270,7 +270,7 @@ export const SkillPackageSummary: React.FC<SkillPackageSummaryProps> = ({
       )}
 
       {skill.packageRoot && (
-        <div className="flex min-w-0 items-center gap-2 text-[11px] text-muted-foreground/70">
+        <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground/70">
           <FolderOpen size={12} className="flex-shrink-0" />
           <span className="truncate font-mono">{skill.packageRoot}</span>
         </div>
@@ -279,7 +279,7 @@ export const SkillPackageSummary: React.FC<SkillPackageSummaryProps> = ({
       {visibleFiles.length > 0 && (
         <div className="space-y-1.5">
           {visibleFiles.map((file) => (
-            <div key={file.path} className="flex min-w-0 items-center gap-2 text-[11px]">
+            <div key={file.path} className="flex min-w-0 items-center gap-2 text-xs">
               <FileText size={12} className="flex-shrink-0 text-muted-foreground/60" />
               <span className="min-w-0 flex-1 truncate font-mono text-muted-foreground/80">
                 {file.path}
@@ -290,7 +290,7 @@ export const SkillPackageSummary: React.FC<SkillPackageSummaryProps> = ({
             </div>
           ))}
           {remainingFiles > 0 && (
-            <div className="text-[11px] text-muted-foreground/60">
+            <div className="text-xs text-muted-foreground/60">
               {t('skills:package.more_files', { count: remainingFiles })}
             </div>
           )}

--- a/src/components/skills-management/SkillTapBrowser.tsx
+++ b/src/components/skills-management/SkillTapBrowser.tsx
@@ -397,17 +397,17 @@ export const SkillTapBrowser: React.FC<SkillTapBrowserProps> = ({ onClose, class
         <p className="text-xs leading-relaxed text-foreground">{sourceLabel}</p>
 
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px]">
+          <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-2xs">
             {t('skills:package.permission_files', { count: scan.files_extracted })}
           </span>
-          <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px]">
+          <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-2xs">
             {t('skills:management.import_scan_scripts', { count: scan.scripts_count })}
           </span>
-          <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px]">
+          <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-2xs">
             {t('skills:management.import_scan_tools', { count: scan.allowed_tools_count })}
           </span>
           {scan.package_sha256 && (
-            <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 font-mono text-[10px]">
+            <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 font-mono text-2xs">
               sha256:{scan.package_sha256.slice(0, 12)}
             </span>
           )}
@@ -415,29 +415,29 @@ export const SkillTapBrowser: React.FC<SkillTapBrowserProps> = ({ onClose, class
 
         <div className="space-y-1.5">
           <div className="flex items-center gap-2">
-            <span className="text-[11px] text-muted-foreground">
+            <span className="text-xs text-muted-foreground">
               {t('skills:management.risk_heading')}
             </span>
-            <span className={cn('rounded-full px-1.5 py-0.5 text-[10px] font-medium', RISK_BADGE_CLASSES[riskLevel])}>
+            <span className={cn('rounded-full px-1.5 py-0.5 text-2xs font-medium', RISK_BADGE_CLASSES[riskLevel])}>
               {t(`skills:management.risk_${riskLevel}`, scan.risk_level)}
             </span>
           </div>
           {riskLevel !== 'low' && scan.risk_signals.length > 0 && (
             <ul className="space-y-0.5">
               {scan.risk_signals.map((signal) => (
-                <li key={signal} className="text-[11px] leading-relaxed text-muted-foreground">
+                <li key={signal} className="text-xs leading-relaxed text-muted-foreground">
                   · {t(`skills:management.risk_signal_${signal}`, signal)}
                 </li>
               ))}
             </ul>
           )}
           {isHighRisk && (
-            <p className="text-[11px] leading-relaxed text-red-600 dark:text-red-400">
+            <p className="text-xs leading-relaxed text-red-600 dark:text-red-400">
               {t('skills:management.risk_high_warning')}
             </p>
           )}
           {overwrite && (
-            <p className="text-[11px] leading-relaxed text-amber-600 dark:text-amber-400">
+            <p className="text-xs leading-relaxed text-amber-600 dark:text-amber-400">
               {t('skills:management.import_confirm_overwrite_hint')}
             </p>
           )}
@@ -543,7 +543,7 @@ export const SkillTapBrowser: React.FC<SkillTapBrowserProps> = ({ onClose, class
               type="button"
               onClick={() => void handleBrowse(source.url)}
               disabled={loading}
-              className="study-shell-badge inline-flex cursor-pointer items-center gap-1 px-2 py-1 [@media(pointer:coarse)]:!min-h-11 text-[11px] transition-colors hover:bg-[var(--interactive-hover)]"
+              className="study-shell-badge inline-flex cursor-pointer items-center gap-1 px-2 py-1 [@media(pointer:coarse)]:!min-h-11 text-xs transition-colors hover:bg-[var(--interactive-hover)]"
             >
               <GithubLogo size={11} />
               {source.label}
@@ -558,7 +558,7 @@ export const SkillTapBrowser: React.FC<SkillTapBrowserProps> = ({ onClose, class
 
       {catalog && catalog.skills.length > 0 && (
         <div className="space-y-1.5">
-          <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+          <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">
             {t('skills:tap.catalog_count', { count: catalog.skills.length })}
           </div>
           <div className="space-y-1">
@@ -575,17 +575,17 @@ export const SkillTapBrowser: React.FC<SkillTapBrowserProps> = ({ onClose, class
                     <Package size={16} className="mt-0.5 flex-shrink-0 text-muted-foreground/60" />
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
-                        <span className="truncate text-[13px] font-medium text-foreground">{displayName}</span>
+                        <span className="truncate text-ui font-medium text-foreground">{displayName}</span>
                         {entry.version && (
-                          <span className="flex-shrink-0 text-[10px] text-muted-foreground/70">v{entry.version}</span>
+                          <span className="flex-shrink-0 text-2xs text-muted-foreground/70">v{entry.version}</span>
                         )}
                       </div>
                       {entry.description && (
-                        <p className="line-clamp-2 text-[11px] leading-relaxed text-muted-foreground">
+                        <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">
                           {entry.description}
                         </p>
                       )}
-                      <div className="mt-0.5 flex items-center gap-2 text-[10px] text-muted-foreground/60">
+                      <div className="mt-0.5 flex items-center gap-2 text-2xs text-muted-foreground/60">
                         {entry.subdir && <span className="truncate font-mono">{entry.subdir}</span>}
                         <span className="flex-shrink-0">{t('skills:tap.file_count', { count: entry.fileCount })}</span>
                       </div>
@@ -636,7 +636,7 @@ export const SkillTapBrowser: React.FC<SkillTapBrowserProps> = ({ onClose, class
         </div>
       )}
 
-      <p className="text-[10px] leading-relaxed text-muted-foreground/70">
+      <p className="text-2xs leading-relaxed text-muted-foreground/70">
         {t('skills:tap.footer_hint')}
       </p>
     </div>
@@ -687,7 +687,7 @@ export const SkillTapBrowser: React.FC<SkillTapBrowserProps> = ({ onClose, class
           />
           {t('skills:tap.market.non_suspicious_only')}
         </label>
-        <span className="text-[10px] text-muted-foreground/60">
+        <span className="text-2xs text-muted-foreground/60">
           {t('skills:tap.market.trending')}
         </span>
       </div>
@@ -743,21 +743,21 @@ export const SkillTapBrowser: React.FC<SkillTapBrowserProps> = ({ onClose, class
                   <Package size={16} className="mt-0.5 flex-shrink-0 text-muted-foreground/60" />
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-center gap-2">
-                      <span className="truncate text-[13px] font-medium text-foreground">
+                      <span className="truncate text-ui font-medium text-foreground">
                         {card.displayName || card.slug}
                       </span>
-                      <span className="font-mono text-[10px] text-muted-foreground/70">{card.slug}</span>
+                      <span className="font-mono text-2xs text-muted-foreground/70">{card.slug}</span>
                       {card.version && (
-                        <span className="flex-shrink-0 text-[10px] text-muted-foreground/70">v{card.version}</span>
+                        <span className="flex-shrink-0 text-2xs text-muted-foreground/70">v{card.version}</span>
                       )}
                       {renderVerifyBadge(card.verify)}
                     </div>
                     {card.summary && (
-                      <p className="line-clamp-2 text-[11px] leading-relaxed text-muted-foreground">
+                      <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">
                         {card.summary}
                       </p>
                     )}
-                    <div className="mt-0.5 flex flex-wrap items-center gap-2 text-[10px] text-muted-foreground/60">
+                    <div className="mt-0.5 flex flex-wrap items-center gap-2 text-2xs text-muted-foreground/60">
                       {card.ownerHandle && (
                         <span>{t('skills:tap.market.owner', { handle: card.ownerHandle })}</span>
                       )}
@@ -811,7 +811,7 @@ export const SkillTapBrowser: React.FC<SkillTapBrowserProps> = ({ onClose, class
         </div>
       )}
 
-      <p className="text-[10px] leading-relaxed text-muted-foreground/70">
+      <p className="text-2xs leading-relaxed text-muted-foreground/70">
         {t('skills:tap.market.footer_hint')}
       </p>
     </div>
@@ -834,10 +834,10 @@ export const SkillTapBrowser: React.FC<SkillTapBrowserProps> = ({ onClose, class
           <GithubLogo size={16} className="flex-shrink-0 text-muted-foreground" />
         )}
         <div className="min-w-0 flex-1">
-          <div className="text-[13px] font-medium text-foreground">
+          <div className="text-ui font-medium text-foreground">
             {tab === 'market' ? t('skills:tap.market.title') : t('skills:tap.title')}
           </div>
-          <p className="truncate text-[11px] text-muted-foreground">
+          <p className="truncate text-xs text-muted-foreground">
             {tab === 'market' ? t('skills:tap.market.description') : t('skills:tap.description')}
           </p>
         </div>

--- a/src/components/skills-management/SkillsList.tsx
+++ b/src/components/skills-management/SkillsList.tsx
@@ -207,7 +207,7 @@ export const SkillsList: React.FC<SkillsListProps> = ({
                 </div>
                 
                 {/* 元信息行：版本与作者 */}
-                <div className="flex items-center gap-2 text-[11px] text-muted-foreground/60 h-4">
+                <div className="flex items-center gap-2 text-xs text-muted-foreground/60 h-4">
                   {skill.version && <span>v{skill.version}</span>}
                   {skill.author && (
                      <>
@@ -228,7 +228,7 @@ export const SkillsList: React.FC<SkillsListProps> = ({
                       onToggleDefault(skill);
                     }}
                     className={cn(
-                      "flex items-center justify-center px-2 py-0.5 rounded-full text-[10px] font-medium transition-colors cursor-pointer border select-none",
+                      "flex items-center justify-center px-2 py-0.5 rounded-full text-2xs font-medium transition-colors cursor-pointer border select-none",
                       // 移动端触控目标：加高 + 负 margin 抵消行高膨胀
                       "max-lg:min-h-9 max-lg:px-2.5 max-lg:-my-1.5",
                       // 触屏（含 ≥lg 触屏平板）补足 44px 触控目标；!important 压过 max-lg:min-h-9
@@ -260,7 +260,7 @@ export const SkillsList: React.FC<SkillsListProps> = ({
                 {/* 停用标记 */}
                 {isDisabledSkill && (
                   <div
-                    className="study-shell-badge study-shell-badge--borderless text-[10px]"
+                    className="study-shell-badge study-shell-badge--borderless text-2xs"
                     title={t('skills:package.disabled_hint')}
                   >
                     {t('skills:package.disabled_badge')}
@@ -269,7 +269,7 @@ export const SkillsList: React.FC<SkillsListProps> = ({
 
                 {/* 自定义标记 */}
                 {isBuiltin && isCustomized && (
-                  <div className="study-shell-badge study-shell-badge--warning study-shell-badge--borderless text-[10px]">
+                  <div className="study-shell-badge study-shell-badge--warning study-shell-badge--borderless text-2xs">
                     {t('skills:management.customized')}
                   </div>
                 )}
@@ -281,7 +281,7 @@ export const SkillsList: React.FC<SkillsListProps> = ({
                 <DsButton
                   variant="ghost"
                   size="sm"
-                  className="!h-auto !px-1.5 !py-1 max-lg:!h-11 max-lg:!px-2.5 [@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!px-2.5 text-[11px] text-muted-foreground/60 hover:text-foreground"
+                  className="!h-auto !px-1.5 !py-1 max-lg:!h-11 max-lg:!px-2.5 [@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!px-2.5 text-xs text-muted-foreground/60 hover:text-foreground"
                   onClick={() => setSkillDisabled(skill.id, !isDisabledSkill)}
                   title={
                     isDisabledSkill

--- a/src/components/skills-management/SkillsManagementPage.tsx
+++ b/src/components/skills-management/SkillsManagementPage.tsx
@@ -1530,8 +1530,8 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
               // 移动端加大纵向点击区，接近触控目标标准（对齐制卡任务页做法）
               // 粗指针设备（如 iPad 横屏走桌面分支）用 !min-h-11 兜底触控高度，
               // 需带 ! 以覆盖 .study-shell-segmented-button 的 min-height: 0
-              ? '!h-auto !px-3 !py-2 text-[12px] font-medium whitespace-nowrap [@media(pointer:coarse)]:!min-h-11'
-              : '!h-auto !px-2.5 !py-1 text-[11px] font-medium whitespace-nowrap [@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!px-3'}
+              ? '!h-auto !px-3 !py-2 text-sm font-medium whitespace-nowrap [@media(pointer:coarse)]:!min-h-11'
+              : '!h-auto !px-2.5 !py-1 text-xs font-medium whitespace-nowrap [@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!px-3'}
             options={locationTabs
               .filter((tab) => tab.id === 'all' || locationCounts[tab.id] > 0)
               .map((tab) => {
@@ -1547,7 +1547,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                       <span>{tab.label}</span>
                       <span
                         className={cn(
-                          'ml-0.5 text-[10px] opacity-60',
+                          'ml-0.5 text-2xs opacity-60',
                           isActiveTab && 'opacity-100 font-bold',
                         )}
                       >
@@ -1632,10 +1632,10 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
         }}
         className="mb-4 space-y-2.5 rounded-lg border border-amber-300/50 bg-amber-50/50 p-3 dark:border-amber-700/40 dark:bg-amber-900/10"
       >
-        <div className="text-[13px] font-medium text-foreground">
+        <div className="text-ui font-medium text-foreground">
           {t('skills:management.update_confirm_title')}
         </div>
-        <p className="text-[11px] leading-relaxed text-muted-foreground">
+        <p className="text-xs leading-relaxed text-muted-foreground">
           {t('skills:management.update_confirm_desc', { count: pendingUpdates.length })}
         </p>
         <div className="space-y-2">
@@ -1649,22 +1649,22 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
               <div className="flex flex-wrap items-center gap-1.5">
                 <div className="text-xs font-medium text-foreground">{item.skillId}</div>
                 <span
-                  className="study-shell-badge study-shell-badge--warning study-shell-badge--borderless text-[10px]"
+                  className="study-shell-badge study-shell-badge--warning study-shell-badge--borderless text-2xs"
                   data-testid={`skill-outdated-badge-${item.skillId}`}
                   title={t('skills:management.update_outdated_hint')}
                 >
                   {t('skills:management.update_outdated_badge')}
                 </span>
               </div>
-              <div className="font-mono text-[10px] text-muted-foreground">
+              <div className="font-mono text-2xs text-muted-foreground">
                 {formatSkillUpdateDrift(item)}
               </div>
-              <div className="truncate text-[10px] text-muted-foreground/70">{item.sourceSummary}</div>
+              <div className="truncate text-2xs text-muted-foreground/70">{item.sourceSummary}</div>
             </div>
           ))}
         </div>
         <p
-          className="text-[11px] leading-relaxed text-amber-600 dark:text-amber-400"
+          className="text-xs leading-relaxed text-amber-600 dark:text-amber-400"
           data-testid="skill-update-retrust-hint"
         >
           {t('skills:management.update_retrust_hint')}
@@ -1713,28 +1713,28 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
             : 'border-border/60 bg-[color:var(--surface-muted)]',
         )}
       >
-        <div className="text-[13px] font-medium text-foreground">
+        <div className="text-ui font-medium text-foreground">
           {overwrite
             ? t('skills:management.import_confirm_overwrite_title')
             : t('skills:management.import_confirm_title')}
         </div>
-        <p className="text-[11px] leading-relaxed text-muted-foreground">
+        <p className="text-xs leading-relaxed text-muted-foreground">
           {t('skills:management.import_confirm_source', { name: scan.skill_id, file: fileName })}
         </p>
         <div className="space-y-3">
           {/* 包扫描摘要：文件 / 脚本 / 兼容工具声明 / sha256 */}
           <div className="flex flex-wrap items-center gap-1.5">
-            <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px]">
+            <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-2xs">
               {t('skills:package.permission_files', { count: scan.files_extracted })}
             </span>
-            <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px]">
+            <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-2xs">
               {t('skills:management.import_scan_scripts', { count: scan.scripts_count })}
             </span>
-            <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px]">
+            <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-2xs">
               {t('skills:management.import_scan_tools', { count: scan.allowed_tools_count })}
             </span>
             {scan.package_sha256 && (
-              <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 font-mono text-[10px]">
+              <span className="study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 font-mono text-2xs">
                 sha256:{scan.package_sha256.slice(0, 12)}
               </span>
             )}
@@ -1745,7 +1745,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
               scan.requires.env.length > 0 ||
               (scan.requires.python_packages?.length ?? 0) > 0) && (
             <div className="space-y-1">
-              <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+              <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">
                 {t('skills:management.requires_heading')}
               </div>
               <div className="flex flex-wrap items-center gap-1.5">
@@ -1753,7 +1753,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                   <span
                     key={`bin-${bin.name}`}
                     className={cn(
-                      'study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px]',
+                      'study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 text-2xs',
                       !bin.found && 'study-shell-badge--warning',
                     )}
                   >
@@ -1769,7 +1769,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                   <span
                     key={`env-${env.name}`}
                     className={cn(
-                      'study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 font-mono text-[10px]',
+                      'study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 font-mono text-2xs',
                       !env.set && 'study-shell-badge--warning',
                     )}
                   >
@@ -1785,7 +1785,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                   <span
                     key={`py-${pkg.name}`}
                     className={cn(
-                      'study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 font-mono text-[10px]',
+                      'study-shell-badge inline-flex items-center gap-1 px-1.5 py-0.5 font-mono text-2xs',
                       !pkg.found && 'study-shell-badge--warning',
                     )}
                   >
@@ -1804,12 +1804,12 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
           {/* 风险分级 + 信号列表（只提示不拦截） */}
           <div className="space-y-1.5">
             <div className="flex items-center gap-2">
-              <span className="text-[11px] text-muted-foreground">
+              <span className="text-xs text-muted-foreground">
                 {t('skills:management.risk_heading')}
               </span>
               <span
                 className={cn(
-                  'rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+                  'rounded-full px-1.5 py-0.5 text-2xs font-medium',
                   RISK_BADGE_CLASSES[riskLevel]
                 )}
               >
@@ -1819,19 +1819,19 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
             {riskLevel !== 'low' && scan.risk_signals.length > 0 && (
               <ul className="space-y-0.5">
                 {scan.risk_signals.map((signal) => (
-                  <li key={signal} className="text-[11px] leading-relaxed text-muted-foreground">
+                  <li key={signal} className="text-xs leading-relaxed text-muted-foreground">
                     · {t(`skills:management.risk_signal_${signal}`, signal)}
                   </li>
                 ))}
               </ul>
             )}
             {isHighRisk && (
-              <p className="text-[11px] leading-relaxed text-red-600 dark:text-red-400">
+              <p className="text-xs leading-relaxed text-red-600 dark:text-red-400">
                 {t('skills:management.risk_high_warning')}
               </p>
             )}
             {overwrite && (
-              <p className="text-[11px] leading-relaxed text-amber-600 dark:text-amber-400">
+              <p className="text-xs leading-relaxed text-amber-600 dark:text-amber-400">
                 {t('skills:management.import_confirm_overwrite_hint')}
               </p>
             )}
@@ -1878,11 +1878,11 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
             }}
             className="mb-4 space-y-2.5 rounded-lg border border-red-300/50 bg-red-50/50 p-3 dark:border-red-700/40 dark:bg-red-900/10"
           >
-            <div className="flex items-center gap-2 text-[13px] font-medium text-foreground">
+            <div className="flex items-center gap-2 text-ui font-medium text-foreground">
               <Warning size={16} className="text-destructive" />
               {t('skills:management.delete')}
             </div>
-            <p className="text-[11px] leading-relaxed text-muted-foreground">
+            <p className="text-xs leading-relaxed text-muted-foreground">
               {t('skills:management.delete_confirm', {
                 name: getLocalizedSkillName(skillToDelete.id, skillToDelete.name, t),
               })}
@@ -1893,10 +1893,10 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                 <span className="min-w-0 truncate font-medium">
                   {getLocalizedSkillName(skillToDelete.id, skillToDelete.name, t)}
                 </span>
-                <span className="flex-shrink-0 text-[10px] text-muted-foreground">({skillToDelete.id})</span>
+                <span className="flex-shrink-0 text-2xs text-muted-foreground">({skillToDelete.id})</span>
               </div>
               {skillToDelete.description && (
-                <p className="mt-1 line-clamp-2 text-[11px] text-muted-foreground">
+                <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
                   {getLocalizedSkillDescription(skillToDelete.id, skillToDelete.description, t)}
                 </p>
               )}
@@ -1932,11 +1932,11 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
             }}
             className="mb-4 space-y-2.5 rounded-lg border border-amber-300/50 bg-amber-50/50 p-3 dark:border-amber-700/40 dark:bg-amber-900/10"
           >
-            <div className="flex items-center gap-2 text-[13px] font-medium text-foreground">
+            <div className="flex items-center gap-2 text-ui font-medium text-foreground">
               <ArrowCounterClockwise size={16} className="text-amber-600 dark:text-amber-400" />
               {t('skills:management.reset_confirm_title')}
             </div>
-            <p className="text-[11px] leading-relaxed text-muted-foreground">
+            <p className="text-xs leading-relaxed text-muted-foreground">
               {t('skills:management.reset_confirm_desc', {
                 name: getLocalizedSkillName(skillToReset.id, skillToReset.name, t),
               })}
@@ -1972,10 +1972,10 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
             onCancel={handleCancelOverwrite}
             className="mb-4 space-y-2.5 rounded-lg border border-amber-300/50 bg-amber-50/50 p-3 dark:border-amber-700/40 dark:bg-amber-900/10"
           >
-            <div className="text-[13px] font-medium text-foreground">
+            <div className="text-ui font-medium text-foreground">
               {t('skills:management.import_overwrite_title')}
             </div>
-            <p className="text-[11px] leading-relaxed text-muted-foreground">
+            <p className="text-xs leading-relaxed text-muted-foreground">
               {t('skills:management.import_overwrite_confirm', { name: pendingImport.skill.name })}
             </p>
             <div className="flex items-center justify-end gap-2">
@@ -2005,10 +2005,10 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
             onCancel={handleCancelZipOverwrite}
             className="mb-4 space-y-2.5 rounded-lg border border-amber-300/50 bg-amber-50/50 p-3 dark:border-amber-700/40 dark:bg-amber-900/10"
           >
-            <div className="text-[13px] font-medium text-foreground">
+            <div className="text-ui font-medium text-foreground">
               {t('skills:management.import_zip_overwrite_title')}
             </div>
-            <p className="text-[11px] leading-relaxed text-muted-foreground">
+            <p className="text-xs leading-relaxed text-muted-foreground">
               {t('skills:management.import_zip_overwrite_confirm', { name: pendingZipImport.name })}
             </p>
             <div className="flex items-center justify-end gap-2">

--- a/src/components/skills-management/SkillsSidebar.tsx
+++ b/src/components/skills-management/SkillsSidebar.tsx
@@ -165,7 +165,7 @@ const SidebarContentComponent: React.FC<SidebarContentProps> = React.memo(({
                 variant="ghost" size="sm"
                 onClick={() => setLocationFilter(tab.id)}
                 className={cn(
-                  '!px-2.5 !py-1 !h-auto [@media(pointer:coarse)]:!min-h-11 text-[11px] font-medium whitespace-nowrap',
+                  '!px-2.5 !py-1 !h-auto [@media(pointer:coarse)]:!min-h-11 text-xs font-medium whitespace-nowrap',
                   isActiveTab
                     ? 'bg-secondary text-secondary-foreground shadow-sm'
                     : 'text-muted-foreground hover:bg-[var(--interactive-hover)] hover:text-foreground'
@@ -174,7 +174,7 @@ const SidebarContentComponent: React.FC<SidebarContentProps> = React.memo(({
                 <span className={cn("opacity-70", isActiveTab && "opacity-100")}>{tab.icon}</span>
                 <span>{tab.label}</span>
                 <span className={cn(
-                  'ml-0.5 text-[10px] opacity-60',
+                  'ml-0.5 text-2xs opacity-60',
                   isActiveTab && 'opacity-100 font-bold'
                 )}>
                   {count}
@@ -360,7 +360,7 @@ export const SkillsSidebar: React.FC<SkillsSidebarProps> = ({
 />
 
       <UnifiedSidebarFooter>
-        <div className="grid grid-cols-3 gap-2 text-[11px]">
+        <div className="grid grid-cols-3 gap-2 text-xs">
           <div className="flex flex-col">
             <span className="text-muted-foreground">{t('skills:location.global')}</span>
             <span className="font-semibold">{skillSummary?.global ?? locationCounts.global}</span>

--- a/src/components/ui/shad/inputShell.ts
+++ b/src/components/ui/shad/inputShell.ts
@@ -18,8 +18,11 @@
 export const inputShellClass = [
   // 形状 / 字色 / 过渡
   'rounded-[var(--radius-shell-control)]',
-  // 触屏（coarse）下 16px：iOS 对 <16px 输入聚焦时会强制放大页面
-  'text-sm [@media(pointer:coarse)]:text-base text-foreground transition-colors',
+  // 触屏（coarse）下 16px：iOS 对 <16px 输入聚焦时会强制放大页面。
+  // 注意本设计系统 text-base=14px，16px 对应 text-lg（--font-size-lg）。
+  // 全局 16px 兜底规则（deep-student.css）仅覆盖 ≤1024px 且 hover:none，
+  // iPad 横屏 / coarse+hover 设备由本类兜底。
+  'text-sm [@media(pointer:coarse)]:text-lg text-foreground transition-colors',
   // 边框 / 底色（默认态）
   'border border-[color:var(--input-shell-border)]',
   'bg-[color:var(--input-shell-surface)]',

--- a/src/features/chat/components/MessageItem.tsx
+++ b/src/features/chat/components/MessageItem.tsx
@@ -1243,7 +1243,7 @@ const MessageItemInner: React.FC<MessageItemProps> = ({
                   <div className="flex items-center gap-1 flex-shrink-0">
                     {message.timestamp && (
                       <span
-                        className="text-2xs leading-none text-muted-foreground/45 flex items-center whitespace-nowrap"
+                        className="text-caption leading-none text-muted-foreground/45 flex items-center whitespace-nowrap"
                         title={new Date(message.timestamp).toLocaleString(locale)}
                       >
                         {formatMessageTime(message.timestamp)}
@@ -1385,7 +1385,7 @@ const MessageItemInner: React.FC<MessageItemProps> = ({
                     {/* 移动端用户消息的时间显示 */}
                     {isUser && message.timestamp && (
                       <span
-                        className="text-2xs leading-none text-muted-foreground/45 flex items-center"
+                        className="text-caption leading-none text-muted-foreground/45 flex items-center"
                         title={new Date(message.timestamp).toLocaleString(locale)}
                       >
                         {formatMessageTime(message.timestamp)}
@@ -1423,7 +1423,8 @@ const MessageItemInner: React.FC<MessageItemProps> = ({
                   onClick={() => requestChatSessionNavigation(target.sessionId)}
                   className={cn(
                     'inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40',
-                    'px-2 py-1 text-[11px] leading-none text-muted-foreground transition-colors',
+                    'px-2 py-1 text-xs leading-none text-muted-foreground transition-colors',
+                    '[@media(pointer:coarse)]:min-h-[var(--touch-target-size)] [@media(pointer:coarse)]:px-3',
                     'hover:border-border hover:bg-muted/70 hover:text-foreground',
                     'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
                   )}

--- a/src/features/chat/components/__tests__/MessageItem.mobileActions.source.test.ts
+++ b/src/features/chat/components/__tests__/MessageItem.mobileActions.source.test.ts
@@ -40,6 +40,7 @@ describe('MessageItem mobile actions source', () => {
   it('keeps the compact mobile affordances visually tighter', () => {
     expect(messageActionsSource).toContain('!h-9 !w-9 rounded-full');
     expect(messageActionsSource).toContain('width={compactMobile ? 168 : 188}');
-    expect(messageItemSource).toContain('text-2xs leading-none text-muted-foreground/45');
+    // 移动端时间戳用 caption（12px）档位：2xs（10px）低于移动端最小可读字号契约
+    expect(messageItemSource).toContain('text-caption leading-none text-muted-foreground/45');
   });
 });

--- a/src/features/chat/components/input-bar/InputBarUI.tsx
+++ b/src/features/chat/components/input-bar/InputBarUI.tsx
@@ -2259,6 +2259,9 @@ const InputBarUIInner: React.FC<InputBarUIProps> = ({
         background: `var(--shell-workspace-panel)`,
         // 🎨 移动端底部安全区 + 导航栏间距（使用 bottomGapValue 同时包含安全区域和导航栏高度）
         paddingBottom: isMobile && !mobileLayout?.isFullscreenContent ? bottomGapValue : '8px',
+        // 横屏刘海/手势条：左右安全区（竖屏两值为 0，等价原 px-4）
+        paddingLeft: isMobile ? 'calc(1rem + var(--mobile-safe-area-left, 0px))' : undefined,
+        paddingRight: isMobile ? 'calc(1rem + var(--mobile-safe-area-right, 0px))' : undefined,
         ['--unified-input-docked-height' as any]: dockedHeightVarValue,
         ['--unified-input-bottom-gap' as any]: bottomGapValue,
         ['--unified-input-keyboard-inset' as any]: `${keyboardInsetPx}px`,

--- a/src/features/chat/components/renderers/CodeBlock.tsx
+++ b/src/features/chat/components/renderers/CodeBlock.tsx
@@ -824,6 +824,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({ children, className, isStr
           <div
             className={`mermaid-preview ${panning ? 'panning' : ''} ${mermaidError ? 'has-error' : ''}`}
             ref={previewRef}
+            data-no-screen-swipe
             onPointerDown={onPanPointerDown}
             onPointerMove={onPanPointerMove}
             onPointerUp={onPanPointerUp}

--- a/src/features/chat/pages/SessionItemRenderer.tsx
+++ b/src/features/chat/pages/SessionItemRenderer.tsx
@@ -200,7 +200,7 @@ const SwipeableSessionRow: React.FC<SwipeableSessionRowProps> = ({
     'flex min-w-0 flex-1 flex-col items-center justify-center gap-0.5 overflow-hidden whitespace-nowrap text-[11px] font-medium leading-none focus:outline-none focus-visible:ring-2 focus-visible:ring-ring';
 
   return (
-    <div ref={setRefs} className="relative overflow-hidden rounded-2xl">
+    <div ref={setRefs} className="relative overflow-hidden rounded-2xl" data-no-screen-swipe>
       {/* 滑出的操作色块：宽度跟随位移渐进展开 */}
       <div
         className="absolute inset-y-0 right-0 flex items-stretch overflow-hidden rounded-r-2xl"

--- a/src/features/chat/plugins/blocks/ankiCardsBlock.tsx
+++ b/src/features/chat/plugins/blocks/ankiCardsBlock.tsx
@@ -17,6 +17,7 @@ import { Textarea } from '@/components/ui/shad/Textarea';
 import { cn } from '@/utils/cn';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { showGlobalNotification } from '@/components/UnifiedNotification';
+import { isMobilePlatform } from '@/utils/platform';
 import { getErrorMessage } from '@/utils/errorUtils';
 import {
   CircleNotch,
@@ -1583,7 +1584,8 @@ const ActionButtons: React.FC<{
             )}
           </DsButton>
 
-          {/* 复习这批 → workbench 闪卡会话 */}
+          {/* 复习这批 → workbench 闪卡会话（OS 模式专属；移动端隐藏避免死路动作） */}
+          {!isMobilePlatform() && (
           <DsButton
             type="button"
             onClick={handleReviewBatch}
@@ -1595,6 +1597,7 @@ const ActionButtons: React.FC<{
             <Stack size={16} />
             {t('blocks.ankiCards.reviewBatch')}
           </DsButton>
+          )}
 
           {/* 牌组名选择：保存/导出/同步共用（默认取生成 options，会话内记住上次输入） */}
           <Popover>

--- a/src/features/notes/NotesContextPanel.tsx
+++ b/src/features/notes/NotesContextPanel.tsx
@@ -619,7 +619,7 @@ export const NotesContextPanel: React.FC<NotesContextPanelProps> = (props) => {
                             <Badge
                                 key={tag}
                                 variant="secondary"
-                                className="group h-5 gap-1 rounded-sm px-1.5 text-[11px] font-normal transition-colors duration-150 hover:bg-[var(--interactive-hover)] [@media(pointer:coarse)]:h-auto [@media(pointer:coarse)]:min-h-7"
+                                className="group h-5 gap-1 rounded-sm px-1.5 text-xs font-normal transition-colors duration-150 hover:bg-[var(--interactive-hover)] [@media(pointer:coarse)]:h-auto [@media(pointer:coarse)]:min-h-9"
                             >
                                 {canEditTags && editingTag === tag ? (
                                     <span className="flex items-center gap-1">

--- a/src/features/settings/components/data-governance/RecordConflictsPanel.tsx
+++ b/src/features/settings/components/data-governance/RecordConflictsPanel.tsx
@@ -584,7 +584,7 @@ export const RecordConflictsPanel: React.FC<{ refreshSignal?: string | number }>
               size="sm"
               onClick={() => void refreshSnapshots()}
               disabled={rollingBackBatch !== null}
-              className="h-7 text-xs [@media(pointer:coarse)]:h-10"
+              className="h-7 text-xs"
             >
               <ArrowClockwise size={12} className="mr-1" />
               {t('common:actions.refresh')}
@@ -624,7 +624,7 @@ export const RecordConflictsPanel: React.FC<{ refreshSignal?: string | number }>
                   size="sm"
                   onClick={() => void handleRollbackBatch(batch)}
                   disabled={rolledBack || rollingBackBatch !== null || loading}
-                  className="h-7 text-xs [@media(pointer:coarse)]:h-10"
+                  className="h-7 text-xs"
                   title={t('data:governance.snapshot_rollback_confirm', { count: batch.record_count })}
                 >
                   {isRollingBack && <CircleNotch size={12} className="mr-1 animate-spin" />}

--- a/src/features/todo/components/TodoMainPanel.tsx
+++ b/src/features/todo/components/TodoMainPanel.tsx
@@ -225,8 +225,9 @@ export const MobileDetailOverlay: React.FC<{
       )}
       style={{
         touchAction: 'pan-y',
-        // 键盘弹出时收缩内容区（padding 变化无需过渡：键盘弹出本身就是瞬时事件）
-        paddingBottom: keyboardInset > 0 ? keyboardInset : undefined,
+        // 键盘弹出时收缩内容区（padding 变化无需过渡：键盘弹出本身就是瞬时事件）；
+        // 底部安全区由 overlay 统一兜底（与键盘 inset 取大），子屏不再各自记得补
+        paddingBottom: `max(${keyboardInset}px, var(--mobile-safe-area-bottom, 0px))`,
         ...(edgeDragX > 0
           ? { transform: `translateX(${edgeDragX}px)`, transition: 'none' as const }
           : null),

--- a/src/features/workbench/components/DesktopShortcuts.css
+++ b/src/features/workbench/components/DesktopShortcuts.css
@@ -24,6 +24,14 @@
   padding: 16px 380px 96px 16px;
 }
 
+/* 窄桌面（<768px，对齐全局 md 断点）：组件栏整体隐藏（见 workbench.css），
+   图标层收回右侧让位——否则 <468px 时图标区可用宽度归零、图标整体不可见 */
+@media (max-width: 767.98px) {
+  .wb-desk-icons {
+    padding-right: 16px;
+  }
+}
+
 .wb-desk-icon {
   pointer-events: auto;
   position: relative;

--- a/src/features/workbench/components/StatusBar.css
+++ b/src/features/workbench/components/StatusBar.css
@@ -634,7 +634,9 @@
   /* RM 下 wb-kf-overshoot-in 已被 motion.css 重定义为纯淡入，无需额外处理 */
 }
 
-@media (max-width: 760px) {
+/* 断点对齐全局 md=768 / sm=640（src/config/breakpoints.ts），
+   避免 760-768px 区间菜单栏已降级而壳层其余部分仍按桌面的跳变 */
+@media (max-width: 767.98px) {
   .wb-menubar {
     gap: 6px;
     padding-right: 8px;
@@ -647,7 +649,7 @@
   }
 }
 
-@media (max-width: 560px) {
+@media (max-width: 639.98px) {
   .wb-menubar-command,
   .wb-menubar-settings,
   .wb-menubar-clock {

--- a/src/features/workbench/styles/workbench.css
+++ b/src/features/workbench/styles/workbench.css
@@ -590,6 +590,15 @@ html[data-wb-material='minimal'] .wb-desk-menu.wb-glass-lens {
   }
 }
 
+/* 窄桌面（<768px，对齐全局 md 断点）：日程+简报组件栏整体隐藏，
+   把全宽还给桌面图标与窗口（图标层 padding 同步收回，见 DesktopShortcuts.css）。
+   组件本就可在设置中关闭；窄窗下 340px 栏宽会压没图标区。 */
+@media (max-width: 767.98px) {
+  .wb-desktop-widget-column {
+    display: none;
+  }
+}
+
 /* ==========================================================================
  * 空桌面引导卡（EmptyDesktop.tsx 消费）
  * ========================================================================== */

--- a/src/hooks/mobile/useSwipeGesture.ts
+++ b/src/hooks/mobile/useSwipeGesture.ts
@@ -197,6 +197,21 @@ export function useSwipeGesture<T extends HTMLElement = HTMLElement>(
     stateRef.current = { ...INITIAL_STATE };
   }, []);
 
+  // 系统中断（通知栏下拉/来电/系统手势抢占）走取消路径：回弹归位，
+  // 不做阈值/fling 提交——与 MobileSlidingLayout 的 touchcancel 语义对齐
+  const handleCancel = useCallback(() => {
+    const s = stateRef.current;
+    const wasSwiping = s.axisLocked !== null && s.axisLocked !== 'rejected';
+    const opts = optionsRef.current;
+
+    if (wasSwiping) {
+      opts.onSwipeEnd?.({ delta: 0, velocity: 0, isFling: false, direction: 0, passed: false });
+      setIsSwiping(false);
+    }
+
+    stateRef.current = { ...INITIAL_STATE };
+  }, []);
+
   const ref = useCallback(
     (node: T | null) => {
       cleanupRef.current?.();
@@ -215,6 +230,7 @@ export function useSwipeGesture<T extends HTMLElement = HTMLElement>(
         });
       };
       const onTouchEnd = () => handleEnd();
+      const onTouchCancel = () => handleCancel();
 
       // 鼠标路径（桌面调试）：down 在容器，move/up 在 window，拖出容器不丢事件
       const onMouseMove = (e: MouseEvent) => {
@@ -235,20 +251,20 @@ export function useSwipeGesture<T extends HTMLElement = HTMLElement>(
       node.addEventListener('touchstart', onTouchStart, { passive: true });
       node.addEventListener('touchmove', onTouchMove, { passive: false });
       node.addEventListener('touchend', onTouchEnd);
-      node.addEventListener('touchcancel', onTouchEnd);
+      node.addEventListener('touchcancel', onTouchCancel);
       node.addEventListener('mousedown', onMouseDown);
 
       cleanupRef.current = () => {
         node.removeEventListener('touchstart', onTouchStart);
         node.removeEventListener('touchmove', onTouchMove);
         node.removeEventListener('touchend', onTouchEnd);
-        node.removeEventListener('touchcancel', onTouchEnd);
+        node.removeEventListener('touchcancel', onTouchCancel);
         node.removeEventListener('mousedown', onMouseDown);
         window.removeEventListener('mousemove', onMouseMove);
         window.removeEventListener('mouseup', onMouseUp);
       };
     },
-    [handleStart, handleMove, handleEnd],
+    [handleStart, handleMove, handleEnd, handleCancel],
   );
 
   return { ref, isSwiping };


### PR DESCRIPTION
## 概述
第三轮 UI/UX 统一性修复，聚焦移动端（前两轮：#353 简报移除+token 统一、#354 制卡区一致性）。基于 4 路并行调研（壳层导航/响应式溢出/触控可读性/关键页面走查）的 P0/P1 修复。

## 修复内容

### 手势（P0）
- `useSwipeGesture` 新增 `touchcancel` 处理：系统接管触摸（来电/控制中心）时回弹复位，不再提交半截位移
- 会话列表行、mermaid 预览加 `data-no-screen-swipe`；屏幕手势豁免选择器补 `[role=slider]`——行内滑动/滑杆拖动不再被整屏手势劫持

### 输入与触控（P0/P1）
- `inputShell` coarse 字号 `text-base→text-lg`（16px）：修复注释自称 16px 实为 14px 的系统级缺口，iOS 聚焦输入框不再触发自动缩放
- 输入栏横屏时左右 padding 叠加安全区，发送键避开刘海/手势条热区
- `MobileDetailOverlay` 底部安全区容器统一兜底（与键盘 inset 取大）
- 消息分支 chip 补 coarse 最小高度；移动端时间戳 2xs→caption（12px 移动端最小可读字号），契约测试同步
- 笔记标签 badge coarse 28→36px；RecordConflictsPanel 移除被契约 min-h 覆盖的死代码 `h-10`
- CrepeEditor 块菜单 `100vh→100dvh`（vh 兜底），iOS 地址栏展开时不再被裁

### 窄桌面与断点
- 桌面组件栏（简报/日程纵列）<768px 整体隐藏；DesktopShortcuts <468px 收回 padding-right（修复图标区被压归零）
- StatusBar 断点 760→767.98、560→639.98，与全局 md/sm 对齐

### 死路动作
- 闪卡「复习这批卡片」移动端隐藏（OS 模式专属能力，此前点击只弹「仅桌面端可用」）

### 字号 token
- skills-management 裸字号 91 处 → token（恢复缩放）；移动端 12px 下限的密度决策维持现状并记录

## 验证
- tsc --noEmit 干净；eslint 0 error（剩余 warning 均为预存）
- vitest：chat 组件/anki 块/设置滑动契约/todo/workbench 共 147 测试全绿

## 暂缓项（已记录，不在本 PR）
横屏 ≥768px 跳桌面壳、聊天抽屉开合 reflow、窗口 minSize 超桌面宽、Dock 窄屏溢出、设置 Sheet 键盘补偿、MCP 弹窗 96vw、skills-management 移动端 12px 下限密度决策