### PR TITLE
fix(pdf): upgrade pdfium-render 0.8.37 → 0.9.4 to fix native crash on concurrent PDF text extraction

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "deep-student"
-version = "0.9.54"
+version = "0.9.56"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7770,9 +7770,9 @@ dependencies = [
 
 [[package]]
 name = "pdfium-render"
-version = "0.8.37"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6553f6604a52b3203db7b4e9d51eb4dd193cf455af9e56d40cab6575b547b679"
+checksum = "8948a803616a9e936b15a6637af2cd48c5fb8ae0fcdeb3c32eac3a540e255a19"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -128,7 +128,8 @@ libc = "0.2"
 # PDF 后端渲染（pdfium-render）
 # 注意：需要运行 scripts/download-pdfium.sh 下载对应平台的 pdfium 动态库
 # 使用 image_024 匹配项目的 image = "0.24" 版本
-pdfium-render = { version = "0.8", default-features = false, features = ["image_024", "pdfium_7350", "thread_safe"] }
+# 0.9.4 修复了 thread_safe feature 只在 init/destroy 加锁的问题（现逐调用加锁），见 docs/dev/pdfium-crash-diagnosis-2026-09-08.md
+pdfium-render = { version = "0.9.4", default-features = false, features = ["image_024", "pdfium_7350", "thread_safe"] }
 fs_extra = "1.3"
 urlencoding = "2.1.3"
 roxmltree = "0.20"

--- a/src-tauri/src/page_rasterizer.rs
+++ b/src-tauri/src/page_rasterizer.rs
@@ -102,7 +102,7 @@ impl PageRasterizer {
         for page_idx in 0..total_pages {
             let page = document
                 .pages()
-                .get(safe_page_index(page_idx)?)
+                .get(safe_page_index(page_idx)? as i32)
                 .map_err(|e| {
                     AppError::internal(format!("获取页面 {} 失败: {:?}", page_idx + 1, e))
                 })?;
@@ -123,8 +123,12 @@ impl PageRasterizer {
                 AppError::internal(format!("渲染页面 {} 失败: {:?}", page_idx + 1, e))
             })?;
 
-            let dynamic_image = bitmap.as_image();
-            let rgb_image = dynamic_image.to_rgb8();
+            let rgb_image = bitmap
+                .as_image()
+                .map_err(|e| {
+                    AppError::internal(format!("转换页面 {} 位图失败: {:?}", page_idx + 1, e))
+                })?
+                .to_rgb8();
             let (width, height) = (rgb_image.width(), rgb_image.height());
 
             let mut jpeg_buffer = std::io::Cursor::new(Vec::new());

--- a/src-tauri/src/pdf_ocr_service.rs
+++ b/src-tauri/src/pdf_ocr_service.rs
@@ -401,7 +401,7 @@ impl PdfOcrService {
                     break;
                 }
 
-                let page = match document.pages().get(page_index as u16) {
+                let page = match document.pages().get(page_index as i32) {
                     Ok(p) => p,
                     Err(e) => {
                         let err_msg = format!("获取页面失败: {:?}", e);
@@ -450,8 +450,28 @@ impl PdfOcrService {
                     }
                 };
 
-                let image = bitmap.as_image();
-                let rgb_image = image.to_rgb8();
+                let rgb_image = match bitmap.as_image() {
+                    Ok(image) => image.to_rgb8(),
+                    Err(e) => {
+                        let err_msg = format!("位图转换失败: {:?}", e);
+                        error!("[PDF-OCR-Backend] 页面 {} {}", page_index, err_msg);
+                        // ★ 记录渲染失败的页面（使用 poison-recovery 避免 panic）
+                        render_failed_for_thread
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .push((page_index, err_msg.clone()));
+                        let _ = render_app_handle.emit(
+                            "pdf_ocr_progress",
+                            serde_json::json!({
+                                "type": "PageRenderFailed",
+                                "session_id": render_session_id,
+                                "page_index": page_index,
+                                "error": err_msg,
+                            }),
+                        );
+                        continue;
+                    }
+                };
                 let (width, height) = rgb_image.dimensions();
 
                 // 保存为 JPEG

--- a/src-tauri/src/vfs/repos/pdf_preview.rs
+++ b/src-tauri/src/vfs/repos/pdf_preview.rs
@@ -289,7 +289,7 @@ fn render_single_page(
     // 1. 获取页面
     let page = document
         .pages()
-        .get(page_index as u16)
+        .get(page_index as i32)
         .map_err(|e| VfsError::Other(format!("获取页面 {} 失败: {:?}", page_index, e)))?;
 
     // 2. 渲染为位图
@@ -298,8 +298,10 @@ fn render_single_page(
         .map_err(|e| VfsError::Other(format!("渲染页面 {} 失败: {:?}", page_index, e)))?;
 
     // 3. 转换为 RGB 图像
-    let image = bitmap.as_image();
-    let rgb_image = image.to_rgb8();
+    let rgb_image = bitmap
+        .as_image()
+        .map_err(|e| VfsError::Other(format!("转换位图失败: {:?}", e)))?
+        .to_rgb8();
     let (width, height) = rgb_image.dimensions();
 
     // 4. 编码为 JPEG（v2.0：使用 JPEG 替代 PNG，减少存储空间）


### PR DESCRIPTION
## 问题

两线程并发对 PDF 做文本提取时，进程在 `pdfium.dll`（141.0.7350.0）内部断言处原生崩溃（事件日志 0x80000003 int3 / 0xc0000409 fastfail，BEX64）。

根因：`pdfium-render 0.8.37` 的 `thread_safe` feature 实现是一个全局 `Mutex<PdfiumThreadMarshall>`，但**只在 `FPDF_InitLibrary` / `FPDF_DestroyLibrary` 两个调用点加锁**，其余所有常规 C 函数调用（`FPDF_LoadPage`、文本提取、位图渲染等）均不加锁直接透传。两个线程同时进入 pdfium 即触发内部状态竞争 → 原生层崩溃，Rust panic hook 无法捕获。

前端对同一 PDF 附件同时发起两路 `vfs_resolve_resource_refs`（上下文面板与 pipeline 各解析一次）即可概率复现。崩溃路径上的代码与上游 main 完全一致，属上游依赖固有问题。

## 修复

升级 `pdfium-render` 0.8.37 → **0.9.4**（2026-09-06 发布）。0.9.4 修复了 `thread_safe` 实现：改为**逐 C 函数调用加锁**（绝大多数 wrapper 进入即 `lock()`），与本项目所有 pdfium 调用路径（加载文档、取页、文本提取、位图渲染）覆盖一致。

### 0.9 API 适配（机械性变更，共 6 处）

- `PdfPages::get()` 参数 `u16` → `i32`（`pdf_ocr_service.rs`、`page_rasterizer.rs`、`vfs/repos/pdf_preview.rs`）
- `PdfBitmap::as_image()` 返回值 `DynamicImage` → `Result<DynamicImage, PdfiumError>`（同上 3 文件，按各自既有错误处理模式补错误分支）

features 不变：`image_024` / `pdfium_7350` / `thread_safe`。

## 验证

- `cargo check` 零错误；`cargo fmt --check` / `clippy` 对触及文件干净
- `cargo test --lib pdf`：35 通过，1 个既有环境性基线失败（`pdf_protocol` 路径规范化，与本改动无关）

## 遗留说明

0.9.4 仍有极少数 wrapper（如 `FPDF_SaveWithVersion`、`FPDF_StructElement_GetAltText`）未加锁，本项目调用路径不涉及。对同一 source_id 的 resolve 做 single-flight 去重可作为后续可选优化。