### PR TITLE
fix(todo)+style(shell): 移除空态圆环装饰，全局顶栏内容物视觉规格统一

### DIFF
--- a/src/app/shell/titlebarUiTokens.ts
+++ b/src/app/shell/titlebarUiTokens.ts
@@ -1,0 +1,28 @@
+/**
+ * 全局顶栏内容物统一规格（workbench 窗口标题栏槽位 / legacy 壳标题栏槽位共用）。
+ *
+ * 对齐既有件：chat 标题栏控件 28×28px（wb-chat-titlebar-sidebar-toggle，px 固定）。
+ * 注意本应用 rem 锚点为 14px（typography.css html font-size），h-8=2rem=28px 实际，
+ * 而 h-7=1.75rem 仅 24.5px——故统一规格用 h-8 对齐 chat 的 28px 真值；
+ * learning-hub titlebarMode 的 !h-7（24.5px）属既有偏差，不在本轮收敛。
+ * coarse 指针 h-10（=35px 实际），不溢出 38px 标题栏。
+ *
+ * 仅用于 portal 进顶栏的内容；页内内联渲染保持各页原有密度（移动端触控 44px 契约不变）。
+ */
+
+/** 标题（页面/视图名）：13px 半粗，与窗口标题文字 wb-title-text 同级 */
+export const TITLEBAR_TITLE_CLASS = 'truncate text-ui font-semibold text-foreground';
+
+/** 次级信息（计数 / 路径分隔 / 副标题）：12px 弱化 */
+export const TITLEBAR_META_CLASS = 'whitespace-nowrap text-xs text-muted-foreground/60';
+
+/** 文本控件（按钮 / 选择器触发器）：实际 28px，coarse 指针 35px */
+export const TITLEBAR_CONTROL_CLASS =
+  '!h-8 !min-h-0 gap-1.5 !px-2.5 !py-0 text-xs [@media(pointer:coarse)]:!h-10';
+
+/** 图标控件：实际 28px 见方，coarse 指针 35px */
+export const TITLEBAR_ICON_CONTROL_CLASS =
+  '!h-8 !w-8 !p-1.5 [@media(pointer:coarse)]:!h-10 [@media(pointer:coarse)]:!w-10';
+
+/** 搜索输入：实际 28px，coarse 指针 35px */
+export const TITLEBAR_INPUT_CLASS = 'h-8 text-xs [@media(pointer:coarse)]:!h-10';

--- a/src/components/skills-management/SkillsManagementPage.tsx
+++ b/src/components/skills-management/SkillsManagementPage.tsx
@@ -29,6 +29,11 @@ import {
 import { cn } from '@/lib/utils';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useDesktopShellHeaderPortal } from '@/app/shell/DesktopShellHeaderPortal';
+import {
+  TITLEBAR_CONTROL_CLASS,
+  TITLEBAR_ICON_CONTROL_CLASS,
+  TITLEBAR_TITLE_CLASS,
+} from '@/app/shell/titlebarUiTokens';
 import { DsButton } from '@/components/ui/DsButton';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { Input } from '@/components/ui/shad/Input';
@@ -231,6 +236,11 @@ export const SkillsManagementPage: React.FC<SkillsManagementPageProps> = ({
   // legacy 壳标题栏槽位；与 workbench 窗口槽位互斥
   const shellHeaderTarget = useDesktopShellHeaderPortal('skills-management');
   const toolbarPortalTarget = windowTitlebarSlot ?? shellHeaderTarget;
+  const inTitlebar = Boolean(toolbarPortalTarget);
+  // 顶栏模式统一控件规格（28px / coarse 40px / text-xs，对齐 chat 与 learning-hub 既有件）
+  const titlebarSecondaryBtnCls = cn(TITLEBAR_CONTROL_CLASS, 'text-muted-foreground');
+  const inlineSecondaryBtnCls = 'max-lg:!h-11 [@media(pointer:coarse)]:!min-h-11 h-7 text-xs px-2 text-muted-foreground';
+  const secondaryBtnCls = inTitlebar ? titlebarSecondaryBtnCls : inlineSecondaryBtnCls;
   // 工具栏折叠口径：移动端 viewport 或非 wide 档的 workbench 窗口
   const collapseToolbarActions =
     isSmallScreen || (windowSizeClass !== undefined && windowSizeClass !== 'wide');
@@ -1355,8 +1365,8 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
     // 页内不再重复渲染；第二行（搜索 + 位置筛选）始终页内保留
     const toolbarPrimaryRow = (
         <div className={cn("flex items-center gap-4", isSmallScreen ? "justify-between" : "justify-between", toolbarPortalTarget && 'pointer-events-auto min-w-0 flex-1')}>
-          <div className="flex items-center gap-2 text-sm text-muted-foreground min-w-0">
-            <span className="font-medium text-foreground truncate">{t('skills:management.all_skills')}</span>
+          <div className={cn('flex min-w-0 items-center gap-2 text-muted-foreground', inTitlebar ? 'text-xs' : 'text-sm')}>
+            <span className={inTitlebar ? TITLEBAR_TITLE_CLASS : 'font-medium text-foreground truncate'}>{t('skills:management.all_skills')}</span>
             <span className="text-muted-foreground/40">/</span>
             <span className="flex-shrink-0">{t('skills:management.skills_count', { count: filteredSkills.length })}</span>
           </div>
@@ -1378,7 +1388,9 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                   variant="shell"
                   size="sm"
                   onClick={handleCreate}
-                  className="h-7 [@media(pointer:coarse)]:!h-11 border-transparent bg-[color:var(--button-tonal-bg)] px-2.5 text-xs"
+                  className={inTitlebar
+                    ? cn(TITLEBAR_CONTROL_CLASS, 'border-transparent bg-[color:var(--button-tonal-bg)]')
+                    : 'h-7 [@media(pointer:coarse)]:!h-11 border-transparent bg-[color:var(--button-tonal-bg)] px-2.5 text-xs'}
                 >
                   <Plus size={14} className="mr-1.5" />
                   {t('skills:management.create')}
@@ -1394,7 +1406,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                   size="sm"
                   onClick={() => void handleRefresh()}
                   disabled={isLoading}
-                  className="max-lg:!h-11 [@media(pointer:coarse)]:!min-h-11 h-7 text-xs px-2 text-muted-foreground"
+                  className={secondaryBtnCls}
                   aria-label={t('skills:selector.refresh')}
                 >
                   <ArrowCounterClockwise size={14} className={cn('mr-1', isLoading && 'animate-spin')} />
@@ -1407,7 +1419,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                   onClick={() => setTapBrowserOpen((v) => !v)}
                   aria-expanded={tapBrowserOpen}
                   className={cn(
-                    'max-lg:!h-11 [@media(pointer:coarse)]:!min-h-11 h-7 text-xs px-2 text-muted-foreground',
+                    secondaryBtnCls,
                     tapBrowserOpen && 'bg-[color:var(--interactive-hover)] text-foreground',
                   )}
                 >
@@ -1420,7 +1432,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                   size="sm"
                   onClick={() => void handleCheckUpdates()}
                   disabled={updateChecking}
-                  className="max-lg:!h-11 [@media(pointer:coarse)]:!min-h-11 h-7 text-xs px-2 text-muted-foreground"
+                  className={secondaryBtnCls}
                 >
                   <CloudArrowDown size={14} className={cn('mr-1', updateChecking && 'animate-pulse')} />
                   {t('skills:management.check_updates')}
@@ -1430,7 +1442,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                   variant="ghost"
                   size="sm"
                   onClick={handleImportZipClick}
-                  className="max-lg:!h-11 [@media(pointer:coarse)]:!min-h-11 h-7 text-xs px-2 text-muted-foreground"
+                  className={secondaryBtnCls}
                 >
                   <Package size={14} className="mr-1" />
                   {t('skills:management.import_zip')}
@@ -1440,7 +1452,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                   variant="ghost"
                   size="sm"
                   onClick={handleImportClick}
-                  className="max-lg:!h-11 [@media(pointer:coarse)]:!min-h-11 h-7 text-xs px-2 text-muted-foreground"
+                  className={secondaryBtnCls}
                 >
                   <Upload size={14} className="mr-1" />
                   {t('skills:management.import')}
@@ -1451,7 +1463,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                   size="sm"
                   onClick={handleExportAll}
                   disabled={allSkills.filter(s => !s.isBuiltin).length === 0}
-                  className="max-lg:!h-11 [@media(pointer:coarse)]:!min-h-11 h-7 text-xs px-2 text-muted-foreground"
+                  className={secondaryBtnCls}
                 >
                   <Download size={14} className="mr-1" />
                   {t('skills:management.export_all_short')}
@@ -1462,7 +1474,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                   size="sm"
                   onClick={() => void handleExportTap()}
                   disabled={allSkills.filter(s => !s.isBuiltin && s.location === 'global').length === 0}
-                  className="max-lg:!h-11 [@media(pointer:coarse)]:!min-h-11 h-7 text-xs px-2 text-muted-foreground"
+                  className={secondaryBtnCls}
                 >
                   <UploadSimple size={14} className="mr-1" />
                   {t('skills:management.export_tap')}
@@ -1477,7 +1489,7 @@ const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElemen
                     variant="ghost"
                     size="icon"
                     iconOnly
-                    className={cn('text-muted-foreground', isSmallScreen ? '!h-11 !w-11' : '!h-7 !w-7')}
+                    className={cn('text-muted-foreground', inTitlebar ? TITLEBAR_ICON_CONTROL_CLASS : isSmallScreen ? '!h-11 !w-11' : '!h-7 !w-7')}
                     aria-label={t('common:more')}
                     title={t('common:more')}
                   >

--- a/src/features/todo/components/TodoAutomationWorkspace.tsx
+++ b/src/features/todo/components/TodoAutomationWorkspace.tsx
@@ -19,6 +19,11 @@ import {
 } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
 import { useTodoToolbarPortalTarget } from './todoToolbarPortal';
+import {
+  TITLEBAR_CONTROL_CLASS,
+  TITLEBAR_ICON_CONTROL_CLASS,
+  TITLEBAR_TITLE_CLASS,
+} from '@/app/shell/titlebarUiTokens';
 import { CustomScrollArea } from '@/components/custom-scroll-area';
 import { DsButton } from '@/components/ui/DsButton';
 import { Input } from '@/components/ui/shad/Input';
@@ -585,7 +590,9 @@ export const TodoAutomationWorkspace: React.FC<TodoAutomationWorkspaceProps> = (
       <div className={cn('flex min-w-0 items-center gap-2.5', headerPortalTarget && 'pointer-events-auto')}>
         <Robot size={20} weight="duotone" className="shrink-0 text-primary" />
         <div className="min-w-0">
-          <h1 className="truncate text-base font-semibold text-foreground">
+          <h1 className={headerPortalTarget
+            ? TITLEBAR_TITLE_CLASS
+            : 'truncate text-base font-semibold text-foreground'}>
             {t('todo:automation.title')}
           </h1>
           <p className="truncate text-xs text-muted-foreground">
@@ -598,7 +605,9 @@ export const TodoAutomationWorkspace: React.FC<TodoAutomationWorkspaceProps> = (
           variant="ghost"
           size="icon"
           iconOnly
-          className="[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11"
+          className={headerPortalTarget
+            ? TITLEBAR_ICON_CONTROL_CLASS
+            : '[@media(pointer:coarse)]:!min-h-11 [@media(pointer:coarse)]:!min-w-11'}
           aria-label={t('common:actions.refresh')}
           title={t('common:actions.refresh')}
           disabled={refreshing}
@@ -612,7 +621,7 @@ export const TodoAutomationWorkspace: React.FC<TodoAutomationWorkspaceProps> = (
             ref={newTaskButtonRef}
             variant="primary"
             size="sm"
-            className="[@media(pointer:coarse)]:!min-h-11"
+            className={headerPortalTarget ? TITLEBAR_CONTROL_CLASS : '[@media(pointer:coarse)]:!min-h-11'}
             aria-expanded={createOpen}
             aria-controls={CREATE_PANEL_ID}
             disabled={capacityFull && !createOpen}

--- a/src/features/todo/components/TodoMainPanel.tsx
+++ b/src/features/todo/components/TodoMainPanel.tsx
@@ -46,6 +46,11 @@ import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/u
 import { CustomScrollArea } from '@/components/custom-scroll-area';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useTodoToolbarPortalTarget } from './todoToolbarPortal';
+import {
+  TITLEBAR_CONTROL_CLASS,
+  TITLEBAR_INPUT_CLASS,
+  TITLEBAR_TITLE_CLASS,
+} from '@/app/shell/titlebarUiTokens';
 import { useTodoStore } from '../stores/useTodoStore';
 import { PomodoroPanel } from '@/features/pomodoro';
 import '../styles/todo-motion.css';
@@ -317,6 +322,7 @@ export const TodoMainPanel: React.FC<TodoMainPanelProps> = ({ onOpenPomodoroSubV
   const { isSmallScreen } = useBreakpoint();
   // workbench 窗口标题栏槽位优先；其次 legacy 壳标题栏。两者互斥（壳模式二选一）
   const toolbarPortalTarget = useTodoToolbarPortalTarget(titlebarPortalTarget);
+  const inTitlebar = Boolean(toolbarPortalTarget);
 
   // 细粒度订阅：只在各自切片变化时重渲染（zustand action 引用稳定）
   const items = useTodoStore((s) => s.items);
@@ -861,7 +867,7 @@ export const TodoMainPanel: React.FC<TodoMainPanelProps> = ({ onOpenPomodoroSubV
     <>
       <div className={cn('flex min-w-0 flex-1 items-baseline gap-3', toolbarPortalTarget && 'pointer-events-auto')}>
             {!isSmallScreen && (
-              <h2 className="truncate text-[15px] font-semibold text-foreground">
+              <h2 className={inTitlebar ? TITLEBAR_TITLE_CLASS : 'truncate text-[15px] font-semibold text-foreground'}>
                 {viewTitle}
               </h2>
             )}
@@ -929,17 +935,21 @@ export const TodoMainPanel: React.FC<TodoMainPanelProps> = ({ onOpenPomodoroSubV
                   onChange={(e) => setSearch(e.target.value)}
                   placeholder={t('todo:actions.search')}
                   data-todo-search
-                  className="h-8 w-28 pl-8 pr-3 text-xs sm:w-56 [@media(pointer:coarse)]:h-11"
+                  className={inTitlebar
+                    ? cn(TITLEBAR_INPUT_CLASS, 'w-36 pl-8 pr-3')
+                    : 'h-8 w-28 pl-8 pr-3 text-xs sm:w-56 [@media(pointer:coarse)]:h-11'}
                 />
               </div>
             )}
 
-            <PriorityFilterMenu />
+            <PriorityFilterMenu triggerClassName={inTitlebar ? TITLEBAR_CONTROL_CLASS : undefined} />
 
             <Select value={filter.sortBy} onValueChange={(v) => setSortBy(v as TodoSortBy)}>
               <SelectTrigger
                 aria-label={t('todo:sort.label')}
-                className="!h-8 !min-h-0 !w-auto gap-1 !px-2.5 !py-0 text-xs [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!min-w-[2.75rem]"
+                className={inTitlebar
+                  ? cn(TITLEBAR_CONTROL_CLASS, '!w-auto')
+                  : '!h-8 !min-h-0 !w-auto gap-1 !px-2.5 !py-0 text-xs [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!min-w-[2.75rem]'}
               >
                 <SortAscending size={14} className="text-muted-foreground" />
                 {/* !hidden：对抗 SelectTrigger 基类的 [&>span]:line-clamp-1（会把 span 重置为 -webkit-box） */}
@@ -963,7 +973,9 @@ export const TodoMainPanel: React.FC<TodoMainPanelProps> = ({ onOpenPomodoroSubV
               disabled={filter.view === 'completed'}
               data-selected={filter.showCompleted}
               className={cn(
-                'h-8 gap-1.5 !px-2.5 text-xs [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:min-w-[2.75rem]',
+                inTitlebar
+                  ? TITLEBAR_CONTROL_CLASS
+                  : 'h-8 gap-1.5 !px-2.5 text-xs [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:min-w-[2.75rem]',
                 filter.showCompleted &&
                   '!bg-[color:var(--button-primary-surface)] !text-[color:var(--button-primary-foreground)]',
               )}
@@ -982,7 +994,9 @@ export const TodoMainPanel: React.FC<TodoMainPanelProps> = ({ onOpenPomodoroSubV
               aria-label={t('todo:bulk.selectMode', '选择')}
               title={t('todo:bulk.selectMode', '选择')}
               className={cn(
-                'h-8 gap-1.5 !px-2.5 text-xs [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:min-w-[2.75rem]',
+                inTitlebar
+                  ? TITLEBAR_CONTROL_CLASS
+                  : 'h-8 gap-1.5 !px-2.5 text-xs [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:min-w-[2.75rem]',
                 checkMode &&
                   '!bg-[color:var(--button-primary-surface)] !text-[color:var(--button-primary-foreground)]',
               )}

--- a/src/features/todo/components/TodoMainPanel.tsx
+++ b/src/features/todo/components/TodoMainPanel.tsx
@@ -1086,8 +1086,6 @@ export const TodoMainPanel: React.FC<TodoMainPanelProps> = ({ onOpenPomodoroSubV
                 <div
                   className={cn(
                     'study-shell-empty-state__icon',
-                    // 纯 CSS 同心圆装饰（缓慢呼吸），替代插画资源
-                    'todo-empty-decor',
                     // 清零类空态：一次性亮色 scale 弹跳（无 confetti，reduced-motion 下退化）
                     emptyState.celebratory &&
                       '!text-[color:hsl(var(--success))] todo-celebrate-pop',

--- a/src/features/todo/components/TodoTrashDialog.tsx
+++ b/src/features/todo/components/TodoTrashDialog.tsx
@@ -37,6 +37,11 @@ import { CustomScrollArea } from '@/components/custom-scroll-area';
 import { cn } from '@/lib/utils';
 import { useTodoStore } from '../stores/useTodoStore';
 import { useTodoToolbarPortalTarget } from './todoToolbarPortal';
+import {
+  TITLEBAR_CONTROL_CLASS,
+  TITLEBAR_ICON_CONTROL_CLASS,
+  TITLEBAR_TITLE_CLASS,
+} from '@/app/shell/titlebarUiTokens';
 
 // ============================================================================
 // 回收站视图开关（侧栏与内容区分属不同挂载点，经模块级 store 协调）
@@ -426,13 +431,17 @@ export const TodoTrashWorkspace: React.FC<{ className?: string; titlebarPortalTa
           onClick={close}
           aria-label={t('todo:trash.back')}
           title={t('todo:trash.back')}
-          className="[@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11"
+          className={headerPortalTarget
+            ? TITLEBAR_ICON_CONTROL_CLASS
+            : '[@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:!w-11'}
         >
           <ArrowLeft size={16} />
         </DsButton>
         <Trash size={18} weight="duotone" className="shrink-0 text-muted-foreground" />
         <div className="min-w-0">
-          <h2 className="truncate text-[15px] font-semibold leading-tight text-foreground">
+          <h2 className={headerPortalTarget
+            ? TITLEBAR_TITLE_CLASS
+            : 'truncate text-[15px] font-semibold leading-tight text-foreground'}>
             {t('todo:trash.title')}
           </h2>
           <p className="hidden truncate text-sm text-muted-foreground md:block">
@@ -440,7 +449,7 @@ export const TodoTrashWorkspace: React.FC<{ className?: string; titlebarPortalTa
           </p>
         </div>
       </div>
-      <TrashEmptyAllButton className={cn('shrink-0', headerPortalTarget && 'pointer-events-auto')} />
+      <TrashEmptyAllButton className={cn('shrink-0', headerPortalTarget && `pointer-events-auto ${TITLEBAR_CONTROL_CLASS}`)} />
     </>
   );
 

--- a/src/features/todo/components/main/PriorityFilterMenu.tsx
+++ b/src/features/todo/components/main/PriorityFilterMenu.tsx
@@ -22,7 +22,7 @@ import { PriorityIcon } from './TodoItemRow';
 
 const PRIORITY_ORDER: TodoPriority[] = ['urgent', 'high', 'medium', 'low', 'none'];
 
-export const PriorityFilterMenu: React.FC = () => {
+export const PriorityFilterMenu: React.FC<{ triggerClassName?: string }> = ({ triggerClassName }) => {
   const { t } = useTranslation(['todo']);
   const priorityFilter = useTodoStore((s) => s.filter.priorityFilter);
   const setPriorityFilter = useTodoStore((s) => s.setPriorityFilter);
@@ -51,7 +51,7 @@ export const PriorityFilterMenu: React.FC = () => {
           size="sm"
           data-selected={Boolean(priorityFilter)}
           className={cn(
-            'h-8 gap-1.5 !px-2.5 text-xs [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:min-w-[2.75rem]',
+            triggerClassName ?? 'h-8 gap-1.5 !px-2.5 text-xs [@media(pointer:coarse)]:!h-11 [@media(pointer:coarse)]:min-w-[2.75rem]',
             priorityFilter &&
               '!bg-[color:var(--button-primary-surface)] !text-[color:var(--button-primary-foreground)]',
           )}

--- a/src/features/todo/styles/todo-motion.css
+++ b/src/features/todo/styles/todo-motion.css
@@ -5,7 +5,6 @@
  * - .todo-check-burst：勾选圈外圈扩散光环（配合 todo-check-pop，Things 式满足感）
  * - .todo-row-completing：完成提交期间行内容轻微右移淡出
  * - .todo-celebrate-pop：清零空态图标一次性 scale 亮色反馈（无 confetti）
- * - .todo-empty-decor：空态图标外的纯 CSS 同心圆装饰（缓慢呼吸）
  * - .todo-quickadd-pop：快速添加成功时加号图标弹跳转绿
  * - .todo-matrix-drag-ghost：四象限拖拽拖影（轻微倾斜 + 阴影）
  * - .todo-swipe-hint-content：触屏首次使用提示——首行内容左移露出「完成」
@@ -101,50 +100,7 @@
   animation: todo-quickadd-pop 360ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }
 
-/* 空态图标外的同心圆装饰：两圈细边框缓慢呼吸（纯 CSS，无图片资源） */
-.todo-empty-decor {
-  position: relative;
-}
-
-.todo-empty-decor::before,
-.todo-empty-decor::after {
-  content: '';
-  position: absolute;
-  /* 居中不用 inset:0 + margin:auto：圆环大于图标盒（200%/290%）时属于
-     过约束绝对定位，各引擎对负自由空间的 auto margin 解析不一致
-     （Blink/WebKit 横向解析为 0，圆环向右偏 24px）。改用 50% + translate
-     显式居中，全引擎一致；呼吸 scale 并入同一 transform */
-  top: 50%;
-  left: 50%;
-  margin: 0;
-  border-radius: 9999px;
-  border: 1px solid currentColor;
-  opacity: 0.12;
-  pointer-events: none;
-}
-
-.todo-empty-decor::before {
-  width: 200%;
-  height: 200%;
-  animation: todo-empty-breathe 4s ease-in-out infinite;
-}
-
-.todo-empty-decor::after {
-  width: 290%;
-  height: 290%;
-  opacity: 0.06;
-  animation: todo-empty-breathe 4s ease-in-out 0.6s infinite;
-}
-
-@keyframes todo-empty-breathe {
-  0%,
-  100% {
-    transform: translate(-50%, -50%) scale(1);
-  }
-  50% {
-    transform: translate(-50%, -50%) scale(1.06);
-  }
-}
+/* 空态同心圆装饰已按产品决策移除（用户反馈观感不佳），不再保留 .todo-empty-decor 规则 */
 
 /* 四象限拖拽拖影：轻微放大 + 倾斜 + 浮起阴影（DragOverlay 内容用） */
 .todo-matrix-drag-ghost {
@@ -198,9 +154,7 @@
   .todo-row-completing,
   .todo-celebrate-pop,
   .todo-quickadd-pop,
-  .todo-swipe-hint-content,
-  .todo-empty-decor::before,
-  .todo-empty-decor::after {
+  .todo-swipe-hint-content {
     animation: none;
   }
 


### PR DESCRIPTION
## 用户反馈驱动（第六轮）

1. **空态背景圆环直接移除**（用户决策：不好看）。第五轮的居中修复随之作废，装饰整体删除（JSX 类名 + CSS 规则 + keyframes + reduced-motion 引用清净）。
2. **各页面顶栏美术/UX 风格统一**。第五轮把 todo/skills 工具栏迁入顶栏后，各页顶栏内容物规格不一：todo 控件 h-8、skills h-7、标题 15px/14px 混用。

## 统一规格（新增 `src/app/shell/titlebarUiTokens.ts`）

对齐既有参照件（chat 标题栏控件 28×28px px 固定、窗口标题 13px）：

| 项 | 规格 | 说明 |
|---|---|---|
| 控件高度 | `!h-8`（实际 28px） | 本应用 rem 锚点 14px，h-8=2rem=28px；h-7 仅 24.5px 是伪对齐 |
| coarse 指针 | `!h-10`（35px） | 不溢出 38px 标题栏，对齐 learning-hub 先例 |
| 标题 | `text-ui`（13px）font-semibold | 与 wb-title-text 同级 |
| 次级信息 | `text-xs` muted | 计数/副标题 |

覆盖：TodoMainPanel、TodoTrashWorkspace、TodoAutomationWorkspace、SkillsManagementPage 的顶栏 portal 内容；PriorityFilterMenu 新增 `triggerClassName` 承接。页内内联渲染（移动端触控 44px 契约）不动。

## 验证

- tsc 0 错、eslint 0 错；vitest todo+skills+learning-hub 282 过、workbench 1776 过。
- 运行时实测（Playwright 双壳）：待办 5 控件与技能 8 控件**全部 28px**、标题 13px；空态圆环 DOM 中已不存在。