### PR TITLE
fix(startup): retry recovery preflight to survive Android IPC race

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -666,9 +666,18 @@ pub fn run() {
     // 调试日志只写 stdout。不要启用 TargetKind::Webview：
     // 后台日志 emit 与主线程 resize/focus 窗口事件可能争用 WebView 锁，
     // 形成锁反转并让 Windows 主窗口触发 AppHangB1。
-    #[cfg(debug_assertions)]
+    // Android：release 构建同样需要 Stdout target——tauri-plugin-log 在安卓上
+    // 把 Stdout 路由到 logcat（android_logger），使非 debuggable 包的后端日志
+    // 可经 `adb logcat` 查看（LogDir 文件目标落在应用私有目录，外部不可读）。
+    #[cfg(any(debug_assertions, target_os = "android"))]
     {
         log_plugin_builder = log_plugin_builder.target(Target::new(TargetKind::Stdout));
+    }
+    // Android：deep_student_lib 提到 Debug，现场排查启动链问题（预检超时、迁移卡顿）所需
+    #[cfg(target_os = "android")]
+    {
+        log_plugin_builder =
+            log_plugin_builder.level_for("deep_student_lib", log::LevelFilter::Debug);
     }
 
     builder

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -399,8 +399,14 @@ const recoveryTree = (
 // 超时只是「IPC 彻底无响应」的兜底，取值 = 后端闸门 120s + 15s 余量。
 // 注意：Tauri 先创建窗口再跑 setup 闭包，慢设备上 setup 数十秒属正常，
 // 此前 15s 硬超时会把「启动慢」误报成「预检失败」的 blocked 屏。
+//
+// Android 冷启动竞态补充：早期发出的 invoke 可能在 WebView JS↔原生消息桥
+// 就绪前丢失（后端从未收到、Promise 永不 settle），单次 135s 死等会把竞态
+// 变成死局（现场复现：三次启动 2 次 blocked）。改为短超时轮询重试：每次尝试
+// 独立限时，消息桥就绪后的重发必然到达后端；总窗口不变，全失败才进恢复壳。
 const BACKEND_STARTUP_GATE_MS = 120_000;
 const STARTUP_PREFLIGHT_TIMEOUT_MS = BACKEND_STARTUP_GATE_MS + 15_000;
+const PREFLIGHT_ATTEMPT_TIMEOUT_MS = 10_000;
 const MAINTENANCE_STATUS_TIMEOUT_MS = 30_000;
 
 const withTimeout = async <T,>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> => {
@@ -420,12 +426,25 @@ const withTimeout = async <T,>(promise: Promise<T>, timeoutMs: number, label: st
   }
 };
 
-const getStartupRecoveryStatusWithTimeout = () =>
-  withTimeout(
-    getStartupRecoveryStatus(),
-    STARTUP_PREFLIGHT_TIMEOUT_MS,
-    'Startup recovery preflight',
+const getStartupRecoveryStatusWithTimeout = async () => {
+  const startedAt = Date.now();
+  let attempt = 0;
+  while (Date.now() - startedAt + PREFLIGHT_ATTEMPT_TIMEOUT_MS <= STARTUP_PREFLIGHT_TIMEOUT_MS) {
+    attempt += 1;
+    try {
+      return await withTimeout(
+        getStartupRecoveryStatus(),
+        PREFLIGHT_ATTEMPT_TIMEOUT_MS,
+        `Startup recovery preflight attempt ${attempt}`,
+      );
+    } catch (error) {
+      console.warn(`[main] Startup preflight attempt ${attempt} failed, retrying`, error);
+    }
+  }
+  throw new Error(
+    `Startup recovery preflight timed out after ${Math.round((Date.now() - startedAt) / 1000)} seconds (${attempt} attempts)`,
   );
+};
 
 // F22: React 18 的 StrictMode 双调用诊断仅在开发态生效，生产构建为 no-op——
 // 因此原先「仅 prod 启用」等于全程没有 StrictMode 检查（注释意图与 React 行为相反）。


### PR DESCRIPTION
## Problem

On Android cold start, an early `invoke` can be issued before the WebView JS↔native message bridge is fully ready: the message is dropped, the backend never receives it, and the Promise never settles. The current single `STARTUP_PREFLIGHT_TIMEOUT_MS` wait then turns that race into a dead end — the user lands on the blocked recovery shell and can only force-restart the app.

Field data from a freshly formatted device (same code, three launches): **2 of 3 launches blocked** (`startup_preflight blocked / Startup recovery preflight timed out`). Backend logs show full init in ~1.2s with zero errors and no trace of ever receiving the preflight invoke — confirming the message was lost in the IPC bridge, not slow backend work. A second launch succeeded with the same build, i.e. the race is timing-dependent, not deterministic.

## Fix

`getStartupRecoveryStatusWithTimeout` now **polls with a per-attempt timeout** instead of one long wait:

- Each attempt is bounded to 10s (a hung invoke never settles on its own, so each try must be time-limited).
- Failed attempts log a warning and re-send; once the bridge is up, the retry deterministically reaches the backend.
- Total window unchanged (= `STARTUP_PREFLIGHT_TIMEOUT_MS`, backend gate 120s + 15s margin) — only the full-failure path still shows the recovery shell.
- Reuses the existing `withTimeout` helper introduced on main.

Net effect: a lost first invoke now costs at most one extra 10s cycle instead of a blocked launch.

## Bundled: Android diagnostics

Also routes tauri-plugin-log's `Stdout` target on Android release builds (lands on logcat via `android_logger`) and raises `deep_student_lib` to Debug. Without this, non-debuggable builds emit no backend logs, which made this exact class of launch-chain issue undiagnosable in the field. Desktop builds are untouched.

## Verification

- Rebuilt the APK via the official `scripts/build_android.sh --debug`, installed via adb on the affected device.
- User re-tested with repeated cold launches — blocked shell no longer appears (previously ~2/3 launches).
- `tsc --noEmit` clean.

## Related observations (separate issues, not fixed here)

- `[RAG] No default embedding dimension set` auto-detect loops every 5s with no backoff when no embedding model is configured.
- RuntimeWatchdog reported tokio runtime starvation (56.5s) on one launch — watchdog detects but has no self-heal.
- Frontend boot shows `BOOT_BLANK_SCREEN` / `BOOT_CSP_VIOLATION` (style-src-elem blocked) on the same device.