### PR TITLE
feat(prompt-cache): 工具面首轮定型 + 一次性加载约束，减少中途扩容导致的缓存失效

### DIFF
--- a/src/features/chat/adapters/TauriAdapter.ts
+++ b/src/features/chat/adapters/TauriAdapter.ts
@@ -91,6 +91,7 @@ import {
   getLoadedSkills,
   getSessionAvailableSkillsPrompt,
   hydrateSessionAvailableSkillsSnapshot,
+  preloadAutoLoadSkillsForSession,
 } from '../skills/progressiveDisclosure';
 import { PROACTIVE_KB_SYSTEM_PROMPT } from '../skills/builtin-tools/knowledge-retrieval';
 // 🆕 工作区状态（用于传递 workspaceId 到后端）
@@ -5264,6 +5265,25 @@ export class ChatV2TauriAdapter {
       chatParams.contextLimit
     );
     const testModeConfig = getTestModeConfig();
+
+    // A2 会话首轮定型：本会话还没有任何技能进入工具面时，先把「设为默认」的技能
+    // 加载进来，使工具面从第 1 个请求就完整——任务中途 load_skills 追加工具会让
+    // provider 的前缀缓存整段失效（首次出现新工具面实测 cached=0）。
+    // 已有技能面的会话（新建会话已激活默认技能、或中途加载过技能）跳过，不改动
+    // 既有前缀。
+    if (
+      getLoadedSkills(this.sessionId).length === 0 &&
+      (!Array.isArray(currentState.activeSkillIds) || currentState.activeSkillIds.length === 0)
+    ) {
+      const preloadedDefaultSkills = preloadAutoLoadSkillsForSession(this.sessionId);
+      if (preloadedDefaultSkills.length > 0) {
+        console.log(
+          LOG_PREFIX,
+          '[ProgressiveDisclosure] Preloaded default skills for first-turn tool face:',
+          preloadedDefaultSkills
+        );
+      }
+    }
 
     const structuredSkillState = this.getStructuredSkillStateFromStore();
     // Runtime-active skills must pass the same trust/enable/requires admission

--- a/src/features/chat/skills/__tests__/progressiveDisclosureConfig.test.ts
+++ b/src/features/chat/skills/__tests__/progressiveDisclosureConfig.test.ts
@@ -12,8 +12,12 @@ import {
   handleLoadSkillsToolCall,
   hasSessionAvailableSkillsSnapshot,
   hydrateSessionAvailableSkillsSnapshot,
+  LOAD_SKILLS_TOOL_SCHEMA,
+  preloadAutoLoadSkillsForSession,
+  setAutoLoadSkills,
 } from '../progressiveDisclosure';
 import { setSkillDisabled } from '../skillEnableStorage';
+import { skillDefaults } from '../skillDefaults';
 import { __setRequiresGateForTest } from '../requiresGating';
 import type { SkillDefinition } from '../types';
 
@@ -325,5 +329,99 @@ describe('progressive disclosure defaults', () => {
       }),
     ]);
     expect(getLoadedSkills('legacy-load-test-session')).toEqual([]);
+  });
+});
+
+describe('first-turn tool face (prompt cache A1/A2)', () => {
+  const SESSION = 'first-turn-preload-session';
+  const SKILL_A = 'preload-skill-a';
+  const SKILL_B = 'preload-skill-b';
+  const SKILL_REJECTED = 'preload-skill-untrusted';
+
+  function registerBuiltin(id: string, toolName?: string): void {
+    skillRegistry.register({
+      id,
+      name: `Preload Skill ${id}`,
+      description: `First-turn preload regression: ${id}`,
+      location: 'builtin',
+      sourcePath: `builtin://${id}`,
+      trustStatus: 'builtin',
+      content: '# preload',
+      embeddedTools: toolName
+        ? [{
+            name: toolName,
+            description: 'Preload test tool',
+            inputSchema: { type: 'object', properties: {} },
+          }]
+        : [],
+    });
+  }
+
+  afterEach(() => {
+    for (const id of [SKILL_A, SKILL_B, SKILL_REJECTED]) {
+      skillRegistry.unregister(id);
+    }
+    clearSessionSkills(SESSION);
+    skillDefaults.clear();
+  });
+
+  it('advertises the one-shot first-turn load constraint in the tool description', () => {
+    // A1：工具描述是模型最常读的指令位，必须明确「第一次工具调用中一次性加载完」，
+    // 否则模型会中途逐个 load_skills，每次新增工具面都让 provider 前缀缓存整段失效。
+    expect(LOAD_SKILLS_TOOL_SCHEMA.description).toContain('第一次工具调用中一次性加载完');
+    expect(LOAD_SKILLS_TOOL_SCHEMA.description).toContain('不要在任务进行到一半时逐个追加加载');
+  });
+
+  it('advertises the same constraint in the available_skills catalog footer', () => {
+    registerBuiltin(SKILL_A);
+    const catalog = generateAvailableSkillsPrompt();
+    expect(catalog).toContain('在第一次工具调用中一次性加载完');
+  });
+
+  it('preloads configured default skills once and reports only newly loaded ids', () => {
+    registerBuiltin(SKILL_A, 'builtin-preload_a');
+    registerBuiltin(SKILL_B, 'builtin-preload_b');
+    setAutoLoadSkills([SKILL_A, SKILL_B]);
+
+    expect(preloadAutoLoadSkillsForSession(SESSION).sort()).toEqual([SKILL_A, SKILL_B].sort());
+    expect(getLoadedSkills(SESSION).map((skill) => skill.id).sort()).toEqual([SKILL_A, SKILL_B].sort());
+
+    // 幂等：第二次调用不再重复加载，也不改变工具面
+    expect(preloadAutoLoadSkillsForSession(SESSION)).toEqual([]);
+    expect(getLoadedSkills(SESSION)).toHaveLength(2);
+  });
+
+  it('keeps admission-rejected default skills out of the tool face', () => {
+    skillRegistry.register({
+      id: SKILL_REJECTED,
+      name: 'Untrusted Preload Skill',
+      description: 'First-turn preload regression: rejected',
+      location: 'global',
+      sourcePath: '/tmp/preload/SKILL.md',
+      trustStatus: 'untrusted',
+      content: '# untrusted',
+      embeddedTools: [{
+        name: 'builtin-preload_untrusted',
+        description: 'must not enter the tool face',
+        inputSchema: { type: 'object', properties: {} },
+      }],
+    });
+    setAutoLoadSkills([SKILL_REJECTED]);
+
+    expect(preloadAutoLoadSkillsForSession(SESSION)).toEqual([]);
+    expect(getLoadedSkills(SESSION)).toEqual([]);
+  });
+
+  it('keeps getProgressiveDisclosureConfig().autoLoadSkills in sync with skillDefaults', () => {
+    expect(getProgressiveDisclosureConfig().autoLoadSkills).toEqual([]);
+
+    setAutoLoadSkills([SKILL_A, SKILL_B]);
+    expect(getProgressiveDisclosureConfig().autoLoadSkills.sort()).toEqual([SKILL_A, SKILL_B].sort());
+
+    setAutoLoadSkills([SKILL_B]);
+    expect(getProgressiveDisclosureConfig().autoLoadSkills).toEqual([SKILL_B]);
+
+    setAutoLoadSkills([]);
+    expect(getProgressiveDisclosureConfig().autoLoadSkills).toEqual([]);
   });
 });

--- a/src/features/chat/skills/index.ts
+++ b/src/features/chat/skills/index.ts
@@ -158,6 +158,8 @@ export {
   AVAILABLE_SKILLS_SNAPSHOT_METADATA_KEY,
   clearSessionAvailableSkillsSnapshot,
   getProgressiveDisclosureConfig,
+  setAutoLoadSkills,
+  preloadAutoLoadSkillsForSession,
   DEFAULT_PROGRESSIVE_DISCLOSURE_CONFIG,
   subscribeToLoadedSkills,
 } from './progressiveDisclosure';

--- a/src/features/chat/skills/progressiveDisclosure.ts
+++ b/src/features/chat/skills/progressiveDisclosure.ts
@@ -11,6 +11,7 @@
 
 import type { ToolSchema } from './types';
 import { skillRegistry } from './registry';
+import { skillDefaults } from './skillDefaults';
 import { getRequiresGate, isSkillRequiresSatisfied } from './requiresGating';
 import {
   getSkillRuntimeAdmission,
@@ -96,6 +97,9 @@ export const LOAD_SKILLS_TOOL_SCHEMA: {
 
 当你需要执行某项任务但没有合适的工具时，请先查看 <available_skills> 列表，选择相关的技能并加载。
 加载技能后，你将获得该技能提供的工具，可以用来完成任务。
+
+【重要】在开始任务前，先判断本任务需要的全部技能，并在第一次工具调用中一次性加载完；
+不要在任务进行到一半时逐个追加加载——中途新增工具会打断上下文复用，显著增加延迟与成本。
 
 可以一次加载多个技能。加载后的技能在整个会话中保持有效。`,
   inputSchema: {
@@ -615,6 +619,7 @@ export function generateAvailableSkillsPrompt(): string {
   lines.push('</available_skills>');
   lines.push('');
   lines.push('当你需要使用某种能力但没有对应工具时，请先通过 load_skills 工具加载相关技能。');
+  lines.push('【重要】开始任务前先判断本任务需要的全部技能，在第一次工具调用中一次性加载完；避免中途逐个追加加载。');
   lines.push('');
   lines.push('<tool_calling_rules>');
   lines.push('【重要】所有技能组中包含的工具必须通过正常的工具调用方式使用，不要直接输出 JSON 文本。调用时请严格遵循技能文档中的参数格式示例。');
@@ -851,18 +856,70 @@ export interface ProgressiveDisclosureConfig {
  * 默认配置
  *
  * 渐进披露模式始终启用，完全替代 builtinMcpServer.ts
- * 所有内置工具通过 Skills 按需加载
+ * 所有内置工具通过 Skills 按需加载。
+ *
+ * `autoLoadSkills` 的单一真源是 `skillDefaults`（技能管理页「设为默认」的持久化
+ * 存储，见 skillDefaults.ts）；本字段仅作默认值占位，运行时以
+ * `getProgressiveDisclosureConfig()` 的返回为准。
  */
 export const DEFAULT_PROGRESSIVE_DISCLOSURE_CONFIG: ProgressiveDisclosureConfig = {
   autoLoadSkills: [],
   preloadAllTools: false,
 };
 
-const currentConfig: ProgressiveDisclosureConfig = { ...DEFAULT_PROGRESSIVE_DISCLOSURE_CONFIG };
-
 /**
  * 获取当前配置
+ *
+ * `autoLoadSkills` 实时读 `skillDefaults`，避免出现第二份互相矛盾的配置。
  */
 export function getProgressiveDisclosureConfig(): ProgressiveDisclosureConfig {
-  return { ...currentConfig };
+  return {
+    autoLoadSkills: skillDefaults.getAll(),
+    preloadAllTools: DEFAULT_PROGRESSIVE_DISCLOSURE_CONFIG.preloadAllTools,
+  };
+}
+
+/**
+ * 写入「默认技能」配置（A2：会话首轮预加载）。
+ *
+ * 单一真源是 `skillDefaults`；本函数只做差集同步，便于设置入口统一调用。
+ */
+export function setAutoLoadSkills(skillIds: string[]): void {
+  const next = new Set(
+    skillIds.filter((id): id is string => typeof id === 'string' && id.length > 0)
+  );
+  for (const id of skillDefaults.getAll()) {
+    if (!next.has(id)) {
+      skillDefaults.remove(id);
+    }
+  }
+  for (const id of next) {
+    if (!skillDefaults.isDefault(id)) {
+      skillDefaults.add(id);
+    }
+  }
+}
+
+/**
+ * 会话首轮预加载（A2）：把「设为默认」的技能加载进本会话，使工具面从第 1 个
+ * 请求就完整。
+ *
+ * 动机（实测，见 docs/dev/prompt-cache-observation-2026-09-10.md）：任务中途
+ * 通过 load_skills 追加工具会让 provider 的前缀缓存整段失效——首次出现新工具面
+ * 时 `cached=0`，一次全量重算约 14–16 万 token；把工具面变化提前到会话最早、
+ * 且只发生一次，是代价最低的定型方式。
+ *
+ * 幂等：已加载技能走 `loadSkillsToSession` 的 alreadyLoaded 分支；未通过
+ * admission（未信任/已禁用/requires 未满足）的技能由该函数内部过滤，不进入工具面。
+ *
+ * @returns 本次新加载（此前不在本会话内）的技能 ID
+ */
+export function preloadAutoLoadSkillsForSession(sessionId: string): string[] {
+  const configured = skillDefaults.getAll();
+  if (configured.length === 0) {
+    return [];
+  }
+  const before = new Set(getLoadedSkills(sessionId).map((skill) => skill.id));
+  const result = loadSkillsToSession(sessionId, configured);
+  return result.loaded.map((skill) => skill.id).filter((id) => !before.has(id));
 }


### PR DESCRIPTION
### Summary

承接 #393 补齐的 Prompt 缓存诊断数据。实机实测（单会话 35 次请求，`CHAT_V2_CACHE_DEBUG=1`）：未命中 521,636 token 中有 **320,357（61%）来自两次「首次出现新工具面」**——任务中途 `load_skills` 追加工具会让 provider 的前缀缓存整段失效（`cached=0`，一次全量重算 14–16 万 token）。本 PR 把工具面的变化时机压到会话最早、且尽量只发生一次。

### 数据依据（#393 上线后实机观测）

| 时刻 | 工具面变化 | 该工具面此前出现过 | 当次命中 |
|---|---|---|---|
| 03:19:29 | 35 → 79（+44，`dstu-tools`+`workspace-tools`） | 否 | `prompt=153297, cached=0` → **0%** |
| 03:25:48 | 79 → 94（+15，custom_agent / mcp_server 类） | 否 | `prompt=167060, cached=0` → **0%** |
| 03:36:26 | 94 → 35（应用重启） | 是 | `cached=139531` → 87.4% |
| 03:47:50 | 35 → 79（重复加载同一组） | 是（03:25:41） | `cached=160730` → 89.0% |

逐条核对 35 条样本得到的 provider 语义：`cached_tokens` = 已缓存历史请求中**最长的、能作为当前请求完整前缀**的那一条；**只有引入从未出现过的工具面时才归零**，且代价 ≈ 变化当时的 prompt 大小（越晚越贵）。

### Changes

| 项 | 变更 |
|---|---|
| **A1 提示词层** | `load_skills` 工具描述追加「开始任务前先判断本任务需要的全部技能，在**第一次工具调用中一次性加载完**；不要在任务进行到一半时逐个追加加载」；`<available_skills>` 目录尾注追加同一约束（目录按会话冻结，仅影响新会话） |
| **A2 机制层** | `getProgressiveDisclosureConfig().autoLoadSkills` 改为实时读 `skillDefaults`，消除第二份互相矛盾的配置真源；新增 `setAutoLoadSkills()` 差集同步；新增 `preloadAutoLoadSkillsForSession()` 把「设为默认」的技能经 runtime admission 过滤后加载进会话（幂等） |
| **A2 接线** | `TauriAdapter` 构建请求前，若本会话**还没有任何技能进入工具面**，调用上述预加载，使工具面从第 1 个请求就完整；已有技能面的会话（新建会话已激活默认技能、或中途加载过技能）**跳过**，不改动既有前缀 |
| **A3 测试** | 新增 5 个用例：工具描述与目录尾注含约束、预加载幂等且只报新增、admission 拒绝的技能不进工具面、配置与 `skillDefaults` 同步 |

**未改动**：`tools` 会话内 append-only 冻结（`freeze_tool_schema_order_for_prompt_cache`）、工具组装顺序、`load_skills` 运行时语义。44 个内置工具的 schema 收敛（动作化）属另一条待评估路线，不在本 PR。

### 验证口径

| 已验证 | 未验证 |
|---|---|
| 1. `npx tsc --noEmit -p tsconfig.json`：通过（exit 0）。<br>2. 新增用例：`npx vitest run src/features/chat/skills/__tests__/progressiveDisclosureConfig.test.ts` → **14 passed / 0 failed**。<br>3. `npx vitest run src/features/chat/skills` → 367 passed / 3 failed；`npx vitest run src/features/chat` → 1385 passed / 4 failed，**失败项均为既有基线**：用 `git stash` 暂存本 PR 改动后在干净 HEAD 上复跑，失败与断言完全一致（`builtinSkillLocalization` 缺 `insight-recall` 本地化、`toolRunSkillContract` 的 `'central admission'` 大小写、`toolDisplayNameLocales` 缺 `insight_recall`/`ptc_run` 显示名），根因是 `insight-recall`（2e9ed991）与 PTC（06f82dc2）两个新特性提交漏补 i18n 词条。<br>4. Windows NSIS 构建：成功。 | 1. **实机效果待验**：需一轮会触发技能加载的长对话，确认 `tools=[…,added=…]` 只出现在第 1 轮、后续 `cached` 精确等于上一次 `prompt`。<br>2. A2 的预加载日志是前端 console（`[ProgressiveDisclosure] Preloaded default skills…`），未落后端日志文件，需运行期确认是否触发。<br>3. 预期收益（未命中 52.2 万 → 约 22 万、命中率 89.3% → 约 93–94%）来自本次数据外推，需实机复测。 |

### 风险与边界

- **改 `load_skills` 工具描述会让所有会话在升级后首次请求各全量重算一次**（工具位于缓存前缀内）——一次性成本，属可接受，但发布说明宜提示。
- A1 是提示词约束，不是硬保证：模型可能仍在中途加载技能；A3 的观测项就是为此准备。若实测仍频繁中途加载，再走「按首条消息/附件预判」的机制加强版。
- A2 依赖用户把技能「设为默认」（技能管理页既有开关）；默认空配置时行为与改动前一致（不影响存量会话的既有前缀）。
- 目录尾注在 `system` 段且按会话冻结（`getSessionAvailableSkillsPrompt` + `chat_v2_freeze_available_skills_snapshot`），存量会话的缓存前缀不会因此被打爆。
