### PR TITLE
fix(chat): 制卡事件合并缓冲，修复批量制卡前端 O(N²) 卡顿

### DIFF
--- a/src/features/chat/adapters/TauriAdapter.ts
+++ b/src/features/chat/adapters/TauriAdapter.ts
@@ -335,6 +335,12 @@ export class ChatV2TauriAdapter {
   private retryingAnkiDocumentIds = new Set<string>();
   /** 防止并发查询的旧结果覆盖更新的重试终态。 */
   private ankiRetryReconcileRevisions = new Map<string, number>();
+  /** 🚀 性能修复（2026-09-06）：anki 卡片事件合并缓冲（blockId → 待写入卡片）。
+   * 100ms 窗口批量写入 store，避免每卡一次 updateBlock 造成 O(N²) 渲染开销。 */
+  private ankiCardFlushQueue = new Map<
+    string,
+    { cards: AnkiCard[]; documentId?: string; timer: ReturnType<typeof setTimeout> | null }
+  >();
 
   constructor(sessionId: string, store: ChatStore, storeApi?: StoreApi<ChatStore>) {
     this.adapterInstanceId = ChatV2TauriAdapter.nextAdapterInstanceId++;
@@ -1083,6 +1089,10 @@ export class ChatV2TauriAdapter {
   async cleanup(): Promise<void> {
     console.log(LOG_PREFIX, 'Cleaning up...');
     this.cancelPendingStreamCompletion();
+    // 🚀 性能修复（2026-09-06）：清理前冲刷所有制卡合并缓冲，避免待写卡片丢失
+    for (const blockId of [...this.ankiCardFlushQueue.keys()]) {
+      this.flushAnkiCardBuffer(blockId);
+    }
     // 使正在进行的 setup/listener 注册代际失效，防止过期监听器被挂回当前实例
     this.setupGeneration += 1;
     this.cancelScheduledFullHistoryLoad?.();
@@ -1533,6 +1543,151 @@ export class ChatV2TauriAdapter {
     }
   }
 
+  /** 从卡片字段中提取问题文本（用于签名/调试快照） */
+  private extractAnkiCardQuestion(card: AnkiCard): string {
+    const fields = (card.fields ?? {}) as Record<string, unknown>;
+    const extraFields = (card.extra_fields ?? {}) as Record<string, unknown>;
+    const fieldQuestion =
+      fields.question ??
+      fields.Question ??
+      extraFields.question ??
+      extraFields.Question;
+    if (typeof fieldQuestion === 'string' && fieldQuestion.trim()) return fieldQuestion.trim();
+    const front = card.front ?? '';
+    if (front.trim().startsWith('{') && front.trim().endsWith('}')) {
+      try {
+        const parsed = JSON.parse(front) as Record<string, unknown>;
+        const q = parsed.Question ?? parsed.question ?? parsed.front;
+        if (typeof q === 'string' && q.trim()) return q.trim();
+      } catch {
+        // ignore
+      }
+    }
+    return front.replace(/\s+/g, ' ').trim().slice(0, 80);
+  }
+
+  /** 构建卡片列表签名（O(N)——仅在冲刷/终态时调用，不再每卡一次） */
+  private buildAnkiCardsSignature(cards: AnkiCard[]): string {
+    return cards
+      .map((card) => `${card.id ?? 'no-id'}::${card.template_id ?? 'no-template'}::${this.extractAnkiCardQuestion(card)}`)
+      .join('|');
+  }
+
+  /** 记录卡片来源快照（调试面板用） */
+  private recordAnkiSourceSnapshot(
+    targetBlock: { id: string },
+    source: string,
+    cards: AnkiCard[],
+    status: string | undefined,
+    docId: string | undefined,
+  ): void {
+    const signature = this.buildAnkiCardsSignature(cards);
+    const updatedAt = new Date().toISOString();
+    const cardIds = cards.map((card) => card.id ?? 'no-id');
+
+    const win = window as Window & {
+      __chatankiCardSourceByBlock?: Record<
+        string,
+        {
+          source: string;
+          blockStatus?: string;
+          documentId?: string;
+          cardIds: string[];
+          signature: string;
+          updatedAt: string;
+        }
+      >;
+    };
+    if (!win.__chatankiCardSourceByBlock) {
+      win.__chatankiCardSourceByBlock = {};
+    }
+    win.__chatankiCardSourceByBlock[targetBlock.id] = {
+      source,
+      blockStatus: status,
+      documentId: docId,
+      cardIds,
+      signature,
+      updatedAt,
+    };
+
+    try {
+      window.dispatchEvent(new CustomEvent('chatanki-debug-lifecycle', { detail: {
+        level: 'info',
+        phase: 'bridge:source',
+        summary: `source snapshot ${source} block=${targetBlock.id.slice(0, 8)} cards=${cards.length} doc=${docId ?? 'null'}`,
+        detail: {
+          blockId: targetBlock.id,
+          source,
+          blockStatus: status ?? null,
+          documentId: docId ?? null,
+          cardsCount: cards.length,
+          cardIds,
+          signature,
+          updatedAt,
+        },
+      }}));
+    } catch { /* debug only */ }
+  }
+
+  /**
+   * 🚀 性能修复（2026-09-06）：批量落盘缓冲的制卡事件。
+   * 将 100ms 窗口内到达的 NewCard/NewErrorCard 合并为一次 updateBlock，
+   * 使 N 张卡的渲染开销从 O(N²) 降为 O(N)。
+   */
+  private flushAnkiCardBuffer(blockId: string): void {
+    const queued = this.ankiCardFlushQueue.get(blockId);
+    if (!queued) return;
+    this.ankiCardFlushQueue.delete(blockId);
+    if (queued.timer) {
+      clearTimeout(queued.timer);
+    }
+    if (queued.cards.length === 0) return;
+
+    const state = this.getCurrentState();
+    const targetBlock = state.blocks.get(blockId);
+    if (!targetBlock) return;
+
+    const currentOutput = (targetBlock.toolOutput as Record<string, unknown> | undefined) ?? {};
+    const currentCards = (currentOutput.cards as AnkiCard[] | undefined) ?? [];
+    const newCards = queued.cards.filter(
+      (card) => !card.id || !currentCards.some((c) => c.id === card.id),
+    );
+    if (newCards.length === 0) return;
+
+    const nextCards = [...currentCards, ...newCards];
+    const documentId = queued.documentId;
+    const ensureDocumentId = documentId && !currentOutput.documentId ? { documentId } : {};
+    const nextTemplateId =
+      (currentOutput.templateId as string | undefined) ||
+      (newCards[0]?.template_id ?? undefined) ||
+      null;
+    const nextProgress = {
+      ...(currentOutput.progress as Record<string, unknown> | undefined),
+      stage: (currentOutput.progress as any)?.stage ?? 'streaming',
+      cardsGenerated: nextCards.length,
+      lastUpdatedAt: new Date().toISOString(),
+    };
+    this.recordAnkiSourceSnapshot(
+      targetBlock,
+      'event-new-card-batched',
+      nextCards,
+      targetBlock.status === 'success' || targetBlock.status === 'error' ? targetBlock.status : 'running',
+      (ensureDocumentId.documentId as string | undefined) ?? (currentOutput.documentId as string | undefined),
+    );
+    state.updateBlock(blockId, {
+      toolOutput: {
+        ...currentOutput,
+        ...ensureDocumentId,
+        cards: nextCards,
+        templateId: nextTemplateId,
+        progress: nextProgress,
+      },
+      ...(targetBlock.status === 'success' || targetBlock.status === 'error'
+        ? {}
+        : { status: 'running' }),
+    });
+  }
+
   /**
    * 处理 ChatAnki 后端事件（anki_generation_event）
    * 将 NewCard/进度事件桥接到 anki_cards 块，实现实时预览
@@ -1655,7 +1810,14 @@ export class ChatV2TauriAdapter {
       }}));
     } catch { /* debug only */ }
 
-    const currentOutput = (targetBlock.toolOutput as Record<string, unknown> | undefined) ?? {};
+    // 🚀 性能修复（2026-09-06）：非卡片事件到达前先冲刷合并缓冲，
+    // 保证进度/完成/失败/重试事件基于最新卡片列表（否则终态事件会用旧 toolOutput 覆盖刚冲刷的卡片）
+    if (type !== 'NewCard' && type !== 'NewErrorCard') {
+      this.flushAnkiCardBuffer(targetBlock.id);
+    }
+    const latestBlock = this.getCurrentState().blocks.get(targetBlock.id) ?? targetBlock;
+
+    const currentOutput = (latestBlock.toolOutput as Record<string, unknown> | undefined) ?? {};
     const currentCards = (currentOutput.cards as AnkiCard[] | undefined) ?? [];
     const ensureDocumentId = documentId && !currentOutput.documentId ? { documentId } : {};
     const retryRelevantEvent = [
@@ -1677,87 +1839,6 @@ export class ChatV2TauriAdapter {
     if (isRetryFlow && documentId) {
       this.retryingAnkiDocumentIds.add(documentId);
     }
-
-    const extractCardQuestion = (card: AnkiCard): string => {
-      const fields = (card.fields ?? {}) as Record<string, unknown>;
-      const extraFields = (card.extra_fields ?? {}) as Record<string, unknown>;
-      const fieldQuestion =
-        fields.question ??
-        fields.Question ??
-        extraFields.question ??
-        extraFields.Question;
-      if (typeof fieldQuestion === 'string' && fieldQuestion.trim()) return fieldQuestion.trim();
-      const front = card.front ?? '';
-      if (front.trim().startsWith('{') && front.trim().endsWith('}')) {
-        try {
-          const parsed = JSON.parse(front) as Record<string, unknown>;
-          const q = parsed.Question ?? parsed.question ?? parsed.front;
-          if (typeof q === 'string' && q.trim()) return q.trim();
-        } catch {
-          // ignore
-        }
-      }
-      return front.replace(/\s+/g, ' ').trim().slice(0, 80);
-    };
-
-    const buildCardsSignature = (cards: AnkiCard[]): string =>
-      cards
-        .map((card) => `${card.id ?? 'no-id'}::${card.template_id ?? 'no-template'}::${extractCardQuestion(card)}`)
-        .join('|');
-
-    const recordSourceSnapshot = (
-      source: string,
-      cards: AnkiCard[],
-      status: string | undefined,
-      docId: string | undefined,
-    ) => {
-      const signature = buildCardsSignature(cards);
-      const updatedAt = new Date().toISOString();
-      const cardIds = cards.map((card) => card.id ?? 'no-id');
-
-      const win = window as Window & {
-        __chatankiCardSourceByBlock?: Record<
-          string,
-          {
-            source: string;
-            blockStatus?: string;
-            documentId?: string;
-            cardIds: string[];
-            signature: string;
-            updatedAt: string;
-          }
-        >;
-      };
-      if (!win.__chatankiCardSourceByBlock) {
-        win.__chatankiCardSourceByBlock = {};
-      }
-      win.__chatankiCardSourceByBlock[targetBlock.id] = {
-        source,
-        blockStatus: status,
-        documentId: docId,
-        cardIds,
-        signature,
-        updatedAt,
-      };
-
-      try {
-        window.dispatchEvent(new CustomEvent('chatanki-debug-lifecycle', { detail: {
-          level: 'info',
-          phase: 'bridge:source',
-          summary: `source snapshot ${source} block=${targetBlock.id.slice(0, 8)} cards=${cards.length} doc=${docId ?? 'null'}`,
-          detail: {
-            blockId: targetBlock.id,
-            source,
-            blockStatus: status ?? null,
-            documentId: docId ?? null,
-            cardsCount: cards.length,
-            cardIds,
-            signature,
-            updatedAt,
-          },
-        }}));
-      } catch { /* debug only */ }
-    };
 
     // 生成质量观测事件（CriticSummary / GenerationStats）：只 patch toolOutput
     // 观测字段，不动 status / progress / cards，不参与 retry reconcile。
@@ -1840,8 +1921,13 @@ export class ChatV2TauriAdapter {
 
     if (type === 'NewCard' || type === 'NewErrorCard') {
       if (!cardData) return;
-      const exists = cardData.id ? currentCards.some((c) => c.id === cardData.id) : false;
-      if (exists) {
+      // 🚀 性能修复（2026-09-06）：卡片事件进入合并缓冲，100ms 窗口批量写入 store。
+      // 原实现每张卡一次 O(N) 签名计算 + updateBlock + 调试 CustomEvent，
+      // N 张卡产生 O(N²) 渲染与事件洪水。
+      const existsInState = cardData.id ? currentCards.some((c) => c.id === cardData.id) : false;
+      const queued = this.ankiCardFlushQueue.get(targetBlock.id);
+      const existsInQueue = !!(cardData.id && queued && queued.cards.some((c) => c.id === cardData.id));
+      if (existsInState || existsInQueue) {
         try {
           window.dispatchEvent(new CustomEvent('chatanki-debug-lifecycle', { detail: {
             level: 'debug', phase: 'bridge:event',
@@ -1849,46 +1935,19 @@ export class ChatV2TauriAdapter {
             documentId, blockId: targetBlock.id,
           }}));
         } catch { /* debug only */ }
+        return;
       }
-      if (!exists) {
-        try {
-          window.dispatchEvent(new CustomEvent('chatanki-debug-lifecycle', { detail: {
-            level: 'debug', phase: 'bridge:card',
-            summary: `${type} → block ${targetBlock.id.slice(0, 8)} | template=${(cardData as any).template_id ?? 'null'} | total=${currentCards.length + 1}`,
-            documentId, blockId: targetBlock.id,
-            detail: { cardId: cardData.id, templateId: (cardData as any).template_id, front: (cardData.front || '').slice(0, 60) },
-          }}));
-        } catch { /* */ }
+      if (queued) {
+        queued.cards.push(cardData);
+        if (documentId && !queued.documentId) queued.documentId = documentId;
+      } else {
+        this.ankiCardFlushQueue.set(targetBlock.id, {
+          cards: [cardData],
+          documentId,
+          timer: setTimeout(() => this.flushAnkiCardBuffer(targetBlock.id), 100),
+        });
       }
-      const nextCards = exists ? currentCards : [...currentCards, cardData];
-      const nextTemplateId =
-        (currentOutput.templateId as string | undefined) ||
-        (cardData.template_id ?? undefined) ||
-        null;
-      const nextProgress = {
-        ...(currentOutput.progress as Record<string, unknown> | undefined),
-        stage: (currentOutput.progress as any)?.stage ?? 'streaming',
-        cardsGenerated: nextCards.length,
-        lastUpdatedAt: new Date().toISOString(),
-      };
-      recordSourceSnapshot(
-        'event-new-card',
-        nextCards,
-        targetBlock.status === 'success' || targetBlock.status === 'error' ? targetBlock.status : 'running',
-        (ensureDocumentId.documentId as string | undefined) ?? (currentOutput.documentId as string | undefined),
-      );
-      state.updateBlock(targetBlock.id, {
-        toolOutput: {
-          ...currentOutput,
-          ...ensureDocumentId,
-          cards: nextCards,
-          templateId: nextTemplateId,
-          progress: nextProgress,
-        },
-        ...(targetBlock.status === 'success' || targetBlock.status === 'error'
-          ? {}
-          : { status: 'running' }),
-      });
+      // 重试对账读的是后端 TaskSnapshot，与前端缓冲时序无关，保持立即调度
       if (isRetryFlow && documentId) {
         this.scheduleAnkiRetryReconcile(targetBlock.id, documentId);
       }
@@ -1908,7 +1967,8 @@ export class ChatV2TauriAdapter {
             : 'processing',
         lastUpdatedAt: new Date().toISOString(),
       };
-      recordSourceSnapshot(
+      this.recordAnkiSourceSnapshot(
+        targetBlock,
         type === 'TaskStatusUpdate' ? 'event-task-status' : 'event-doc-started',
         currentCards,
         targetBlock.status === 'success' || targetBlock.status === 'error' ? targetBlock.status : 'running',
@@ -1950,7 +2010,8 @@ export class ChatV2TauriAdapter {
           detail: { cardsCount: currentCards.length, templateIds: [...new Set(currentCards.map((c: any) => c.template_id).filter(Boolean))] },
         }}));
       } catch { /* */ }
-      recordSourceSnapshot(
+      this.recordAnkiSourceSnapshot(
+        targetBlock,
         'event-doc-completed',
         currentCards,
         'success',
@@ -1984,7 +2045,8 @@ export class ChatV2TauriAdapter {
           detail: { cardsCount: currentCards.length },
         }}));
       } catch { /* */ }
-      recordSourceSnapshot(
+      this.recordAnkiSourceSnapshot(
+        targetBlock,
         'event-doc-cancelled',
         currentCards,
         'success',

--- a/tests/vitest/chat-v2/adapters/TauriAdapter.test.ts
+++ b/tests/vitest/chat-v2/adapters/TauriAdapter.test.ts
@@ -1643,6 +1643,7 @@ describe('ChatV2TauriAdapter', () => {
     });
 
     it('routes by documentId and does not cross-write between two anki blocks', () => {
+      vi.useFakeTimers();
       seedAnkiBlock('anki-block-a', { documentId: 'doc-a', status: 'running' });
       seedAnkiBlock('anki-block-b', { documentId: 'doc-b', status: 'running' });
 
@@ -1664,6 +1665,8 @@ describe('ChatV2TauriAdapter', () => {
           },
         },
       });
+      // 🚀 性能修复（2026-09-06）：NewCard 经 100ms 合并缓冲批量落盘，推进定时器后断言
+      vi.advanceTimersByTime(100);
 
       const blockA = mockStore.blocks.get('anki-block-a') as any;
       const blockB = mockStore.blocks.get('anki-block-b') as any;
@@ -1675,6 +1678,7 @@ describe('ChatV2TauriAdapter', () => {
       expect(blockB.toolOutput.documentId).toBe('doc-b');
       expect(blockB.toolOutput.cards).toHaveLength(1);
       expect(blockB.toolOutput.cards[0].id).toBe('card-b1');
+      vi.useRealTimers();
     });
 
     it('keeps the document running when only one task completes', async () => {
@@ -1724,6 +1728,7 @@ describe('ChatV2TauriAdapter', () => {
     });
 
     it('allows latest-active fallback only when event has no documentId (owner)', () => {
+      vi.useFakeTimers();
       seedAnkiBlock('anki-block-1', { documentId: 'doc-1', status: 'running' });
       seedAnkiBlock('anki-block-2', { status: 'running' }); // latest active without doc id
 
@@ -1736,11 +1741,15 @@ describe('ChatV2TauriAdapter', () => {
         },
       });
 
+      // 🚀 性能修复（2026-09-06）：NewCard 经 100ms 合并缓冲批量落盘，推进定时器后断言
+      vi.advanceTimersByTime(100);
+
       const block1 = mockStore.blocks.get('anki-block-1') as any;
       const block2 = mockStore.blocks.get('anki-block-2') as any;
       expect(block1.toolOutput.cards).toEqual([]);
       expect(block2.toolOutput.cards).toHaveLength(1);
       expect(block2.toolOutput.cards[0].id).toBe('card-fallback');
+      vi.useRealTimers();
     });
 
     it('recovers a terminal error block when its retried task completes', async () => {
@@ -1998,6 +2007,103 @@ describe('ChatV2TauriAdapter', () => {
         expect(block.toolOutput.syncStatus).toBe('error');
         expect(block.toolOutput.syncError).toBe('anki-connect-down');
         expect(block.toolOutput.finalStatus).toBe('completed_with_errors');
+      });
+    });
+
+    // ==========================================================================
+    // 🚀 制卡事件合并缓冲（2026-09-06 性能修复）
+    // 验证 NewCard/NewErrorCard 事件在 100ms 窗口内合并为一次 updateBlock（O(N²)→O(N)），
+    // 非卡片事件到达前先冲刷缓冲，cleanup 时冲刷而非丢弃。
+    // ==========================================================================
+    describe('anki card event coalescing (perf fix 2026-09-06)', () => {
+      const makeCard = (id: string) => ({
+        id,
+        template_id: 'tpl-test',
+        fields: { front: `Q-${id}`, back: `A-${id}` },
+      });
+
+      const newCardEvent = (id: string) => ({
+        payload: {
+          type: 'NewCard',
+          data: { card: makeCard(id), document_id: 'doc-1' },
+        },
+      });
+
+      beforeEach(() => {
+        vi.useFakeTimers();
+        // 预置一个 running 的 anki_cards 块作为事件路由目标
+        seedAnkiBlock('blk-1', { documentId: 'doc-1', status: 'running' });
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('batches N NewCard events in one 100ms window into a single updateBlock', () => {
+        for (let i = 0; i < 50; i++) {
+          ankiEventCallback(newCardEvent(`c${i}`));
+        }
+        // 窗口未到期：不落盘
+        expect(mockStore.updateBlock).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(100);
+
+        expect(mockStore.updateBlock).toHaveBeenCalledTimes(1);
+        const [blockId, updates] = vi.mocked(mockStore.updateBlock).mock.calls[0];
+        expect(blockId).toBe('blk-1');
+        expect((updates as any).toolOutput.cards).toHaveLength(50);
+        expect((updates as any).toolOutput.progress.cardsGenerated).toBe(50);
+      });
+
+      it('batches each window separately (O(windows) writes, not O(cards))', () => {
+        for (let i = 0; i < 10; i++) ankiEventCallback(newCardEvent(`w1-${i}`));
+        vi.advanceTimersByTime(100);
+        for (let i = 0; i < 10; i++) ankiEventCallback(newCardEvent(`w2-${i}`));
+        vi.advanceTimersByTime(100);
+
+        expect(mockStore.updateBlock).toHaveBeenCalledTimes(2);
+        const block = mockStore.blocks.get('blk-1') as any;
+        expect(block.toolOutput.cards).toHaveLength(20);
+      });
+
+      it('flushes buffered cards before DocumentProcessingCompleted so terminal state keeps all cards', () => {
+        for (let i = 0; i < 5; i++) ankiEventCallback(newCardEvent(`c${i}`));
+        ankiEventCallback({
+          payload: { type: 'DocumentProcessingCompleted', data: { document_id: 'doc-1' } },
+        });
+
+        // 第一次 updateBlock 是冲刷卡片，第二次是终态
+        const calls = vi.mocked(mockStore.updateBlock).mock.calls;
+        expect(calls.length).toBe(2);
+        expect((calls[0][1] as any).toolOutput.cards).toHaveLength(5);
+        expect((calls[1][1] as any).toolOutput.finalStatus).toBe('completed');
+        // 终态块仍保留全部卡片（未被旧 toolOutput 覆盖）
+        const block = mockStore.blocks.get('blk-1') as any;
+        expect(block.toolOutput.cards).toHaveLength(5);
+        expect(block.toolOutput.finalStatus).toBe('completed');
+        expect(block.status).toBe('success');
+      });
+
+      it('cleanup flushes pending cards instead of dropping them', async () => {
+        for (let i = 0; i < 3; i++) ankiEventCallback(newCardEvent(`c${i}`));
+        await adapter.cleanup();
+
+        expect(mockStore.updateBlock).toHaveBeenCalledTimes(1);
+        const block = mockStore.blocks.get('blk-1') as any;
+        expect(block.toolOutput.cards).toHaveLength(3);
+      });
+
+      it('drops duplicate cards (against state and against queue)', () => {
+        // 状态中已有 c0
+        (mockStore.blocks.get('blk-1') as any).toolOutput.cards = [makeCard('c0')];
+
+        ankiEventCallback(newCardEvent('c0')); // 与状态重复 → 丢弃
+        ankiEventCallback(newCardEvent('c1'));
+        ankiEventCallback(newCardEvent('c1')); // 与队列重复 → 丢弃
+        vi.advanceTimersByTime(100);
+
+        expect(mockStore.updateBlock).toHaveBeenCalledTimes(1);
+        expect((mockStore.blocks.get('blk-1') as any).toolOutput.cards).toHaveLength(2);
       });
     });
   });


### PR DESCRIPTION
NewCard/NewErrorCard 事件原先每张卡触发一次 updateBlock + O(N) 签名 计算 + 2 个调试 CustomEvent，N 张卡产生 O(N²) 的 store 更新与渲染开销， 批量制卡（数百张卡）时 UI 明显卡顿。

修复：新增 ankiCardFlushQueue 100ms 合并缓冲——
- 卡片事件先进缓冲，窗口到期一次性批量写入 store（O(N²)→O(N)）
- 非卡片事件（进度/完成/失败/重试）到达前先冲刷缓冲， 保证终态事件基于最新卡片列表
- cleanup 时冲刷所有未落盘缓冲，避免卡片丢失
- 去重同时检查 store 状态与缓冲队列
- 移除每卡一条的 bridge:card 调试事件（事件洪水的一部分）， 保留重复丢弃调试事件

测试：新增 5 个 vitest 用例（100ms 窗口合并 / 多窗口分批 /
终态前冲刷 / cleanup 冲刷 / 状态+队列双重去重）；
调整 2 个既有路由测试适配异步批量落盘。

### Summary

Describe what this PR changes and why.

### Changes
- 

### How to test
- Steps to verify the change locally

### Screenshots / Logs

### Third-party content
<!-- 如包含第三方代码，请勾选并在此说明详情 -->
- [ ] 本 PR 包含第三方代码 → 来源与许可证：

### Checklist
- [ ] I ran `npm run build` and `cargo build` locally
- [ ] I updated docs/README if needed
- [ ] I linked the related Issue(s)
- [ ] I have read the [CLA](https://github.com/helixnow/deep-student/blob/main/.github/CLA.md) and will sign it when prompted by the CLA bot
