### PR TITLE
fix(mobile): 触控目标 44px 契约修正 rem 锚点缩水 + 运行时验证发现修复（第四轮）

### DIFF
--- a/src/features/chat/pages/ChatV2Page.tsx
+++ b/src/features/chat/pages/ChatV2Page.tsx
@@ -1127,7 +1127,7 @@ export const ChatV2Page: React.FC<ChatV2PageProps> = ({
             title={t('page.welcome')}
             brandIcon={<Chat size={26} weight="duotone" />}
             description={t('page.emptyPage.subtitle')}
-            hint={t('page.emptyPage.hint')}
+            hint={isSmallScreen ? undefined : t('page.emptyPage.hint')}
             actions={
               <>
                 <DsButton variant="primary" size="sm" className="[@media(pointer:coarse)]:!min-h-11" onClick={() => void createSession()}>

--- a/src/features/notes/NotesContextPanel.tsx
+++ b/src/features/notes/NotesContextPanel.tsx
@@ -619,7 +619,7 @@ export const NotesContextPanel: React.FC<NotesContextPanelProps> = (props) => {
                             <Badge
                                 key={tag}
                                 variant="secondary"
-                                className="group h-5 gap-1 rounded-sm px-1.5 text-xs font-normal transition-colors duration-150 hover:bg-[var(--interactive-hover)] [@media(pointer:coarse)]:h-auto [@media(pointer:coarse)]:min-h-9"
+                                className="group h-5 gap-1 rounded-sm px-1.5 text-xs font-normal transition-colors duration-150 hover:bg-[var(--interactive-hover)] [@media(pointer:coarse)]:h-auto [@media(pointer:coarse)]:min-h-[36px]"
                             >
                                 {canEditTags && editingTag === tag ? (
                                     <span className="flex items-center gap-1">

--- a/src/features/todo/components/TodoContentView.tsx
+++ b/src/features/todo/components/TodoContentView.tsx
@@ -323,7 +323,7 @@ export const TodoContentView: React.FC<TodoContentViewProps> = ({
           <div className="flex h-full w-full flex-col bg-[color:var(--surface-root)]">
             <CustomScrollArea
               className="min-h-0 flex-1"
-              viewportClassName="px-5 py-4 pb-[calc(1rem+var(--mobile-safe-area-bottom,0px))]"
+              viewportClassName="px-5 py-4"
             >
               {pomodoroSubView === 'stats' ? (
                 <PomodoroStatsContent showTitle={false} />

--- a/src/features/todo/components/TodoTrashDialog.tsx
+++ b/src/features/todo/components/TodoTrashDialog.tsx
@@ -474,7 +474,8 @@ export const TodoTrashScreen: React.FC<{ className?: string }> = ({ className })
         <TrashSections />
       </CustomScrollArea>
 
-      <div className="flex flex-shrink-0 items-center justify-end px-4 py-2 pb-[calc(0.5rem+var(--mobile-safe-area-bottom,0px))]">
+      {/* 底部安全区由 MobileDetailOverlay 容器统一兜底，此处不再重复叠加 */}
+      <div className="flex flex-shrink-0 items-center justify-end px-4 py-2">
         <TrashEmptyAllButton />
       </div>
     </div>

--- a/src/features/todo/components/main/TodoItemDetail.tsx
+++ b/src/features/todo/components/main/TodoItemDetail.tsx
@@ -1000,7 +1000,8 @@ export const TodoItemDetail: React.FC<{
         )}
       </CustomScrollArea>
 
-      <div className="flex items-center justify-between gap-3 border-t border-[color:var(--border-default)] px-4 py-3 pb-[calc(0.75rem+var(--mobile-safe-area-bottom,0px))]">
+      {/* 底部安全区由 MobileDetailOverlay 容器统一兜底，此处不再重复叠加 */}
+      <div className="flex items-center justify-between gap-3 border-t border-[color:var(--border-default)] px-4 py-3">
         <span className="min-w-0 flex-shrink truncate text-xs text-muted-foreground">
           {item.updatedAt
             ? t('todo:detail.updatedAt', {

--- a/src/shared/styles/deep-student.css
+++ b/src/shared/styles/deep-student.css
@@ -261,14 +261,21 @@ html.is-android-webview [contenteditable="true"] {
  * [@media(pointer:coarse)]:!min-h-11（(0,1,0)），令同时携带尺寸类与
  * coarse !min 的可点元素在触屏塌回 20–24px。这里用三重类名把 coarse
  * 契约抬到 (0,3,0)，保证 !min-h-11 / !min-w-11 在 coarse 指针下恒 ≥44px。
+ *
+ * 2026-08-30 修正：本应用 rem 锚点为 14px × font-scale（typography.css 把
+ * html font-size 设为 var(--font-size-base)），2.75rem 实际渲染 38.5px——
+ * 本规则此前写 2.75rem 并未真正达到 44px。改用 px 固定的
+ * var(--touch-target-size)，并补非 ! 变体的同等覆盖。
  */
 @media (pointer: coarse) {
-  .\[\@media\(pointer\:coarse\)\]\:\!min-h-11.\[\@media\(pointer\:coarse\)\]\:\!min-h-11.\[\@media\(pointer\:coarse\)\]\:\!min-h-11 {
-    min-height: 2.75rem !important;
+  .\[\@media\(pointer\:coarse\)\]\:\!min-h-11.\[\@media\(pointer\:coarse\)\]\:\!min-h-11.\[\@media\(pointer\:coarse\)\]\:\!min-h-11,
+  .\[\@media\(pointer\:coarse\)\]\:min-h-11.\[\@media\(pointer\:coarse\)\]\:min-h-11.\[\@media\(pointer\:coarse\)\]\:min-h-11 {
+    min-height: var(--touch-target-size, 44px) !important;
   }
 
-  .\[\@media\(pointer\:coarse\)\]\:\!min-w-11.\[\@media\(pointer\:coarse\)\]\:\!min-w-11.\[\@media\(pointer\:coarse\)\]\:\!min-w-11 {
-    min-width: 2.75rem !important;
+  .\[\@media\(pointer\:coarse\)\]\:\!min-w-11.\[\@media\(pointer\:coarse\)\]\:\!min-w-11.\[\@media\(pointer\:coarse\)\]\:\!min-w-11,
+  .\[\@media\(pointer\:coarse\)\]\:min-w-11.\[\@media\(pointer\:coarse\)\]\:min-w-11.\[\@media\(pointer\:coarse\)\]\:min-w-11 {
+    min-width: var(--touch-target-size, 44px) !important;
   }
 }
 

--- a/src/voice-input/VoiceInputControl.tsx
+++ b/src/voice-input/VoiceInputControl.tsx
@@ -123,10 +123,11 @@ export function VoiceInputControl({
       onPointerLeave={handlePointerUp}
       onPointerCancel={handlePointerUp}
       className={cn(
-        'inline-flex h-8 items-center gap-2 rounded-full border px-2.5 text-[12px] font-medium transition-colors motion-reduce:transition-none',
+        'inline-flex h-8 items-center gap-2 rounded-full border px-2.5 text-sm font-medium transition-colors motion-reduce:transition-none',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ring)]',
-        // P1-3: 32px 视觉高度保留，触屏用伪元素把命中区扩到 ≥44px
-        "relative [@media(pointer:coarse)]:after:absolute [@media(pointer:coarse)]:after:-inset-1.5 [@media(pointer:coarse)]:after:content-['']",
+        // 触屏直接给 44px 物理最小高（px 固定，不受 rem 锚点 14px 缩水影响），
+        // 与输入栏其余工具按钮（发送/添加均为 44px）对齐
+        '[@media(pointer:coarse)]:min-h-[var(--touch-target-size)]',
         isRecording
           ? 'border-destructive/40 bg-destructive/10 text-destructive shadow-[0_0_0_3px_hsl(var(--destructive)/0.08)]'
           : 'border-[color:var(--button-plain-border)] bg-[var(--button-plain-bg)] text-[color:var(--button-utility-foreground)] hover:bg-[var(--button-plain-hover-bg)] hover:text-[color:var(--text-primary)]',


### PR DESCRIPTION
## 概述
第四轮改用**运行时实测**（Playwright + iPhone 视口 + coarse 指针 + Tauri IPC mock）验证第三轮修复并深查。发现一个系统性根因和若干点状问题。

## 系统性根因：rem 锚点 14px 使触控目标集体缩水 12.5%

`typography.css` 把 `html` 的 font-size 设为 `var(--font-size-base)`（14px × font-scale），全应用 **1rem = 14px**。所有 rem 基准的 Tailwind 数值高度类随之缩水：`min-h-11`（名义 2.75rem=44px）**实际渲染 38.5px**，低于 Apple HIG 44pt 触控下限。

最深的证据：`deep-student.css` 6b 节的「coarse 触控契约恢复」规则（三重类名 (0,3,0) 专门压住小尺寸基线）自身写的也是 `2.75rem`——**连契约恢复规则都被锚点欺骗，从未真正达到 44px**。

修复：6b 规则值改 `var(--touch-target-size)`（px 固定，免疫字号缩放），并补非 `!` 变体覆盖。一处改动，全库约 2400 处 coarse 触控类归位 44px。

运行时实测（修复前 → 后）：bang 变体 38.5px → **44px**；plain 变体 38.5px → **44px**；尺寸基线叠加场景 20-24px 塌陷 → **44px**。

## 其他运行时实测发现

- **语音输入按钮 34x28px**（h-8 缩水 + 伪元素扩展也是 rem 基准）：改为 coarse `min-h-[var(--touch-target-size)]`，实测 34x44
- **移动端欢迎空态显示「Ctrl / ⌘ + N 新建对话」键盘提示**：触屏无意义，isSmallScreen 时不传 hint
- **Todo 子屏底部安全区双计**（第三轮 overlay 容器兜底引入的回归）：详情 footer / 回收站 / 番茄滚动区各自的安全区 padding 移除

## 第三轮修复的运行时回归验证（全部通过）

输入框 16px 生效（textarea fs=16 实测）；横屏安全区 padding 生效；键盘 hint 已隐藏；抽屉/会话导航正常；390px 无横向溢出。

## 级联考古记录（对后续维护者重要）

Tailwind v3 的 @layer 只是排序约定（输出无层 CSS），!important 变体与同特异性覆盖按源序决胜；`deep-student.css` 6b 的三重类名 (0,3,0) 是最终赢家。任何后续触控覆盖请直接改 6b 的值，不要在别的文件另起规则（会被 6b 压过）。

## 验证
- tsc 干净；eslint 0 error（49 warning 均为预存）
- vitest：voice-input / InputBarUI.voiceInput / ThreadEmptyStateShell / todo 共 65 测试全绿
- 运行时：Playwright iPhone 视口全流程（协议页→抽屉→会话→输入栏）实测通过

## 已知边界（有意不修）
- `coarse:h-11`（503 处固定高度）维持 38.5px：固定高度膨胀有溢出风险，遵循 6b 原作者的 min-only 范围决策
- rem 锚点改回 16px 是设计决策（全应用间距 +14.3%），不在本轮范围