### PR TITLE
feat(qbank): 单题型上限放宽与组卷余量校验；填空题改走 AI 评判并回写判定结果

### DIFF
--- a/src-tauri/permissions/application-commands.toml
+++ b/src-tauri/permissions/application-commands.toml
@@ -596,6 +596,7 @@ commands.allow = [
   "qbank_batch_update_questions",
   "qbank_cancel_generation_task",
   "qbank_cancel_grading",
+  "qbank_count_by_type",
   "qbank_create_question",
   "qbank_crop_source_image",
   "qbank_delete_question",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7189,6 +7189,20 @@ pub async fn qbank_get_stats(
     service.get_stats(&exam_id)
 }
 
+/// 按题型统计题目数量（组卷配置的前端余量校验）
+#[tauri::command]
+pub async fn qbank_count_by_type(
+    exam_id: String,
+    state: State<'_, AppState>,
+) -> Result<std::collections::HashMap<String, u32>> {
+    let service = state
+        .question_bank_service
+        .as_ref()
+        .ok_or_else(|| AppError::internal("QuestionBankService not initialized"))?;
+
+    service.count_by_type(&exam_id)
+}
+
 /// 刷新统计
 #[tauri::command]
 pub async fn qbank_refresh_stats(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2567,6 +2567,7 @@ pub fn run() {
             ,crate::commands::qbank_submit_answer
             ,crate::commands::qbank_toggle_favorite
             ,crate::commands::qbank_get_stats
+            ,crate::commands::qbank_count_by_type
             ,crate::commands::qbank_refresh_stats
             ,crate::commands::qbank_get_history
             ,crate::commands::qbank_get_submissions

--- a/src-tauri/src/question_bank_service.rs
+++ b/src-tauri/src/question_bank_service.rs
@@ -1116,10 +1116,10 @@ impl QuestionBankService {
             }
             // 匹配题：配对集合相等
             QuestionType::Matching => Self::grade_matching(user_answer, structured_data),
-            // 填空题：优先按 structured_data.blanks 逐空判分，否则旧逻辑单串比对
-            QuestionType::FillBlank => {
-                Self::grade_fill_blank(user_answer, trimmed_answer, structured_data)
-            }
+            // 填空题：学生答案可能意思对而字面不同（同义表述/单位/格式差异），
+            // 字符串比对易误判——一律交由 AI 评判（needs_manual_grading →
+            // 前端自动触发 qbank_ai_grade，回传题干/参考答案/解析/学生答案）。
+            QuestionType::FillBlank => (false, true),
             // 主观题：需要手动批改
             QuestionType::ShortAnswer
             | QuestionType::Essay
@@ -1523,90 +1523,6 @@ impl QuestionBankService {
         (is_correct, false)
     }
 
-    /// 填空题判分
-    ///
-    /// 有 structured_data.blanks 时逐空判分：
-    /// {"blanks":[{"answers":["答案1","答案一"],"case_sensitive":false,"trim":true}]}
-    /// user_answer 为 JSON 数组字符串 ["ans1","ans2"]；单空兼容旧的裸字符串。
-    /// 无 structured_data 时回退旧逻辑（忽略空白/大小写/全半角的单串比对）。
-    fn grade_fill_blank(
-        user_answer: &str,
-        correct_answer: Option<&str>,
-        structured_data: Option<&serde_json::Value>,
-    ) -> (bool, bool) {
-        let blanks = structured_data
-            .and_then(|sd| sd.get("blanks"))
-            .and_then(|v| v.as_array())
-            .filter(|arr| !arr.is_empty());
-
-        if let Some(blanks) = blanks {
-            // 解析用户答案：JSON 数组，或（单空时）裸字符串兼容
-            let user_values: Vec<String> =
-                match serde_json::from_str::<serde_json::Value>(user_answer.trim()) {
-                    Ok(serde_json::Value::Array(items)) => items
-                        .into_iter()
-                        .map(|v| match v {
-                            serde_json::Value::String(s) => s,
-                            other => other.to_string(),
-                        })
-                        .collect(),
-                    _ => vec![user_answer.to_string()],
-                };
-            if user_values.len() != blanks.len() {
-                return (false, false);
-            }
-
-            let normalize = |s: &str, case_sensitive: bool, trim: bool| -> String {
-                let mut value: String = s.chars().map(Self::normalize_fullwidth_char).collect();
-                if trim {
-                    value = value.trim().to_string();
-                }
-                if !case_sensitive {
-                    value = value.to_lowercase();
-                }
-                value
-            };
-
-            for (blank, user_value) in blanks.iter().zip(user_values.iter()) {
-                let Some(answers) = blank.get("answers").and_then(|v| v.as_array()) else {
-                    // 空位缺少可接受答案 → 数据问题，走手动批改
-                    return (false, true);
-                };
-                if answers.is_empty() {
-                    return (false, true);
-                }
-                let case_sensitive = blank
-                    .get("case_sensitive")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
-                let trim = blank.get("trim").and_then(|v| v.as_bool()).unwrap_or(true);
-
-                let normalized_user = normalize(user_value, case_sensitive, trim);
-                let matched = answers
-                    .iter()
-                    .filter_map(|a| a.as_str())
-                    .any(|accepted| normalize(accepted, case_sensitive, trim) == normalized_user);
-                if !matched {
-                    return (false, false);
-                }
-            }
-            return (true, false);
-        }
-
-        // 旧逻辑：单串模糊匹配（忽略空白、大小写与全半角差异）
-        let Some(correct_answer) = correct_answer else {
-            return (false, true);
-        };
-        let normalize = |s: &str| -> String {
-            s.chars()
-                .map(Self::normalize_fullwidth_char)
-                .filter(|c| !c.is_whitespace())
-                .collect::<String>()
-                .to_lowercase()
-        };
-        (normalize(user_answer) == normalize(correct_answer), false)
-    }
-
     /// 切换收藏状态
     pub fn toggle_favorite(&self, question_id: &str) -> Result<Question, AppError> {
         let question = self
@@ -1642,6 +1558,15 @@ impl QuestionBankService {
     /// 获取统计（优先读缓存）
     pub fn get_stats(&self, exam_id: &str) -> Result<Option<QuestionBankStats>, AppError> {
         VfsQuestionRepo::get_stats(&self.vfs_db, exam_id)
+            .map_err(|e| AppError::database(e.to_string()))
+    }
+
+    /// 按题型统计题目数量（组卷配置的前端余量校验用）
+    pub fn count_by_type(
+        &self,
+        exam_id: &str,
+    ) -> Result<std::collections::HashMap<String, u32>, AppError> {
+        VfsQuestionRepo::count_by_type(&self.vfs_db, exam_id)
             .map_err(|e| AppError::database(e.to_string()))
     }
 
@@ -3805,19 +3730,22 @@ mod tests {
     }
 
     #[test]
-    fn test_fill_blank_whitespace_and_case() {
+    fn test_fill_blank_always_ai_graded() {
+        // 填空题不再字符串比对（学生答案可能意思对而字面不同）：
+        // 任意作答一律 needs_manual_grading，交由 AI 评判
         assert_eq!(
             check(" Newton ", Some("newton"), QuestionType::FillBlank),
-            (true, false)
+            (false, true)
         );
         assert_eq!(
             check("能量 守恒", Some("能量守恒"), QuestionType::FillBlank),
-            (true, false)
+            (false, true)
         );
         assert_eq!(
             check("动量守恒", Some("能量守恒"), QuestionType::FillBlank),
-            (false, false)
+            (false, true)
         );
+        assert_eq!(check("2", None, QuestionType::FillBlank), (false, true));
     }
 
     #[test]
@@ -3877,23 +3805,22 @@ mod tests {
             check("ＢＡ", Some("AB"), QuestionType::MultipleChoice),
             (true, false)
         );
-        // 填空：全角数字/字母等价于半角
+        // 填空：一律交由 AI 评判，全角归一化不再参与其判分
         assert_eq!(
             check("１２３", Some("123"), QuestionType::FillBlank),
-            (true, false)
+            (false, true)
         );
         assert_eq!(
             check("ｎｅｗｔｏｎ", Some("Newton"), QuestionType::FillBlank),
-            (true, false)
+            (false, true)
         );
-        // 全角空格视为空白被忽略
         assert_eq!(
             check(
                 "能量\u{3000}守恒",
                 Some("能量守恒"),
                 QuestionType::FillBlank
             ),
-            (true, false)
+            (false, true)
         );
         // 全角归一化不应引入误判
         assert_eq!(
@@ -4098,7 +4025,9 @@ mod tests {
     }
 
     #[test]
-    fn test_fill_blank_structured_multi_blank() {
+    fn test_fill_blank_structured_multi_blank_always_ai_graded() {
+        // 填空题不再逐空比对：structured blanks 仅供编辑与 AI 评判参考，
+        // 任意作答（全对/部分对/空数不符/裸字符串）一律 needs_manual_grading
         let sd = serde_json::json!({
             "blanks": [
                 {"answers": ["牛顿", "Newton"], "case_sensitive": false, "trim": true},
@@ -4112,18 +4041,8 @@ mod tests {
                 QuestionType::FillBlank,
                 sd.clone()
             ),
-            (true, false)
+            (false, true)
         );
-        assert_eq!(
-            check_structured(
-                r#"["牛顿"," 1687 "]"#,
-                None,
-                QuestionType::FillBlank,
-                sd.clone()
-            ),
-            (true, false)
-        );
-        // 第二空错误
         assert_eq!(
             check_structured(
                 r#"["牛顿","1688"]"#,
@@ -4131,24 +4050,20 @@ mod tests {
                 QuestionType::FillBlank,
                 sd.clone()
             ),
-            (false, false)
+            (false, true)
         );
         // 空数不符
         assert_eq!(
             check_structured(r#"["牛顿"]"#, None, QuestionType::FillBlank, sd.clone()),
-            (false, false)
+            (false, true)
         );
-        // case_sensitive = true
+        // case_sensitive 变体
         let cs = serde_json::json!({
             "blanks": [{"answers": ["pH"], "case_sensitive": true, "trim": true}]
         });
         assert_eq!(
             check_structured("pH", None, QuestionType::FillBlank, cs.clone()),
-            (true, false)
-        );
-        assert_eq!(
-            check_structured("ph", None, QuestionType::FillBlank, cs),
-            (false, false)
+            (false, true)
         );
         // 单空兼容裸字符串
         let single = serde_json::json!({
@@ -4156,7 +4071,7 @@ mod tests {
         });
         assert_eq!(
             check_structured("能量守恒", None, QuestionType::FillBlank, single),
-            (true, false)
+            (false, true)
         );
     }
 

--- a/src-tauri/src/vfs/repos/question_repo.rs
+++ b/src-tauri/src/vfs/repos/question_repo.rs
@@ -17,6 +17,8 @@
 //! - 搜索词长度限制（最大 200 字符）
 //! - 特殊字符自动转义
 
+use std::collections::HashMap;
+
 use rusqlite::{params, Connection, OptionalExtension, Row};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
@@ -2284,6 +2286,23 @@ impl VfsQuestionRepo {
     // ========================================================================
     // 统计
     // ========================================================================
+
+    /// 按题型统计题目数量（组卷配置的前端余量校验用）
+    pub fn count_by_type(db: &VfsDatabase, exam_id: &str) -> VfsResult<HashMap<String, u32>> {
+        let conn = db.get_conn_safe()?;
+        let mut stmt = conn.prepare(
+            "SELECT question_type, COUNT(*) FROM questions WHERE exam_id = ?1 GROUP BY question_type",
+        )?;
+        let rows = stmt.query_map(params![exam_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        let mut counts = HashMap::new();
+        for row in rows {
+            let (question_type, n) = row?;
+            counts.insert(question_type, n.max(0) as u32);
+        }
+        Ok(counts)
+    }
 
     /// 获取统计（优先读缓存）
     pub fn get_stats(db: &VfsDatabase, exam_id: &str) -> VfsResult<Option<QuestionBankStats>> {

--- a/src/components/AiQuestionGenerationPanel.tsx
+++ b/src/components/AiQuestionGenerationPanel.tsx
@@ -344,7 +344,7 @@ export const AiQuestionGenerationPanel: React.FC<AiQuestionGenerationPanelProps>
   };
 
   const handleStart = async () => {
-    if (maxQuestions <= 0 || maxQuestions > 50) return;
+    if (maxQuestions <= 0 || maxQuestions > 100) return;
     try {
       await startGeneration({
         exam_id: examId,
@@ -485,9 +485,9 @@ export const AiQuestionGenerationPanel: React.FC<AiQuestionGenerationPanelProps>
                     <input
                       type="number"
                       min={1}
-                      max={20}
+                      max={100}
                       value={spec.count}
-                      onChange={(e) => updateSpec(spec.id, { count: Math.max(1, Math.min(20, Number(e.target.value) || 1)) })}
+                      onChange={(e) => updateSpec(spec.id, { count: Math.max(1, Math.min(100, Number(e.target.value) || 1)) })}
                       className="w-16 h-8 rounded-md border border-border bg-transparent px-2 text-sm"
                       aria-label={t('exam_sheet:aiGeneration.countLabel')}
                     />
@@ -723,7 +723,7 @@ export const AiQuestionGenerationPanel: React.FC<AiQuestionGenerationPanelProps>
               {t('exam_sheet:aiGeneration.basedOnExisting')}
             </label>
 
-            {maxQuestions > 50 && (
+            {maxQuestions > 100 && (
               <div className="flex items-center gap-2 text-sm text-destructive">
                 <WarningCircle size={16} />
                 {t('exam_sheet:aiGeneration.tooManyQuestions')}
@@ -890,7 +890,7 @@ export const AiQuestionGenerationPanel: React.FC<AiQuestionGenerationPanelProps>
               <DsButton
                 variant="default"
                 size="sm"
-                disabled={maxQuestions <= 0 || maxQuestions > 50}
+                disabled={maxQuestions <= 0 || maxQuestions > 100}
                 onClick={() => void handleStart()}
               >
                 <Sparkle size={14} className="mr-1" />

--- a/src/components/QuestionBankEditor.tsx
+++ b/src/components/QuestionBankEditor.tsx
@@ -113,6 +113,8 @@ export interface QuestionBankEditorProps {
   onModeChange?: (mode: PracticeMode, tag?: string) => void;
   onMarkCorrect?: (questionId: string, isCorrect: boolean) => Promise<void>;
   onRefreshQuestion?: (questionId: string) => Promise<void>;
+  /** 主观题/填空题 AI 评判完成（verdict 已落库）：宿主据此回写练习进度与模拟考成绩 */
+  onGradingResolved?: (questionId: string, isCorrect: boolean) => void;
   onToggleFavorite?: (questionId: string, isFavorite: boolean) => Promise<void>;
   /** 编辑模式：删除题目 */
   onDeleteQuestion?: (questionId: string) => Promise<void>;
@@ -489,6 +491,7 @@ export const QuestionBankEditor: React.FC<QuestionBankEditorProps> = ({
   onModeChange,
   onMarkCorrect,
   onRefreshQuestion,
+  onGradingResolved,
   onToggleFavorite,
   onDeleteQuestion,
   onBack,
@@ -1122,6 +1125,10 @@ export const QuestionBankEditor: React.FC<QuestionBankEditorProps> = ({
             if (verdict) {
               const isCorrect = verdict === 'correct';
               setSubmitResult(prev => prev ? { ...prev, isCorrect, needsManualGrading: false } : null);
+              // verdict 已由后端落库（grading_method='ai'）：通知宿主回写
+              // 练习进度（首答按 null 记的差量修正）与模拟考成绩，否则
+              // 成绩单把 AI 已判对的主观题/填空题按错统计。
+              onGradingResolved?.(questionId, isCorrect);
               if (onRefreshQuestion) {
                 onRefreshQuestion(questionId).catch((err) => {
                   debugLog.error('[QuestionBankEditor] refresh after AI grading failed:', err);

--- a/src/components/practice/MockExamMode.tsx
+++ b/src/components/practice/MockExamMode.tsx
@@ -479,7 +479,7 @@ export const MockExamMode: React.FC<MockExamModeProps> = ({
                   label={t(`questionType.${key}`)}
                   value={typeDistribution[key] || 0}
                   onChange={(value) => handleTypeChange(key, value)}
-                  max={20}
+                  max={100}
 />
               ))}
             </div>
@@ -500,7 +500,7 @@ export const MockExamMode: React.FC<MockExamModeProps> = ({
                   labelClassName={color}
                   value={difficultyDistribution[key] || 0}
                   onChange={(value) => handleDifficultyChange(key, value)}
-                  max={20}
+                  max={100}
 />
               ))}
             </div>

--- a/src/components/practice/PaperGenerator.tsx
+++ b/src/components/practice/PaperGenerator.tsx
@@ -44,7 +44,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { showGlobalNotification } from '@/components/UnifiedNotification';
 import { getErrorMessage } from '@/utils/errorUtils';
-import { CountStepperRow } from './CountStepperRow';
+import { findTypeShortages } from './paperValidation';
 import { registerBackHandler, BACK_PRIORITY } from '@/app/navigation/androidBackCoordinator';
 
 interface PaperGeneratorProps {
@@ -150,6 +150,27 @@ export const PaperGenerator: React.FC<PaperGeneratorProps> = ({
   
   // 生成试卷
   const handleGenerate = useCallback(async () => {
+    // 题库余量校验：请求数 > 题库实际数量时，后端随机抽取会静默少抽，
+    // 这里先拦下并提示用户调整后重试。统计失败不阻断（保持旧行为兜底）。
+    let availableByType: Record<string, number> = {};
+    try {
+      availableByType = await invoke<Record<string, number>>('qbank_count_by_type', { examId });
+    } catch (err) {
+      console.error('Failed to count questions by type:', err);
+    }
+    const shortages = findTypeShortages(typeSelection, availableByType);
+    if (shortages.length > 0) {
+      const details = shortages
+        .map(
+          ({ questionType, requested, available }) =>
+            `${t(`questionType.${questionType}`)} ${requested} > ${available}`,
+        )
+        .join(', ');
+      setGenerationError(t('paper.insufficientQuestions', { details }));
+      showGlobalNotification('warning', t('paper.insufficientQuestions', { details }));
+      return;
+    }
+
     const config: PaperConfig = {
       title,
       type_selection: typeSelection,
@@ -363,13 +384,26 @@ export const PaperGenerator: React.FC<PaperGeneratorProps> = ({
           </Label>
           <div className="space-y-1.5">
             {QUESTION_TYPE_KEYS.map((key) => (
-              <CountStepperRow
-                key={key}
-                label={t(`questionType.${key}`)}
-                value={typeSelection[key] || 0}
-                onChange={(value) => handleTypeChange(key, value)}
-                max={20}
-/>
+              <div key={key} className="flex items-center gap-2 sm:gap-3">
+                <span
+                  className="w-16 shrink-0 truncate text-sm sm:w-20"
+                  title={t(`questionType.${key}`)}
+                >
+                  {t(`questionType.${key}`)}
+                </span>
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  min={0}
+                  step={1}
+                  value={typeSelection[key] ?? 0}
+                  onChange={(e) =>
+                    handleTypeChange(key, Math.max(0, Math.floor(Number(e.target.value) || 0)))
+                  }
+                  aria-label={t(`questionType.${key}`)}
+                  className="w-20"
+                />
+              </div>
             ))}
           </div>
           <div className="text-sm text-muted-foreground">

--- a/src/components/practice/__tests__/paperValidation.test.ts
+++ b/src/components/practice/__tests__/paperValidation.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { findTypeShortages } from '../paperValidation';
+
+describe('findTypeShortages', () => {
+  it('returns empty when every requested count fits the bank', () => {
+    const shortages = findTypeShortages(
+      { single_choice: 20, essay: 5 },
+      { single_choice: 20, essay: 30 },
+    );
+    expect(shortages).toEqual([]);
+  });
+
+  it('flags types whose request exceeds the available count', () => {
+    const shortages = findTypeShortages(
+      { single_choice: 30, essay: 3 },
+      { single_choice: 12, essay: 10 },
+    );
+    expect(shortages).toEqual([{ questionType: 'single_choice', requested: 30, available: 12 }]);
+  });
+
+  it('treats missing bank entries as zero available', () => {
+    const shortages = findTypeShortages({ true_false: 1 }, {});
+    expect(shortages).toEqual([{ questionType: 'true_false', requested: 1, available: 0 }]);
+  });
+
+  it('ignores zero and non-finite requests', () => {
+    const shortages = findTypeShortages(
+      { single_choice: 0, essay: Number.NaN },
+      {},
+    );
+    expect(shortages).toEqual([]);
+  });
+
+  it('does not flag requests within supply even when other types are short', () => {
+    const shortages = findTypeShortages(
+      { fill_blank: 4, short_answer: 8 },
+      { fill_blank: 4 },
+    );
+    expect(shortages).toEqual([{ questionType: 'short_answer', requested: 8, available: 0 }]);
+  });
+});

--- a/src/components/practice/paperValidation.ts
+++ b/src/components/practice/paperValidation.ts
@@ -1,0 +1,35 @@
+/**
+ * 组卷配置校验（纯函数，便于单测）
+ *
+ * 题库余量校验：题型请求数 > 题库中该题型实际数量时生成缺口清单，
+ * 由 PaperGenerator 在生成前阻断并提示用户调整重试（后端随机抽取在
+ * 池不足时会静默少抽，必须在提交前拦住）。
+ */
+
+export interface TypeShortage {
+  /** 题型（snake_case，与后端 question_type 一致） */
+  questionType: string;
+  /** 用户请求的数量 */
+  requested: number;
+  /** 题库中该题型的实际数量 */
+  available: number;
+}
+
+/**
+ * 找出请求数超过题库余量的题型。
+ *
+ * - 忽略 0 / 非有限数的请求项；
+ * - 题库中不存在该题型时按 0 计。
+ */
+export function findTypeShortages(
+  typeSelection: Record<string, number>,
+  availableByType: Record<string, number>,
+): TypeShortage[] {
+  return Object.entries(typeSelection)
+    .map(([questionType, requested]) => ({
+      questionType,
+      requested: Number.isFinite(requested) ? requested : 0,
+      available: availableByType[questionType] ?? 0,
+    }))
+    .filter(({ requested, available }) => requested > 0 && requested > available);
+}

--- a/src/features/learning-hub/apps/views/ExamContentView.tsx
+++ b/src/features/learning-hub/apps/views/ExamContentView.tsx
@@ -1048,6 +1048,33 @@ const ExamContentView: React.FC<ContentViewProps> = ({
     }
   }, [sessionId, markCorrect, practiceMode, setMockExamSession]);
 
+  // AI 评判完成（主观题/填空题 verdict 已在后端落库）后的回写。此前只有
+  // 自评改判（handleMarkCorrect）会回写：模拟考成绩单把 AI 已判对的主观题
+  // 按「错」统计（submit_mock_exam 对无 results 的题 unwrap_or(false)），
+  // 练习进度里首答按 null 记的基线也永不修正。
+  const handleGradingResolved = useCallback((questionId: string, isCorrect: boolean) => {
+    if (!sessionId) return;
+    // 与 handleMarkCorrect 同口径：action 内部做成员资格/首答幂等/差量修正门禁
+    useQuestionBankStore.getState().recordPracticeAnswer(sessionId, questionId, isCorrect);
+
+    if (practiceMode === 'mock_exam') {
+      const latestSession = useQuestionBankStore.getState().mockExamSession;
+      if (
+        latestSession &&
+        latestSession.exam_id === sessionId &&
+        !latestSession.is_submitted &&
+        latestSession.question_ids.includes(questionId) &&
+        questionId in latestSession.answers
+      ) {
+        setMockExamSession({
+          ...latestSession,
+          // 只回写判定，不改作答内容（改判不改答）
+          results: { ...latestSession.results, [questionId]: isCorrect },
+        });
+      }
+    }
+  }, [sessionId, practiceMode, setMockExamSession]);
+
   // 🆕 使用 Hook 的 navigate
   const handleNavigate = useCallback((index: number) => {
     navigate(index);
@@ -2532,6 +2559,7 @@ const ExamContentView: React.FC<ContentViewProps> = ({
               onNavigate={handlePracticeNavigate}
               onModeChange={handleModeChange}
               onMarkCorrect={readOnly ? undefined : handleMarkCorrect}
+              onGradingResolved={readOnly ? undefined : handleGradingResolved}
               onRefreshQuestion={readOnly ? undefined : handleRefreshQuestion}
               onToggleFavorite={readOnly ? undefined : handleToggleFavorite}
               onUpdateUserNote={readOnly ? undefined : handleUpdateUserNote}

--- a/src/locales/en-US/exam_sheet.json
+++ b/src/locales/en-US/exam_sheet.json
@@ -626,7 +626,7 @@
     "topicHintLabel": "Topic scope (optional)",
     "topicHintPlaceholder": "e.g. Quadratic functions: graphs & properties, vertex form conversion…",
     "basedOnExisting": "Generate variants based on existing questions",
-    "tooManyQuestions": "Total questions cannot exceed 50",
+    "tooManyQuestions": "Total questions cannot exceed 100",
     "start": "Generate",
     "generating": "AI is generating questions…",
     "rejectedSummary": "{{count}} question(s) failed validation and were dropped:",

--- a/src/locales/en-US/practice.json
+++ b/src/locales/en-US/practice.json
@@ -205,6 +205,7 @@
     "answer": "Answer",
     "explanation": "Explanation",
     "generateFailed": "Failed to generate paper: {{error}}",
+    "insufficientQuestions": "Not enough questions in the bank, please adjust and retry: {{details}}",
     "exportComingSoon": "PDF / Word export is coming soon. Use Markdown export or preview for now.",
     "exportTitle": "Export Paper",
     "exportSuccess": "Paper exported",

--- a/src/locales/zh-CN/exam_sheet.json
+++ b/src/locales/zh-CN/exam_sheet.json
@@ -626,7 +626,7 @@
     "topicHintLabel": "知识点范围（可选）",
     "topicHintPlaceholder": "例如：二次函数的图像与性质、顶点式与一般式的互化…",
     "basedOnExisting": "参考题目集现有题目出变式题",
-    "tooManyQuestions": "总题量不能超过 50 题",
+    "tooManyQuestions": "总题量不能超过 100 题",
     "start": "开始生成",
     "generating": "AI 正在出题…",
     "rejectedSummary": "{{count}} 道题未通过校验已自动剔除：",

--- a/src/locales/zh-CN/practice.json
+++ b/src/locales/zh-CN/practice.json
@@ -205,6 +205,7 @@
     "answer": "答案",
     "explanation": "解析",
     "generateFailed": "生成试卷失败：{{error}}",
+    "insufficientQuestions": "题库题目数量不足，请调整后重试：{{details}}",
     "exportComingSoon": "PDF / Word 导出即将推出，可先用 Markdown 导出或预览",
     "exportTitle": "导出试卷",
     "exportSuccess": "试卷已导出",


### PR DESCRIPTION
## 概要

承接 #397（基于其 head 堆叠，#397 合并后 diff 收敛为以下 2 个提交）。

### 1. 填空题改走 AI 评判（6dbf42cf）

`check_answer_correctness` 的 `FillBlank` 分支原为逐空字符串比对，任一空不匹配直接判错（`grading_method='auto'`）——学生答案意思对而字面不同（同义表述/单位/格式差异）时误判率高。现改为与主观题一致：一律 `(false, true)` 进 `needs_manual_grading`，由前端既有自动评判流（`qbank_ai_grade` Grade 模式）回传题干/选项/参考答案/解析/学生答案，返回 verdict + 评分 + 流式解析，落库 `grading_method='ai'`。移除不再使用的 `grade_fill_blank`，三个单测改写断言新语义。

同时修复 AI 判定结果回写断链：`QuestionBankEditor` 新增 `onGradingResolved`（Grade 模式 verdict 落库后触发），`ExamContentView` 回写 `recordPracticeAnswer` 差量修正与 mock_exam 会话 `results`——此前只有「我答对/我答错」自评改判路径会回写，模拟考成绩单把 AI 已判对的主观/填空题按错统计（`submit_mock_exam` 对无 results 的题 `unwrap_or(false)`）。

### 2. 单题型上限放宽 + 组卷余量校验（c35cca3d）

- AI 生成面板 / 模拟考（题型与难度配比）：上限 20→100；AI 面板总量门控 50→100（提交拦截、红色警告、按钮禁用三处 + 中英文文案）。
- 组卷器题型选择滑杆改为数字输入（min=0，不设上限）；生成前调用新增命令 `qbank_count_by_type` 校验题库余量，请求数超余量时列出明细（如「单选题 30 > 12」）阻断并提示调整重试——后端随机抽取在池不足时会静默少抽；统计接口失败不阻断（保留后端兜底，行为同旧）。

## 测试

- `cargo test --lib -p deep-student -- question_bank_service question_repo llm_manager::tests vfs::unified_retriever` 106/106；`cargo fmt --check` 干净
- `npx tsc --noEmit` exit 0；`npx vitest run src/components/practice` 7/7（新增 paperValidation 5 例）
- 新命令已同步注册 `lib.rs` + `permissions/application-commands.toml`（规避 build.rs 同步检查 panic）