### PR TITLE
fix(todo)+feat(workbench): 待办空态圆环居中修复与页面工具栏迁入全局顶栏

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2813,12 +2813,12 @@ function App() {
                 className="desktop-shell-header-cell desktop-shell-header-cell--workspace relative z-10 flex flex-1 min-w-0 items-center justify-between px-5"
                 style={{ paddingLeft: `${20 + desktopTitlebarLeadingInset}px` }}
               >
-                {currentView === 'learning-hub' ? (
+                {currentView === 'learning-hub' || currentView === 'todo' || currentView === 'skills-management' ? (
                   <div
                     ref={setDesktopPageHeaderTarget}
                     className="h-full min-w-0 flex-1"
                     data-no-drag
-                    data-shell-slot="learning-hub-toolbar"
+                    data-shell-slot={currentView === 'learning-hub' ? 'learning-hub-toolbar' : currentView === 'todo' ? 'todo-toolbar' : 'skills-toolbar'}
                   />
                 ) : currentView === 'chat-v2' && currentChatHeaderSessionId && currentChatHeaderTitle ? (
                   <div className="flex min-w-0 flex-1 items-center gap-3">

--- a/src/components/skills-management/SkillsManagementPage.tsx
+++ b/src/components/skills-management/SkillsManagementPage.tsx
@@ -4,7 +4,8 @@
  * 卡片网格布局，顶部工具栏包含搜索和筛选功能
  */
 
-import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useMemo, useEffect, useLayoutEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
 import { LayoutGroup } from 'framer-motion';
@@ -27,6 +28,7 @@ import {
 } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
+import { useDesktopShellHeaderPortal } from '@/app/shell/DesktopShellHeaderPortal';
 import { DsButton } from '@/components/ui/DsButton';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { Input } from '@/components/ui/shad/Input';
@@ -201,6 +203,34 @@ export const SkillsManagementPage: React.FC<SkillsManagementPageProps> = ({
 
   // ========== 响应式布局 ==========
   const { isSmallScreen } = useBreakpoint();
+  // workbench 窗口标题栏 app 槽位查找（与 ChatAppWindow 同款：壳内查询 + 观察兜底）
+  const [windowTitlebarSlot, setWindowTitlebarSlot] = useState<HTMLElement | null>(null);
+  useLayoutEffect(() => {
+    if (!workbenchWindowId) return;
+    const escapedId = typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(workbenchWindowId) : workbenchWindowId;
+    const shell = document.querySelector<HTMLElement>(`[data-wb-window-id="${escapedId}"]`);
+    const queryRoot: ParentNode = shell ?? document;
+    let currentTarget: HTMLElement | null = null;
+    let observer: MutationObserver | null = null;
+    const findTarget = () => {
+      const target = Array.from(queryRoot.querySelectorAll<HTMLElement>('[data-wb-titlebar-slot]'))
+        .find((element) => element.dataset.windowId === workbenchWindowId) ?? null;
+      if (!target) return;
+      currentTarget = target;
+      setWindowTitlebarSlot((current) => (current === target ? current : target));
+      observer?.disconnect();
+      observer = null;
+    };
+    findTarget();
+    if (!currentTarget) {
+      observer = new MutationObserver(findTarget);
+      observer.observe(shell ?? document.body, { childList: true, subtree: true });
+    }
+    return () => observer?.disconnect();
+  }, [workbenchWindowId]);
+  // legacy 壳标题栏槽位；与 workbench 窗口槽位互斥
+  const shellHeaderTarget = useDesktopShellHeaderPortal('skills-management');
+  const toolbarPortalTarget = windowTitlebarSlot ?? shellHeaderTarget;
   // 工具栏折叠口径：移动端 viewport 或非 wide 档的 workbench 窗口
   const collapseToolbarActions =
     isSmallScreen || (windowSizeClass !== undefined && windowSizeClass !== 'wide');
@@ -1320,10 +1350,11 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
   }, [workbenchWindowId]);
 
   // ========== 渲染主内容 ==========
-  const renderMainContent = () => (
-    <div className="study-shell-page flex-1 flex flex-col min-w-0 h-full overflow-hidden">
-      <div className="study-shell-toolbar flex-shrink-0 px-5 sm:px-8 lg:px-10 py-3 space-y-3">
-        <div className={cn("flex items-center gap-4", isSmallScreen ? "justify-between" : "justify-between")}>
+  const renderMainContent = () => {
+    // 工具栏第一行（面包屑/计数 + 动作条）：桌面端有全局顶栏槽位时 portal 上移，
+    // 页内不再重复渲染；第二行（搜索 + 位置筛选）始终页内保留
+    const toolbarPrimaryRow = (
+        <div className={cn("flex items-center gap-4", isSmallScreen ? "justify-between" : "justify-between", toolbarPortalTarget && 'pointer-events-auto min-w-0 flex-1')}>
           <div className="flex items-center gap-2 text-sm text-muted-foreground min-w-0">
             <span className="font-medium text-foreground truncate">{t('skills:management.all_skills')}</span>
             <span className="text-muted-foreground/40">/</span>
@@ -1499,7 +1530,18 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
             )}
           </div>
         </div>
+    );
 
+    return (
+    <div className="study-shell-page flex-1 flex flex-col min-w-0 h-full overflow-hidden">
+      {toolbarPortalTarget
+        ? createPortal(
+            <div className="pointer-events-none flex h-full min-w-0 items-center px-2">{toolbarPrimaryRow}</div>,
+            toolbarPortalTarget,
+          )
+        : null}
+      <div className={cn('study-shell-toolbar flex-shrink-0 px-5 sm:px-8 lg:px-10', toolbarPortalTarget ? 'py-2' : 'py-3 space-y-3')}>
+        {!toolbarPortalTarget && toolbarPrimaryRow}
         <div className={cn("flex items-center gap-3", isSmallScreen && "flex-col items-stretch")}>
           <div className={cn("relative flex-1", !isSmallScreen && "max-w-xs")}>
             <MagnifyingGlass size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground/50" />
@@ -1590,7 +1632,8 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
         </div>
       </CustomScrollArea>
     </div>
-  );
+    );
+  };
 
   // ========== 渲染右侧面板（移动端编辑器） ==========
   const renderRightPanel = () => (

--- a/src/features/todo/components/TodoAutomationWorkspace.tsx
+++ b/src/features/todo/components/TodoAutomationWorkspace.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import {
   ArrowsClockwise,
@@ -17,6 +18,7 @@ import {
   X,
 } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
+import { useTodoToolbarPortalTarget } from './todoToolbarPortal';
 import { CustomScrollArea } from '@/components/custom-scroll-area';
 import { DsButton } from '@/components/ui/DsButton';
 import { Input } from '@/components/ui/shad/Input';
@@ -240,11 +242,15 @@ interface TodoAutomationWorkspaceProps {
    * 第二条顶栏。桌面端与 Workbench 窗口承载（无统一顶栏）保持默认 false。
    */
   hideHeader?: boolean;
+  /** 桌面端：全局顶栏 portal 目标（workbench 窗口标题栏槽位 / legacy 壳标题栏） */
+  titlebarPortalTarget?: HTMLElement | null;
 }
 
-export const TodoAutomationWorkspace: React.FC<TodoAutomationWorkspaceProps> = ({ hideHeader = false }) => {
+export const TodoAutomationWorkspace: React.FC<TodoAutomationWorkspaceProps> = ({ hideHeader = false, titlebarPortalTarget }) => {
   const { t, i18n } = useTranslation(['todo', 'settings', 'common']);
   const locale = i18n.resolvedLanguage || i18n.language || 'zh-CN';
+  // 桌面端：标题栏迁入全局顶栏（hideHeader 的移动壳场景不参与）
+  const headerPortalTarget = useTodoToolbarPortalTarget(titlebarPortalTarget);
 
   const automations = useAutomationStore((state) => state.automations);
   const count = useAutomationStore((state) => state.count);
@@ -573,54 +579,69 @@ export const TodoAutomationWorkspace: React.FC<TodoAutomationWorkspaceProps> = (
     ? localizeAutomationError(error)
     : null;
 
+  // 标题栏内容（页内内联 / portal 进全局顶栏两种承载共用）
+  const headerClusters = (
+    <>
+      <div className={cn('flex min-w-0 items-center gap-2.5', headerPortalTarget && 'pointer-events-auto')}>
+        <Robot size={20} weight="duotone" className="shrink-0 text-primary" />
+        <div className="min-w-0">
+          <h1 className="truncate text-base font-semibold text-foreground">
+            {t('todo:automation.title')}
+          </h1>
+          <p className="truncate text-xs text-muted-foreground">
+            {t('todo:automation.subtitle')}
+          </p>
+        </div>
+      </div>
+      <div className={cn('flex shrink-0 items-center gap-1.5', headerPortalTarget && 'pointer-events-auto')}>
+        <DsButton
+          variant="ghost"
+          size="icon"
+          iconOnly
+          className="[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11"
+          aria-label={t('common:actions.refresh')}
+          title={t('common:actions.refresh')}
+          disabled={refreshing}
+          onClick={handleRefresh}
+        >
+          <ArrowsClockwise size={16} className={cn(refreshing && 'animate-spin motion-reduce:animate-none')} />
+        </DsButton>
+        {/* 容量门禁：与 AutomationSettingsSection 的新建按钮同一判定与提示文案 */}
+        <span title={capacityFull ? t('settings:automation.create.capacity_full', { max }) : undefined}>
+          <DsButton
+            ref={newTaskButtonRef}
+            variant="primary"
+            size="sm"
+            className="[@media(pointer:coarse)]:!min-h-11"
+            aria-expanded={createOpen}
+            aria-controls={CREATE_PANEL_ID}
+            disabled={capacityFull && !createOpen}
+            onClick={() => (createOpen ? closeCreate() : openCreate())}
+          >
+            <Plus size={15} />
+            {t('todo:automation.new')}
+          </DsButton>
+        </span>
+      </div>
+    </>
+  );
+
   return (
     <div className="flex h-full min-w-0 flex-col bg-[color:var(--surface-root,var(--background))]">
       {/* 页内标题栏：移动/桌面分界由 TodoContentView 按 isSmallScreen(<768)
           经 hideHeader 决定，不再用 sm(640) 断点自行分界（640–767 曾与
-          统一顶栏叠出双标题，<640 残留纯动作条）。渲染时标题块恒显示。 */}
-      {hideHeader ? null : (
+          统一顶栏叠出双标题，<640 残留纯动作条）。渲染时标题块恒显示。
+          桌面端有全局顶栏槽位时整体 portal 上移，页内不再重复渲染。 */}
+      {hideHeader ? null : headerPortalTarget ? (
+        createPortal(
+          <div className="pointer-events-none flex h-full min-w-0 items-center justify-between gap-3 px-2">
+            {headerClusters}
+          </div>,
+          headerPortalTarget,
+        )
+      ) : (
       <header className="study-shell-toolbar flex min-h-14 shrink-0 items-center justify-between gap-3 border-b border-border px-4 sm:px-6">
-        <div className="flex min-w-0 items-center gap-2.5">
-          <Robot size={20} weight="duotone" className="shrink-0 text-primary" />
-          <div className="min-w-0">
-            <h1 className="truncate text-base font-semibold text-foreground">
-              {t('todo:automation.title')}
-            </h1>
-            <p className="truncate text-xs text-muted-foreground">
-              {t('todo:automation.subtitle')}
-            </p>
-          </div>
-        </div>
-        <div className="flex shrink-0 items-center gap-1.5">
-          <DsButton
-            variant="ghost"
-            size="icon"
-            iconOnly
-            className="[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11"
-            aria-label={t('common:actions.refresh')}
-            title={t('common:actions.refresh')}
-            disabled={refreshing}
-            onClick={handleRefresh}
-          >
-            <ArrowsClockwise size={16} className={cn(refreshing && 'animate-spin motion-reduce:animate-none')} />
-          </DsButton>
-          {/* 容量门禁：与 AutomationSettingsSection 的新建按钮同一判定与提示文案 */}
-          <span title={capacityFull ? t('settings:automation.create.capacity_full', { max }) : undefined}>
-            <DsButton
-              ref={newTaskButtonRef}
-              variant="primary"
-              size="sm"
-              className="[@media(pointer:coarse)]:!min-h-11"
-              aria-expanded={createOpen}
-              aria-controls={CREATE_PANEL_ID}
-              disabled={capacityFull && !createOpen}
-              onClick={() => (createOpen ? closeCreate() : openCreate())}
-            >
-              <Plus size={15} />
-              {t('todo:automation.new')}
-            </DsButton>
-          </span>
-        </div>
+        {headerClusters}
       </header>
       )}
 

--- a/src/features/todo/components/TodoContentView.tsx
+++ b/src/features/todo/components/TodoContentView.tsx
@@ -36,6 +36,8 @@ interface TodoContentViewProps {
   todoListId?: string;
   initialView?: 'todos' | 'automations';
   className?: string;
+  /** workbench 窗口标题栏槽位（TodoAppWindow 传入）；提供时主面板工具栏迁入窗口标题栏 */
+  titlebarPortalTarget?: HTMLElement | null;
 }
 
 /** 详情面板内焦点守卫：activeElement 落在 data-todo-detail-panel 内则延迟 reload */
@@ -72,6 +74,7 @@ export const TodoContentView: React.FC<TodoContentViewProps> = ({
   todoListId,
   initialView,
   className,
+  titlebarPortalTarget,
 }) => {
   const { t } = useTranslation(['todo', 'common']);
   const { isSmallScreen } = useBreakpoint();
@@ -364,11 +367,11 @@ export const TodoContentView: React.FC<TodoContentViewProps> = ({
           exit={{ opacity: 0, y: -4, transition: motionSafe({ ...tweenFast, duration: 0.1 }) }}
         >
           {desktopMode === 'trash' ? (
-            <TodoTrashWorkspace />
+            <TodoTrashWorkspace titlebarPortalTarget={titlebarPortalTarget} />
           ) : desktopMode === 'automations' ? (
-            <TodoAutomationWorkspace />
+            <TodoAutomationWorkspace titlebarPortalTarget={titlebarPortalTarget} />
           ) : (
-            <TodoMainPanel />
+            <TodoMainPanel titlebarPortalTarget={titlebarPortalTarget} />
           )}
         </motion.div>
       </AnimatePresence>

--- a/src/features/todo/components/TodoMainPanel.tsx
+++ b/src/features/todo/components/TodoMainPanel.tsx
@@ -13,6 +13,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import {
   Calendar,
@@ -44,6 +45,7 @@ import { Input } from '@/components/ui/shad/Input';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/shad/Select';
 import { CustomScrollArea } from '@/components/custom-scroll-area';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
+import { useTodoToolbarPortalTarget } from './todoToolbarPortal';
 import { useTodoStore } from '../stores/useTodoStore';
 import { PomodoroPanel } from '@/features/pomodoro';
 import '../styles/todo-motion.css';
@@ -303,11 +305,18 @@ interface TodoMainPanelProps {
    * 联动统一顶栏返回箭头与 Android 返回键）。未提供时番茄钟按钮走桌面锚定弹层。
    */
   onOpenPomodoroSubView?: (view: PomodoroSubView) => void;
+  /**
+   * 桌面端：窗口标题栏 portal 目标（workbench 窗口的 wb-titlebar-slot）。
+   * 提供时工具栏整体迁入窗口标题栏，页内不再重复渲染一条顶栏。
+   */
+  titlebarPortalTarget?: HTMLElement | null;
 }
 
-export const TodoMainPanel: React.FC<TodoMainPanelProps> = ({ onOpenPomodoroSubView }) => {
+export const TodoMainPanel: React.FC<TodoMainPanelProps> = ({ onOpenPomodoroSubView, titlebarPortalTarget }) => {
   const { t } = useTranslation(['todo', 'common']);
   const { isSmallScreen } = useBreakpoint();
+  // workbench 窗口标题栏槽位优先；其次 legacy 壳标题栏。两者互斥（壳模式二选一）
+  const toolbarPortalTarget = useTodoToolbarPortalTarget(titlebarPortalTarget);
 
   // 细粒度订阅：只在各自切片变化时重渲染（zustand action 引用稳定）
   const items = useTodoStore((s) => s.items);
@@ -846,15 +855,11 @@ export const TodoMainPanel: React.FC<TodoMainPanelProps> = ({ onOpenPomodoroSubV
     }
   })();
 
-  return (
-    // h-full：MobileSlidingLayout 的内容窗格是普通块级容器（非 flex），flex-1 在其中不生效，
-    // 高度会塌缩成内容高度，导致移动端详情覆盖层（absolute inset-0）跟着变矮
-    <div ref={panelRootRef} className="flex h-full min-w-0 flex-1 flex-row overflow-hidden">
-      {/* 主列 */}
-      <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
-        {/* 顶部工具栏 */}
-        <div className="study-shell-toolbar flex flex-shrink-0 flex-wrap items-center gap-3 px-4 py-3 sm:px-6">
-          <div className="flex min-w-0 flex-1 items-baseline gap-3">
+  // 桌面端：工具栏整体 portal 进全局顶栏（workbench 窗口标题栏槽位 / legacy 壳标题栏），
+  // 页内不再重复渲染一条顶栏；移动端保持页内内联
+  const toolbarClusters = (
+    <>
+      <div className={cn('flex min-w-0 flex-1 items-baseline gap-3', toolbarPortalTarget && 'pointer-events-auto')}>
             {!isSmallScreen && (
               <h2 className="truncate text-[15px] font-semibold text-foreground">
                 {viewTitle}
@@ -896,7 +901,7 @@ export const TodoMainPanel: React.FC<TodoMainPanelProps> = ({ onOpenPomodoroSubV
             )}
           </div>
 
-          <div className="flex flex-shrink-0 items-center gap-2">
+      <div className={cn('flex flex-shrink-0 items-center gap-2', toolbarPortalTarget && 'pointer-events-auto')}>
             {isSmallScreen ? (
               // 窄屏：搜索折叠为图标（≥44px 触控），点击展开下方内联输入行
               <DsButton
@@ -985,9 +990,28 @@ export const TodoMainPanel: React.FC<TodoMainPanelProps> = ({ onOpenPomodoroSubV
               <ListChecks size={14} />
               <span className="hidden sm:inline">{t('todo:bulk.selectMode', '选择')}</span>
             </DsButton>
-          </div>
+      </div>
+    </>
+  );
 
-          {/* 窄屏内联搜索行（flex-wrap 下换行占满整行；关闭时清空搜索词） */}
+  return (
+    // h-full：MobileSlidingLayout 的内容窗格是普通块级容器（非 flex），flex-1 在其中不生效，
+    // 高度会塌缩成内容高度，导致移动端详情覆盖层（absolute inset-0）跟着变矮
+    <div ref={panelRootRef} className="flex h-full min-w-0 flex-1 flex-row overflow-hidden">
+      {/* 主列 */}
+      <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+        {/* 顶部工具栏：桌面端 portal 进全局顶栏；移动端页内内联 */}
+        {toolbarPortalTarget ? (
+          createPortal(
+            <div className="pointer-events-none flex h-full min-w-0 items-center gap-3 px-2">
+              {toolbarClusters}
+            </div>,
+            toolbarPortalTarget,
+          )
+        ) : (
+          <div className="study-shell-toolbar flex flex-shrink-0 flex-wrap items-center gap-3 px-4 py-3 sm:px-6">
+            {toolbarClusters}
+            {/* 窄屏内联搜索行（flex-wrap 下换行占满整行；关闭时清空搜索词） */}
           {isSmallScreen && mobileSearchOpen && (
             <div className="ui-rise-in flex w-full items-center gap-2 pb-1">
               <div className="relative min-w-0 flex-1">
@@ -1023,7 +1047,8 @@ export const TodoMainPanel: React.FC<TodoMainPanelProps> = ({ onOpenPomodoroSubV
               </DsButton>
             </div>
           )}
-        </div>
+          </div>
+        )}
 
         {/* 批量多选操作条（内联，非弹窗）：Cmd/Ctrl/Shift 点选行或多选模式勾选后出现 */}
         {checkedIds.size > 0 && (

--- a/src/features/todo/components/TodoTrashDialog.tsx
+++ b/src/features/todo/components/TodoTrashDialog.tsx
@@ -19,6 +19,7 @@
  */
 
 import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { create } from 'zustand';
 import { AnimatePresence } from 'framer-motion';
@@ -35,6 +36,7 @@ import { AnimatedListRow } from '@/components/ui/AnimatedListRow';
 import { CustomScrollArea } from '@/components/custom-scroll-area';
 import { cn } from '@/lib/utils';
 import { useTodoStore } from '../stores/useTodoStore';
+import { useTodoToolbarPortalTarget } from './todoToolbarPortal';
 
 // ============================================================================
 // 回收站视图开关（侧栏与内容区分属不同挂载点，经模块级 store 协调）
@@ -384,10 +386,12 @@ const TrashEmptyAllButton: React.FC<{ className?: string }> = ({ className }) =>
 // TodoTrashWorkspace — 桌面端主内容区内联回收站视图（带返回）
 // ============================================================================
 
-export const TodoTrashWorkspace: React.FC<{ className?: string }> = ({ className }) => {
+export const TodoTrashWorkspace: React.FC<{ className?: string; titlebarPortalTarget?: HTMLElement | null }> = ({ className, titlebarPortalTarget }) => {
   const { t } = useTranslation(['todo', 'common']);
   const { loadTrash } = useTodoStore();
   const close = useTodoTrashView((s) => s.close);
+  // 桌面端：头部迁入全局顶栏（workbench 窗口标题栏槽位 / legacy 壳标题栏）
+  const headerPortalTarget = useTodoToolbarPortalTarget(titlebarPortalTarget);
 
   useEffect(() => {
     void loadTrash();
@@ -412,6 +416,34 @@ export const TodoTrashWorkspace: React.FC<{ className?: string }> = ({ className
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [close]);
 
+  const headerClusters = (
+    <>
+      <div className={cn('flex min-w-0 items-center gap-2', headerPortalTarget && 'pointer-events-auto')}>
+        <DsButton
+          variant="ghost"
+          size="sm"
+          iconOnly
+          onClick={close}
+          aria-label={t('todo:trash.back')}
+          title={t('todo:trash.back')}
+          className="[@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11"
+        >
+          <ArrowLeft size={16} />
+        </DsButton>
+        <Trash size={18} weight="duotone" className="shrink-0 text-muted-foreground" />
+        <div className="min-w-0">
+          <h2 className="truncate text-[15px] font-semibold leading-tight text-foreground">
+            {t('todo:trash.title')}
+          </h2>
+          <p className="hidden truncate text-sm text-muted-foreground md:block">
+            {t('todo:trash.description')}
+          </p>
+        </div>
+      </div>
+      <TrashEmptyAllButton className={cn('shrink-0', headerPortalTarget && 'pointer-events-auto')} />
+    </>
+  );
+
   return (
     <div
       ref={workspaceRef}
@@ -420,31 +452,18 @@ export const TodoTrashWorkspace: React.FC<{ className?: string }> = ({ className
         className,
       )}
     >
-      <header className="study-shell-toolbar flex min-h-14 shrink-0 items-center justify-between gap-3 px-4 sm:px-6">
-        <div className="flex min-w-0 items-center gap-2">
-          <DsButton
-            variant="ghost"
-            size="sm"
-            iconOnly
-            onClick={close}
-            aria-label={t('todo:trash.back')}
-            title={t('todo:trash.back')}
-            className="[@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11"
-          >
-            <ArrowLeft size={16} />
-          </DsButton>
-          <Trash size={18} weight="duotone" className="shrink-0 text-muted-foreground" />
-          <div className="min-w-0">
-            <h2 className="truncate text-[15px] font-semibold leading-tight text-foreground">
-              {t('todo:trash.title')}
-            </h2>
-            <p className="hidden truncate text-sm text-muted-foreground md:block">
-              {t('todo:trash.description')}
-            </p>
-          </div>
-        </div>
-        <TrashEmptyAllButton className="shrink-0" />
-      </header>
+      {headerPortalTarget ? (
+        createPortal(
+          <div className="pointer-events-none flex h-full min-w-0 items-center justify-between gap-3 px-2">
+            {headerClusters}
+          </div>,
+          headerPortalTarget,
+        )
+      ) : (
+        <header className="study-shell-toolbar flex min-h-14 shrink-0 items-center justify-between gap-3 px-4 sm:px-6">
+          {headerClusters}
+        </header>
+      )}
 
       <CustomScrollArea className="min-h-0 flex-1" viewportClassName="px-2 pb-4 sm:px-4">
         <TrashSections />

--- a/src/features/todo/components/todoToolbarPortal.ts
+++ b/src/features/todo/components/todoToolbarPortal.ts
@@ -1,0 +1,15 @@
+import { useDesktopShellHeaderPortal } from '@/app/shell/DesktopShellHeaderPortal';
+
+/**
+ * 待办工具栏 portal 目标解析（TodoMainPanel / TodoTrashWorkspace /
+ * TodoAutomationWorkspace 共用）：
+ * - workbench 窗口标题栏槽位（TodoAppWindow 经 prop 透传）优先；
+ * - 其次 legacy 壳标题栏（currentView==='todo' 时由 App 壳提供）；
+ * - 两者互斥（壳模式二选一）；移动端均为 null，工具栏保持页内内联。
+ */
+export function useTodoToolbarPortalTarget(
+  windowTitlebarSlot?: HTMLElement | null,
+): HTMLElement | null {
+  const shellTarget = useDesktopShellHeaderPortal('todo');
+  return windowTitlebarSlot ?? shellTarget;
+}

--- a/src/features/todo/styles/todo-motion.css
+++ b/src/features/todo/styles/todo-motion.css
@@ -110,8 +110,13 @@
 .todo-empty-decor::after {
   content: '';
   position: absolute;
-  inset: 0;
-  margin: auto;
+  /* 居中不用 inset:0 + margin:auto：圆环大于图标盒（200%/290%）时属于
+     过约束绝对定位，各引擎对负自由空间的 auto margin 解析不一致
+     （Blink/WebKit 横向解析为 0，圆环向右偏 24px）。改用 50% + translate
+     显式居中，全引擎一致；呼吸 scale 并入同一 transform */
+  top: 50%;
+  left: 50%;
+  margin: 0;
   border-radius: 9999px;
   border: 1px solid currentColor;
   opacity: 0.12;
@@ -134,10 +139,10 @@
 @keyframes todo-empty-breathe {
   0%,
   100% {
-    transform: scale(1);
+    transform: translate(-50%, -50%) scale(1);
   }
   50% {
-    transform: scale(1.06);
+    transform: translate(-50%, -50%) scale(1.06);
   }
 }
 

--- a/src/features/workbench/apps/system/TodoAppWindow.tsx
+++ b/src/features/workbench/apps/system/TodoAppWindow.tsx
@@ -15,7 +15,7 @@
  *   自行在「完整侧栏 / 图标栏」间切换；useWbSysSize 的测量元素改为
  *   兄弟节点，绕开 `[data-wb-sys-size='compact'] .wb-sys-aside` 的 CSS 隐藏。
  */
-import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TodoContentView, TodoShellSidebar } from '@/features/todo';
 import { TodoIconRail } from '@/features/todo/components/TodoIconRail';
@@ -143,13 +143,39 @@ const SidebarResizeHandle: React.FC<{
 // TodoAppWindow
 // ============================================================================
 
-const TodoAppWindow: React.FC<AppWindowProps> = ({ launchPayload, onTitleChange }) => {
+const TodoAppWindow: React.FC<AppWindowProps> = ({ launchPayload, onTitleChange, windowId }) => {
   const { t } = useTranslation('workbench');
   const { ref: sizeRef, sizeClass } = useWbSysSize();
   const compact = sizeClass === 'compact';
 
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState(readStoredSidebarWidth);
+  const [titlebarTarget, setTitlebarTarget] = useState<HTMLElement | null>(null);
+
+  // 窗口标题栏 app 槽位查找（与 ChatAppWindow 同款：壳内查询 + MutationObserver 兜底，
+  // 命中后断开——槽位与窗口同生命周期）
+  useLayoutEffect(() => {
+    const escapedWindowId = typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(windowId) : windowId;
+    const shell = document.querySelector<HTMLElement>(`[data-wb-window-id="${escapedWindowId}"]`);
+    const queryRoot: ParentNode = shell ?? document;
+    let currentTarget: HTMLElement | null = null;
+    let observer: MutationObserver | null = null;
+    const findTarget = () => {
+      const target = Array.from(queryRoot.querySelectorAll<HTMLElement>('[data-wb-titlebar-slot]'))
+        .find((element) => element.dataset.windowId === windowId) ?? null;
+      if (!target) return;
+      currentTarget = target;
+      setTitlebarTarget((current) => (current === target ? current : target));
+      observer?.disconnect();
+      observer = null;
+    };
+    findTarget();
+    if (!currentTarget) {
+      observer = new MutationObserver(findTarget);
+      observer.observe(shell ?? document.body, { childList: true, subtree: true });
+    }
+    return () => observer?.disconnect();
+  }, [windowId]);
   const sizeClassRef = useRef(sizeClass);
   sizeClassRef.current = sizeClass;
 
@@ -225,7 +251,7 @@ const TodoAppWindow: React.FC<AppWindowProps> = ({ launchPayload, onTitleChange 
             navLabel={t('workbench:apps.system.todoNav')}
             sidebar={sidebarSlot}
           >
-            <TodoContentView todoListId={todoListId} initialView={initialView} className="h-full" />
+            <TodoContentView todoListId={todoListId} initialView={initialView} className="h-full" titlebarPortalTarget={titlebarTarget} />
           </WorkbenchSidebarLayout>
         </WbSysFade>
       </Suspense>

--- a/src/features/workbench/components/WindowTitleBar.tsx
+++ b/src/features/workbench/components/WindowTitleBar.tsx
@@ -414,7 +414,9 @@ export const WindowTitleBar: React.FC<WindowTitleBarProps> = ({
       ? t('a11y.immersiveExit')
       : t('a11y.immersiveEnter');
   const hostsAppTabs = appTypeId === 'notes' || appTypeId === 'files';
-  const hostsAppTitlebarSlot = hostsAppTabs || appTypeId === 'chat';
+  // todo/skills 工具栏整体 portal 进窗口标题栏（应用名已由菜单栏承接，居中标题冗余）
+  const hostsAppTitlebarSlot = hostsAppTabs || appTypeId === 'chat' || appTypeId === 'todo' || appTypeId === 'skills';
+  const suppressCenteredTitle = hostsAppTabs || appTypeId === 'todo' || appTypeId === 'skills';
   /** 长标题被渐隐截断时，悬停标题栏空白区可见完整标题（三键自带 title 优先） */
   const barTooltip = titleOverflow ? title : undefined;
 
@@ -560,7 +562,7 @@ export const WindowTitleBar: React.FC<WindowTitleBarProps> = ({
         />
       ) : null}
       {/* 标题绝对居中（不受左侧三键宽度影响）；溢出时 mask 渐隐 */}
-      {!hostsAppTabs ? (
+      {!suppressCenteredTitle ? (
         <div
           className="pointer-events-none absolute inset-x-16 top-0 flex h-full items-center justify-center"
           aria-hidden={title === ''}

--- a/tests/vitest/learning-hub/learningHubGlobalHeaderContract.test.ts
+++ b/tests/vitest/learning-hub/learningHubGlobalHeaderContract.test.ts
@@ -8,7 +8,9 @@ describe('learning hub desktop header ownership', () => {
   const filesAppSource = readFileSync(resolve(process.cwd(), 'src/features/workbench/apps/files/FilesAppWindow.tsx'), 'utf-8');
 
   it('portals the normal-mode Finder toolbar into the global shell header', () => {
-    expect(appSource).toContain('data-shell-slot="learning-hub-toolbar"');
+    // 槽位为多页面共享（learning-hub / todo / skills-management 按 currentView 切换 data-shell-slot）
+    expect(appSource).toContain("currentView === 'learning-hub'");
+    expect(appSource).toContain("'learning-hub-toolbar'");
     expect(appSource).toContain('<DesktopShellHeaderPortalProvider value={desktopShellHeaderPortalValue}>');
     expect(pageSource).toContain("useDesktopShellHeaderPortal('learning-hub')");
     expect(pageSource).toContain('toolbarPortalTarget={desktopShellHeaderTarget}');


### PR DESCRIPTION
## 用户反馈驱动（第五轮）

1. **待办空态图标外大圆圈不居中** → 根因：`inset:0 + margin:auto` 对 oversized 伪元素（200%/290%）在 Blink 下横向 auto margin 解析为 0。改 `top/left:50% + translate(-50%,-50%)`，呼吸 scale 并入 keyframes。
2. **待办桌面端自带顶栏，应用全局顶栏承接状态** → workbench 模式下窗口原为 menubar → 窗口标题栏（仅重复应用名）→ 页内工具栏三层堆叠。
3. **排查其他页面同类毛病** → 全库 `study-shell-toolbar` 用户仅 6 文件：learning-hub（已有 portal）、chat（已有标题栏控件 portal 的自有设计）、todo×3、skills-management。全部处理完毕。

## 方案

复用既有机制，零新发明：
- **workbench**：`WindowTitleBar` 的 app 槽位（notes/files/chat 同款 `data-wb-titlebar-slot`）扩展到 todo/skills，居中标题让位（应用名已由菜单栏承接）。
- **legacy 壳**：`desktop-shell-titlebar` 页面槽位（learning-hub 同款 `useDesktopShellHeaderPortal`）扩展到 todo/skills-management。
- 新增 `useTodoToolbarPortalTarget` 共享解析（窗口槽位优先、壳槽位兜底、移动端为 null 保持内联）。
- 槽位容器 `pointer-events:none`，仅交互簇恢复 auto——空隙保持窗口可拖拽。

## 覆盖面

| 页面 | 上移内容 | 页内保留 |
|---|---|---|
| 待办主面板 | 标题/计数/进度/搜索/排序/筛选/选择 | — |
| 回收站 | 返回/标题/清空 | — |
| 定时任务 | 标题/刷新/新建 | — |
| 技能管理 | 面包屑/计数/动作条 | 搜索+位置筛选行 |

子视图同步上移是关键：主面板卸载后标题栏不会空置。

## 验证

- tsc 0 错；eslint 0 错；vitest todo+workbench 1938 过、skills+workbench 1790 过、shell+learning-hub 180 过；`cargo check --lib` 通过。
- 运行时（Playwright + 系统 Chrome mock，双壳实测）：workbench 槽位 8 元素无横向溢出、垂直居中偏差 ≤4px；legacy 壳槽位内容齐全；回收站标题栏返回按钮真实点击可用；页内无重复工具栏；技能页首行入槽、搜索筛选行留页内。

## 已知边界

- 窗口极窄时槽位 overflow hidden 裁剪右侧动作（技能页非 wide 档已自动收 ⋯ 菜单；待办窗口可拉宽）。
- ChatV2Page 页内工具栏为会话级操作的自有设计，本轮不动。