### PR TITLE
fix(mcp): connection-test failures against strict servers (null experimental, swallowed errors, loopback proxy, SSE task leak)

### DIFF
--- a/src-tauri/src/mcp/client.rs
+++ b/src-tauri/src/mcp/client.rs
@@ -158,6 +158,9 @@ pub struct ClientInfo {
 pub struct ClientCapabilities {
     pub roots: Option<RootsCapability>,
     pub sampling: Option<SamplingCapability>,
+    // MCP 服务器（如 @modelcontextprotocol/sdk 的 Zod 校验）把 experimental 定义为
+    // optional record<string, unknown>；None 序列化成 null 会被判 invalid_type 而拒绝 initialize。
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental: Option<HashMap<String, Value>>,
 }
 
@@ -632,6 +635,9 @@ impl RequestManager {
         let mut pending = self.pending.lock().await;
         if let Some(request) = pending.remove(&id) {
             let _ = request.tx.send(response);
+        } else {
+            // 响应 id 无对应 pending 请求：可能超时清理先行，或 server 回了错乱 id
+            log::warn!("[McpClient] complete_request: no pending request for id={}", id);
         }
     }
 
@@ -978,6 +984,7 @@ impl McpClient {
                     match result {
                         Ok(message) => {
                             attempt = 0; // reset
+                            log::debug!("[McpClient] message_loop recv: {}", &message.chars().take(200).collect::<String>());
                             if let Err(e) = Self::handle_message(
                                 &message,
                                 request_manager.clone(),
@@ -1016,6 +1023,12 @@ impl McpClient {
     ) -> McpResult<()> {
         // 尝试解析为响应
         if let Ok(response) = serde_json::from_str::<JsonRpcResponse>(message) {
+            log::debug!(
+                "[McpClient] handle_message response: id={:?} has_result={} has_error={}",
+                response.id,
+                response.result.is_some(),
+                response.error.is_some()
+            );
             if let Some(id) = response.id.as_ref() {
                 let id_str = match id {
                     Value::String(s) => s.clone(),
@@ -1183,7 +1196,18 @@ impl McpClient {
 
             Ok(server_info)
         } else {
-            Err(McpError::ProtocolError("Initialize failed".to_string()))
+            // 服务器返回了 JSON-RPC error（或无 result）。把真实拒绝原因透传，
+            // 否则只报 "Initialize failed" 无法定位（如 capabilities 字段校验失败）。
+            let detail = response
+                .error
+                .as_ref()
+                .map(|e| format!("code={} message={}", e.code, e.message))
+                .unwrap_or_else(|| "response contained no result".to_string());
+            log::error!("[McpClient] initialize rejected by server: {}", detail);
+            Err(McpError::ProtocolError(format!(
+                "Initialize failed: {}",
+                detail
+            )))
         }
     }
 
@@ -1913,6 +1937,29 @@ impl ReconnectingClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn client_capabilities_none_experimental_is_omitted_not_null() {
+        // 回归：experimental: None 曾被序列化为 "experimental": null，
+        // 严格校验的 server（@modelcontextprotocol/sdk Zod）会以
+        // -32603 invalid_type (params.capabilities.experimental expected record, received null)
+        // 拒绝 initialize，propose 连测报 "Initialize failed" 且细节被吞。
+        let caps = ClientCapabilities {
+            roots: Some(RootsCapability {
+                list_changed: Some(true),
+            }),
+            sampling: Some(SamplingCapability { enabled: true }),
+            experimental: None,
+        };
+        let value = serde_json::to_value(&caps).expect("serialize capabilities");
+        assert!(
+            value.get("experimental").is_none(),
+            "experimental: None must be omitted from wire format, got: {}",
+            value
+        );
+        assert_eq!(value["roots"]["listChanged"], true);
+        assert_eq!(value["sampling"]["enabled"], true);
+    }
 
     #[test]
     fn tool_deserializes_spec_camel_case_fields() {

--- a/src-tauri/src/mcp/http_transport.rs
+++ b/src-tauri/src/mcp/http_transport.rs
@@ -96,7 +96,7 @@ impl HttpTransport {
             HeaderValue::from_static("application/json, text/event-stream"),
         );
 
-        let client = Client::builder()
+        let client = super::reqwest_builder_for_endpoint(&config.url)
             .timeout(config.timeout)
             .default_headers(headers)
             .build()

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -33,3 +33,52 @@ pub use http_transport::{HttpConfig, HttpTransport};
 pub use protocol_version::{CompatibilityChecker, ProtocolNegotiator, ProtocolVersion};
 pub use sse_transport::{SSEConfig, SSETransport};
 pub use types::*;
+
+/// 判断 MCP endpoint 是否指向本机回环地址（复用全库正源 browser::policy）。
+pub(crate) fn endpoint_is_loopback(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(str::to_string))
+        .map(|host| crate::browser::policy::is_loopback_host(&host))
+        .unwrap_or(false)
+}
+
+/// 构建 MCP transport 的 reqwest Client builder。
+/// 回环地址必须绕过系统/环境代理：代理无法回连发起方本机端口，
+/// 典型症状是本地 SSE/HTTP 连测收到代理返回的 502 Bad Gateway。
+pub(crate) fn reqwest_builder_for_endpoint(url: &str) -> reqwest::ClientBuilder {
+    let builder = reqwest::Client::builder();
+    if endpoint_is_loopback(url) {
+        builder.no_proxy()
+    } else {
+        builder
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loopback_endpoints_are_detected() {
+        assert!(endpoint_is_loopback("http://127.0.0.1:8931/sse"));
+        assert!(endpoint_is_loopback("http://localhost:8931/sse"));
+        assert!(endpoint_is_loopback("http://[::1]:8931/sse"));
+        assert!(endpoint_is_loopback("http://app.localhost:8931/sse"));
+        assert!(!endpoint_is_loopback("https://example.com/mcp"));
+        assert!(!endpoint_is_loopback("https://mcp.modelscope.cn/sse"));
+        // 无法解析的输入按非回环处理（保持默认代理行为）
+        assert!(!endpoint_is_loopback("not a url"));
+    }
+
+    #[test]
+    fn loopback_builder_disables_proxy() {
+        // 回环 builder 应启用 no_proxy（ReqwestClientBuilder::no_proxy 后 proxy 仍可构建）
+        let _ = reqwest_builder_for_endpoint("http://127.0.0.1:1/mcp")
+            .build()
+            .expect("loopback builder builds");
+        let _ = reqwest_builder_for_endpoint("https://example.com/mcp")
+            .build()
+            .expect("remote builder builds");
+    }
+}

--- a/src-tauri/src/mcp/sse_transport.rs
+++ b/src-tauri/src/mcp/sse_transport.rs
@@ -59,6 +59,37 @@ pub struct SSETransport {
     buffer: Arc<Mutex<SseLineBuffer>>,
     /// 最后接收的事件ID，用于断线续传
     last_event_id: Arc<RwLock<Option<String>>>,
+    /// 停止信号：drop/close 后接收与发送任务必须退出，
+    /// 否则连测超时被上层放弃后，重连循环会在后台无限重试（泄漏）。
+    stop: StopSignal,
+}
+
+/// watch 通道封装的停止标志（接收/发送任务可 select 等待，立即退出）。
+#[derive(Clone)]
+struct StopSignal {
+    tx: tokio::sync::watch::Sender<bool>,
+    rx: tokio::sync::watch::Receiver<bool>,
+}
+
+impl StopSignal {
+    fn new() -> Self {
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        Self { tx, rx }
+    }
+
+    fn signal(&self) {
+        let _ = self.tx.send(true);
+    }
+
+    fn rx(&self) -> tokio::sync::watch::Receiver<bool> {
+        self.rx.clone()
+    }
+}
+
+impl Drop for SSETransport {
+    fn drop(&mut self) {
+        self.stop.signal();
+    }
 }
 
 impl SSETransport {
@@ -94,7 +125,7 @@ impl SSETransport {
             );
         }
 
-        let client = Client::builder()
+        let client = super::reqwest_builder_for_endpoint(&config.endpoint)
             .timeout(config.timeout)
             .default_headers(headers)
             .build()
@@ -113,6 +144,7 @@ impl SSETransport {
             connected: Arc::new(AtomicBool::new(false)),
             buffer: Arc::new(Mutex::new(SseLineBuffer::new())),
             last_event_id: Arc::new(RwLock::new(None)),
+            stop: StopSignal::new(),
         };
 
         // 启动发送任务
@@ -130,9 +162,17 @@ impl SSETransport {
         let endpoint = self.config.endpoint.clone();
         let session_id = self.session_id.clone();
         let wait_timeout = self.config.timeout; // 在首次发送前等待会话建立
+        let mut stop_rx = self.stop.rx();
 
         tokio::spawn(async move {
-            while let Some(message) = send_rx.recv().await {
+            loop {
+                let message = tokio::select! {
+                    msg = send_rx.recv() => match msg {
+                        Some(m) => m,
+                        None => break,
+                    },
+                    _ = stop_rx.changed() => break,
+                };
                 // 发送前尽量等待会话ID（部分服务端要求）
                 let start = std::time::Instant::now();
                 loop {
@@ -182,6 +222,7 @@ impl SSETransport {
         let session_id = self.session_id.clone();
         let last_event_id = self.last_event_id.clone();
         let open_timeout = self.config.timeout; // 复用配置超时作为连接建立超时
+        let stop_rx = self.stop.rx();
 
         // 创建SSE连接（保留认证/自定义头）
         let client = {
@@ -211,7 +252,7 @@ impl SSETransport {
                         .map_err(|e| McpError::AuthenticationError(e.to_string()))?,
                 );
             }
-            reqwest::Client::builder()
+            super::reqwest_builder_for_endpoint(&endpoint)
                 .default_headers(headers)
                 .build()
                 .map_err(|e| McpError::TransportError(e.to_string()))?
@@ -231,9 +272,17 @@ impl SSETransport {
                 }
             };
             let mut backoff_ms = 500u64;
+            let mut stop_rx = stop_rx;
 
             loop {
-                match es.next().await {
+                let event = tokio::select! {
+                    ev = es.next() => ev,
+                    _ = stop_rx.changed() => {
+                        info!("SSE receive task stopping (transport dropped or closed)");
+                        break;
+                    }
+                };
+                match event {
                     Some(Ok(SSEEvent::Open)) => {
                         connected.store(true, Ordering::SeqCst);
                         backoff_ms = 500; // 重置退避时间
@@ -287,8 +336,11 @@ impl SSETransport {
                         error!("SSE error: {:?}", e);
                         connected.store(false, Ordering::SeqCst);
 
-                        // 指数退避重连
-                        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                        // 指数退避重连（可被停止信号立即打断）
+                        tokio::select! {
+                            _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {}
+                            _ = stop_rx.changed() => break,
+                        }
                         backoff_ms = (backoff_ms * 2).min(30_000);
 
                         // 尝试重新创建连接，携带 Last-Event-ID 以支持断线续传
@@ -402,6 +454,8 @@ impl Transport for SSETransport {
 
     async fn close(&self) -> McpResult<()> {
         self.connected.store(false, Ordering::SeqCst);
+        // 通知接收/发送任务退出（与 Drop 相同的停止路径）
+        self.stop.signal();
 
         // 清理会话
         if let Some(session_id) = self.session_id.read().await.as_ref() {
@@ -431,6 +485,62 @@ impl Transport for SSETransport {
 mod tests {
     use super::*;
     use crate::mcp::auth::resolve_authorization_header;
+
+    /// 回归：连测超时/上层放弃后 transport 被 drop，接收任务必须停止重连，
+    /// 而不是在后台无限 `reconnecting → error` 循环（2026-09-05 安装版日志泄漏证据）。
+    #[tokio::test]
+    async fn sse_receive_task_stops_after_transport_drop() {
+        use tokio::io::AsyncWriteExt;
+
+        // 本地假 SSE server：发一条事件后挂住连接（不关流）
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let server = tokio::spawn(async move {
+            let (sock, _) = listener.accept().await.expect("accept");
+            let mut sock = sock;
+            sock.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n",
+            )
+            .await
+            .expect("write headers");
+            sock.write_all(b"data: {\"sessionId\":\"s1\"}\n\n")
+                .await
+                .expect("write event");
+            // 保持连接打开，模拟服务器不结束流
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+
+        let config = SSEConfig {
+            endpoint: format!("http://{addr}/sse"),
+            api_key: None,
+            oauth: None,
+            auth_provider: None,
+            headers: reqwest::header::HeaderMap::new(),
+            timeout: Duration::from_secs(5),
+        };
+        let transport = SSETransport::new(config).await.expect("transport connects");
+        let connected = transport.connected.clone();
+        assert!(
+            connected.load(Ordering::SeqCst),
+            "SSE should be connected after new()"
+        );
+
+        // drop → Drop 发停止信号 → 接收任务应尽快退出并置 connected=false
+        drop(transport);
+        let mut stopped = false;
+        for _ in 0..50 {
+            if !connected.load(Ordering::SeqCst) {
+                stopped = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            stopped,
+            "receive task must stop after transport drop (no background reconnect loop)"
+        );
+        server.abort();
+    }
 
     #[tokio::test]
     async fn test_sse_config() {


### PR DESCRIPTION
## Summary

While configuring `@playwright/mcp` through `mcp_server_propose` on Windows, every transport (stdio / SSE / HTTP) failed in the connection test even though the server itself was verified healthy via pipe, `.NET Process`, and full manual handshake. Root-caused to four independent bugs in the MCP client; all are fixed here with tests.

| # | Bug | Root cause | Fix |
|---|---|---|---|
| 1 | stdio test fails in <1s with `Protocol error: Initialize failed` | `ClientCapabilities.experimental: Option<HashMap>` serialized as `"experimental": null` when `None`; strict servers (`@modelcontextprotocol/sdk` Zod validation) reject with JSON-RPC `-32603 invalid_type: params.capabilities.experimental expected record, received null` | `#[serde(skip_serializing_if = "Option::is_none")]` on the field |
| 2 | Every server rejection surfaces as a bare `Initialize failed` | `initialize()` only checks `response.result`; `response.error` (real code/message) was discarded | Surface `code=` + `message=` in the error and `log::error!`; add dispatch debug logging so future failures are diagnosable |
| 3 | SSE/HTTP tests against `127.0.0.1` return `502 Bad Gateway` | reqwest `Client` built without `.no_proxy()` inherits the system proxy; the proxy cannot reach the caller's own loopback port | New `endpoint_is_loopback` (reuses the canonical `browser::policy::is_loopback_host`) + `reqwest_builder_for_endpoint`; all SSE/HTTP client builds route through it — loopback forces `no_proxy()`, remote endpoints keep default proxy behavior (corporate proxies unaffected) |
| 4 | After the connection test times out, the SSE receive task keeps `reconnecting → error` in the background forever (observed every ~30s in release logs for minutes) | `run_connection_test` timeout only drops the future; `SSETransport`'s spawned receive task had no stop mechanism | Watch-channel stop signal: the receive loop (incl. the ≤30s backoff sleep) and the send task `select` on it; wired into `Transport::close()` and a new `impl Drop` |

## Evidence & verification

- Reproduced with an in-repo probe reusing the real `create_stdio_transport` + `McpClient` path: stage-1 raw transport and stage-3 wire round-trip were healthy, only the `McpClient` path failed → bisected to bug 1 via the newly-surfaced server error message; after the fix the same probe reports `INIT OK: Playwright 1.63.0-alpha`.
- `cargo test --lib mcp::`: 60 passed, incl. three new tests — `client_capabilities_none_experimental_is_omitted_not_null`, `loopback_endpoints_are_detected`, and `sse_receive_task_stops_after_transport_drop` (spawns a local fake SSE server, asserts the receive task exits after transport drop; also exercises the loopback no-proxy path).
- A full NSIS build with these fixes was installed and the Playwright MCP server configures successfully.

No API/DB changes; behavior for remote (non-loopback) MCP endpoints is unchanged.
